### PR TITLE
fix get_property method

### DIFF
--- a/src/common/command.rs
+++ b/src/common/command.rs
@@ -294,7 +294,7 @@ impl<'a> Command<'a> {
             Command::GetElementProperty(element_id, property_name) => RequestData::new(
                 RequestMethod::Get,
                 format!(
-                    "/session/{}/element/{}/proprty/{}",
+                    "/session/{}/element/{}/property/{}",
                     session_id, element_id, property_name
                 ),
             ),

--- a/src/webelement.rs
+++ b/src/webelement.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 #[cfg(any(feature = "tokio-runtime", feature = "async-std-runtime"))]
 use std::path::Path;
+use std::any::{Any, TypeId};
+use serde_json::json;
 
 #[cfg(feature = "async-std-runtime")]
 use async_std::fs::File;
@@ -242,12 +244,54 @@ impl<'a> WebElement<'a> {
     }
 
     /// Get the specified property.
+    ///
+    /// # Example:
+    /// ```rust
+    /// # use thirtyfour::prelude::*;
+    /// # use thirtyfour::support::block_on;
+    /// #
+    /// # fn main() -> WebDriverResult<()> {
+    /// #     block_on(async {
+    /// #         let caps = DesiredCapabilities::chrome();
+    /// #         let driver = WebDriver::new("http://localhost:4444/wd/hub", &caps).await?;
+    /// #         driver.get("http://webappdemo").await?;
+    /// #         driver.find_element(By::Id("pagetextinput")).await?.click().await?;
+    /// #         let elem = driver.find_element(By::Name("input2")).await?;
+    /// #         //Convert property value to string because its type is boolean, get_property
+    /// #         let property_value = elem.get_property("checked").await?;
+    /// #         assert_eq!(property_value, "true");
+    /// #         Ok(())
+    /// #     })
+    /// # }
+    /// ```
     pub async fn get_property(&self, name: &str) -> WebDriverResult<String> {
         let v = self.cmd(Command::GetElementProperty(&self.element_id, name.to_owned())).await?;
+        if !is_string(&v["value"]) {
+           return convert_json(&json!(&v["value"].to_string()))
+        }
         convert_json(&v["value"])
     }
 
     /// Get the specified attribute.
+    ///
+    /// # Example:
+    /// ```rust
+    /// # use thirtyfour::prelude::*;
+    /// # use thirtyfour::support::block_on;
+    /// #
+    /// # fn main() -> WebDriverResult<()> {
+    /// #     block_on(async {
+    /// #         let caps = DesiredCapabilities::chrome();
+    /// #         let driver = WebDriver::new("http://localhost:4444/wd/hub", &caps).await?;
+    /// #         driver.get("http://webappdemo").await?;
+    /// #         driver.find_element(By::Id("pagetextinput")).await?.click().await?;
+    /// #         let elem = driver.find_element(By::Name("input2")).await?;
+    /// #         let value = elem.get_attribute("checked").await?;
+    /// #         assert_eq!(value, "true");
+    /// #         Ok(())
+    /// #     })
+    /// # }
+    /// ```
     pub async fn get_attribute(&self, name: &str) -> WebDriverResult<String> {
         let v = self.cmd(Command::GetElementAttribute(&self.element_id, name.to_owned())).await?;
         convert_json(&v["value"])
@@ -470,4 +514,8 @@ impl<'a> Serialize for WebElement<'a> {
         map.serialize_entry(MAGIC_ELEMENTID, &self.element_id.to_string())?;
         map.end()
     }
+}
+
+fn is_string<T: ?Sized + Any>(_s: &T) -> bool {
+    TypeId::of::<String>() == TypeId::of::<T>()
 }

--- a/src/webelement.rs
+++ b/src/webelement.rs
@@ -1,8 +1,6 @@
 use std::fmt;
 #[cfg(any(feature = "tokio-runtime", feature = "async-std-runtime"))]
 use std::path::Path;
-use std::any::{Any, TypeId};
-use serde_json::json;
 
 #[cfg(feature = "async-std-runtime")]
 use async_std::fs::File;
@@ -266,10 +264,7 @@ impl<'a> WebElement<'a> {
     /// ```
     pub async fn get_property(&self, name: &str) -> WebDriverResult<String> {
         let v = self.cmd(Command::GetElementProperty(&self.element_id, name.to_owned())).await?;
-        if !is_string(&v["value"]) {
-           return convert_json(&json!(&v["value"].to_string()))
-        }
-        convert_json(&v["value"])
+        Ok(v["value"].to_string())
     }
 
     /// Get the specified attribute.
@@ -514,8 +509,4 @@ impl<'a> Serialize for WebElement<'a> {
         map.serialize_entry(MAGIC_ELEMENTID, &self.element_id.to_string())?;
         map.end()
     }
-}
-
-fn is_string<T: ?Sized + Any>(_s: &T) -> bool {
-    TypeId::of::<String>() == TypeId::of::<T>()
 }

--- a/webappdemo/src/components/inputs.rs
+++ b/webappdemo/src/components/inputs.rs
@@ -54,8 +54,8 @@ impl Component for InputComponent {
                 </div>
                 <div class="pure-u-1-6">
                     <input type="text" name="input2"
-                        oninput={self.link.callback(|e| InputMsg::GotInput(e))}
                         value="default input text"
+                        checked=true
                         size="15"
                         maxlength="20">
                         {&self.value}


### PR DESCRIPTION
`get_property` has a typo which makes the call returned as `unknown function` from selenium server.

`get_property` also returning the value as its original type, which means for example with boolean property it would cause panic on `serde_json` parse value at `convert_json` in `connection_common`.

I'm proposing a check if the origin type is not string and parse it as string before handling to `convert_json`

```rust
pub fn convert_json<T>(value: &serde_json::Value) -> WebDriverResult<T>
where
    T: DeserializeOwned,
{
    let s: T = serde_json::from_value(value.clone())?;
    Ok(s)
}
```

```rust
        if !is_string(&v["value"]) {
           return convert_json(&json!(&v["value"].to_string()))
        }
```

