### PR TITLE
Extensions command feature

### DIFF
--- a/src/common/command.rs
+++ b/src/common/command.rs
@@ -74,6 +74,14 @@ impl<'a> By<'a> {
     }
 }
 
+pub trait ExtensionCommand {
+    fn parameters_json(&self) -> Option<serde_json::Value>;
+
+    fn method(&self) -> RequestMethod;
+
+    fn endpoint(&self) -> String;
+}
+
 pub enum Command<'a> {
     NewSession(&'a Value),
     DeleteSession,
@@ -131,6 +139,7 @@ pub enum Command<'a> {
     SendAlertText(TypingData),
     TakeScreenshot,
     TakeElementScreenshot(&'a ElementId),
+    ExtensionCommand(Box<dyn ExtensionCommand + Send + 'a>),
 }
 
 impl<'a> Command<'a> {
@@ -147,15 +156,13 @@ impl<'a> Command<'a> {
                 RequestData::new(RequestMethod::Delete, format!("/session/{}", session_id))
             }
             Command::Status => RequestData::new(RequestMethod::Get, "/status"),
-            Command::GetTimeouts => RequestData::new(
-                RequestMethod::Get,
-                format!("/session/{}/timeouts", session_id),
-            ),
-            Command::SetTimeouts(timeout_configuration) => RequestData::new(
-                RequestMethod::Post,
-                format!("/session/{}/timeouts", session_id),
-            )
-            .add_body(json!(timeout_configuration)),
+            Command::GetTimeouts => {
+                RequestData::new(RequestMethod::Get, format!("/session/{}/timeouts", session_id))
+            }
+            Command::SetTimeouts(timeout_configuration) => {
+                RequestData::new(RequestMethod::Post, format!("/session/{}/timeouts", session_id))
+                    .add_body(json!(timeout_configuration))
+            }
             Command::NavigateTo(url) => {
                 RequestData::new(RequestMethod::Post, format!("/session/{}/url", session_id))
                     .add_body(json!({ "url": url }))
@@ -167,63 +174,54 @@ impl<'a> Command<'a> {
                 RequestData::new(RequestMethod::Post, format!("/session/{}/back", session_id))
                     .add_body(json!({}))
             }
-            Command::Forward => RequestData::new(
-                RequestMethod::Post,
-                format!("/session/{}/forward", session_id),
-            )
-            .add_body(json!({})),
-            Command::Refresh => RequestData::new(
-                RequestMethod::Post,
-                format!("/session/{}/refresh", session_id),
-            )
-            .add_body(json!({})),
+            Command::Forward => {
+                RequestData::new(RequestMethod::Post, format!("/session/{}/forward", session_id))
+                    .add_body(json!({}))
+            }
+            Command::Refresh => {
+                RequestData::new(RequestMethod::Post, format!("/session/{}/refresh", session_id))
+                    .add_body(json!({}))
+            }
             Command::GetTitle => {
                 RequestData::new(RequestMethod::Get, format!("/session/{}/title", session_id))
             }
-            Command::GetWindowHandle => RequestData::new(
-                RequestMethod::Get,
-                format!("/session/{}/window", session_id),
-            ),
-            Command::CloseWindow => RequestData::new(
-                RequestMethod::Delete,
-                format!("/session/{}/window", session_id),
-            ),
-            Command::SwitchToWindow(window_handle) => RequestData::new(
-                RequestMethod::Post,
-                format!("/session/{}/window", session_id),
-            )
-            .add_body(json!({ "handle": window_handle.to_string() })),
+            Command::GetWindowHandle => {
+                RequestData::new(RequestMethod::Get, format!("/session/{}/window", session_id))
+            }
+            Command::CloseWindow => {
+                RequestData::new(RequestMethod::Delete, format!("/session/{}/window", session_id))
+            }
+            Command::SwitchToWindow(window_handle) => {
+                RequestData::new(RequestMethod::Post, format!("/session/{}/window", session_id))
+                    .add_body(json!({ "handle": window_handle.to_string() }))
+            }
             Command::GetWindowHandles => RequestData::new(
                 RequestMethod::Get,
                 format!("/session/{}/window/handles", session_id),
             ),
-            Command::SwitchToFrameDefault => RequestData::new(
-                RequestMethod::Post,
-                format!("/session/{}/frame", session_id),
-            )
-            .add_body(json!({ "id": serde_json::Value::Null })),
-            Command::SwitchToFrameNumber(frame_number) => RequestData::new(
-                RequestMethod::Post,
-                format!("/session/{}/frame", session_id),
-            )
-            .add_body(json!({ "id": frame_number })),
-            Command::SwitchToFrameElement(element_id) => RequestData::new(
-                RequestMethod::Post,
-                format!("/session/{}/frame", session_id),
-            )
-            .add_body(json!({"id": {
-                "ELEMENT": element_id.to_string(),
-                MAGIC_ELEMENTID: element_id.to_string()
-            }})),
+            Command::SwitchToFrameDefault => {
+                RequestData::new(RequestMethod::Post, format!("/session/{}/frame", session_id))
+                    .add_body(json!({ "id": serde_json::Value::Null }))
+            }
+            Command::SwitchToFrameNumber(frame_number) => {
+                RequestData::new(RequestMethod::Post, format!("/session/{}/frame", session_id))
+                    .add_body(json!({ "id": frame_number }))
+            }
+            Command::SwitchToFrameElement(element_id) => {
+                RequestData::new(RequestMethod::Post, format!("/session/{}/frame", session_id))
+                    .add_body(json!({"id": {
+                        "ELEMENT": element_id.to_string(),
+                        MAGIC_ELEMENTID: element_id.to_string()
+                    }}))
+            }
             Command::SwitchToParentFrame => RequestData::new(
                 RequestMethod::Post,
                 format!("/session/{}/frame/parent", session_id),
             )
             .add_body(json!({})),
-            Command::GetWindowRect => RequestData::new(
-                RequestMethod::Get,
-                format!("/session/{}/window/rect", session_id),
-            ),
+            Command::GetWindowRect => {
+                RequestData::new(RequestMethod::Get, format!("/session/{}/window/rect", session_id))
+            }
             Command::SetWindowRect(option_rect) => RequestData::new(
                 RequestMethod::Post,
                 format!("/session/{}/window/rect", session_id),
@@ -250,19 +248,13 @@ impl<'a> Command<'a> {
             ),
             Command::FindElement(by) => {
                 let (selector, value) = by.get_w3c_selector();
-                RequestData::new(
-                    RequestMethod::Post,
-                    format!("/session/{}/element", session_id),
-                )
-                .add_body(json!({"using": selector, "value": value}))
+                RequestData::new(RequestMethod::Post, format!("/session/{}/element", session_id))
+                    .add_body(json!({"using": selector, "value": value}))
             }
             Command::FindElements(by) => {
                 let (selector, value) = by.get_w3c_selector();
-                RequestData::new(
-                    RequestMethod::Post,
-                    format!("/session/{}/elements", session_id),
-                )
-                .add_body(json!({"using": selector, "value": value}))
+                RequestData::new(RequestMethod::Post, format!("/session/{}/elements", session_id))
+                    .add_body(json!({"using": selector, "value": value}))
             }
             Command::FindElementFromElement(element_id, by) => {
                 let (selector, value) = by.get_w3c_selector();
@@ -300,10 +292,7 @@ impl<'a> Command<'a> {
             ),
             Command::GetElementCSSValue(element_id, property_name) => RequestData::new(
                 RequestMethod::Get,
-                format!(
-                    "/session/{}/element/{}/css/{}",
-                    session_id, element_id, property_name
-                ),
+                format!("/session/{}/element/{}/css/{}", session_id, element_id, property_name),
             ),
             Command::GetElementText(element_id) => RequestData::new(
                 RequestMethod::Get,
@@ -336,10 +325,9 @@ impl<'a> Command<'a> {
                 format!("/session/{}/element/{}/value", session_id, element_id),
             )
             .add_body(json!({"text": typing_data.to_string(), "value": typing_data.as_vec() })),
-            Command::GetPageSource => RequestData::new(
-                RequestMethod::Get,
-                format!("/session/{}/source", session_id),
-            ),
+            Command::GetPageSource => {
+                RequestData::new(RequestMethod::Get, format!("/session/{}/source", session_id))
+            }
             Command::ExecuteScript(script, args) => RequestData::new(
                 RequestMethod::Post,
                 format!("/session/{}/execute/sync", session_id),
@@ -350,36 +338,31 @@ impl<'a> Command<'a> {
                 format!("/session/{}/execute/async", session_id),
             )
             .add_body(json!({"script": script, "args": args})),
-            Command::GetAllCookies => RequestData::new(
-                RequestMethod::Get,
-                format!("/session/{}/cookie", session_id),
-            ),
+            Command::GetAllCookies => {
+                RequestData::new(RequestMethod::Get, format!("/session/{}/cookie", session_id))
+            }
             Command::GetNamedCookie(cookie_name) => RequestData::new(
                 RequestMethod::Get,
                 format!("/session/{}/cookie/{}", session_id, cookie_name),
             ),
-            Command::AddCookie(cookie) => RequestData::new(
-                RequestMethod::Post,
-                format!("/session/{}/cookie", session_id),
-            )
-            .add_body(json!({ "cookie": cookie })),
+            Command::AddCookie(cookie) => {
+                RequestData::new(RequestMethod::Post, format!("/session/{}/cookie", session_id))
+                    .add_body(json!({ "cookie": cookie }))
+            }
             Command::DeleteCookie(cookie_name) => RequestData::new(
                 RequestMethod::Delete,
                 format!("/session/{}/cookie/{}", session_id, cookie_name),
             ),
-            Command::DeleteAllCookies => RequestData::new(
-                RequestMethod::Delete,
-                format!("/session/{}/cookie", session_id),
-            ),
-            Command::PerformActions(actions) => RequestData::new(
-                RequestMethod::Post,
-                format!("/session/{}/actions", session_id),
-            )
-            .add_body(json!({"actions": actions.0})),
-            Command::ReleaseActions => RequestData::new(
-                RequestMethod::Delete,
-                format!("/session/{}/actions", session_id),
-            ),
+            Command::DeleteAllCookies => {
+                RequestData::new(RequestMethod::Delete, format!("/session/{}/cookie", session_id))
+            }
+            Command::PerformActions(actions) => {
+                RequestData::new(RequestMethod::Post, format!("/session/{}/actions", session_id))
+                    .add_body(json!({"actions": actions.0}))
+            }
+            Command::ReleaseActions => {
+                RequestData::new(RequestMethod::Delete, format!("/session/{}/actions", session_id))
+            }
             Command::DismissAlert => RequestData::new(
                 RequestMethod::Post,
                 format!("/session/{}/alert/dismiss", session_id),
@@ -390,25 +373,32 @@ impl<'a> Command<'a> {
                 format!("/session/{}/alert/accept", session_id),
             )
             .add_body(json!({})),
-            Command::GetAlertText => RequestData::new(
-                RequestMethod::Get,
-                format!("/session/{}/alert/text", session_id),
-            ),
-            Command::SendAlertText(typing_data) => RequestData::new(
-                RequestMethod::Post,
-                format!("/session/{}/alert/text", session_id),
-            )
-            .add_body(json!({
-                "value": typing_data.as_vec(), "text": typing_data.to_string()
-            })),
-            Command::TakeScreenshot => RequestData::new(
-                RequestMethod::Get,
-                format!("/session/{}/screenshot", session_id),
-            ),
+            Command::GetAlertText => {
+                RequestData::new(RequestMethod::Get, format!("/session/{}/alert/text", session_id))
+            }
+            Command::SendAlertText(typing_data) => {
+                RequestData::new(RequestMethod::Post, format!("/session/{}/alert/text", session_id))
+                    .add_body(json!({
+                        "value": typing_data.as_vec(), "text": typing_data.to_string()
+                    }))
+            }
+            Command::TakeScreenshot => {
+                RequestData::new(RequestMethod::Get, format!("/session/{}/screenshot", session_id))
+            }
             Command::TakeElementScreenshot(element_id) => RequestData::new(
                 RequestMethod::Get,
                 format!("/session/{}/element/{}/screenshot", session_id, element_id),
             ),
+            Command::ExtensionCommand(command) => {
+                let request_data = RequestData::new(
+                    command.method(),
+                    format!("/session/{}{}", session_id, command.endpoint()),
+                );
+                match command.parameters_json() {
+                    Some(param) => request_data.add_body(param),
+                    None => request_data,
+                }
+            }
         }
     }
 }

--- a/src/common/command.rs
+++ b/src/common/command.rs
@@ -75,10 +75,15 @@ impl<'a> By<'a> {
 }
 
 pub trait ExtensionCommand {
+    /// Request Body
     fn parameters_json(&self) -> Option<serde_json::Value>;
 
+    /// HTTP method accepting by the webdriver
     fn method(&self) -> RequestMethod;
 
+    /// Endpoint URL without `/session/{sessionId}` prefix
+    ///
+    /// Example:- `/moz/addon/install`
     fn endpoint(&self) -> String;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ pub use common::{
         firefox::FirefoxCapabilities, ie::InternetExplorerCapabilities, opera::OperaCapabilities,
         safari::SafariCapabilities,
     },
-    command::By,
+    command::{By, ExtensionCommand, RequestMethod},
     cookie::Cookie,
     keys::{Keys, TypingData},
     scriptargs::ScriptArgs,

--- a/src/sync/webdrivercommands.rs
+++ b/src/sync/webdrivercommands.rs
@@ -10,6 +10,7 @@ use crate::sync::http_sync::connection_sync::WebDriverHttpClientSync;
 use crate::{
     common::{
         command::Command,
+        command::ExtensionCommand,
         connection_common::{convert_json, convert_json_vec},
     },
     error::WebDriverResult,
@@ -1017,6 +1018,72 @@ pub trait WebDriverCommands {
     fn set_window_name(&self, window_name: &str) -> WebDriverResult<()> {
         self.execute_script(&format!(r#"window.name = "{}""#, window_name))?;
         Ok(())
+    }
+
+    /// Running an extension command
+    /// Extension commands are browser specific commands and using browser specific endpoints and
+    /// parameters.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use thirtyfour::sync::prelude::*;
+    /// # use serde::Serialize;
+    ///
+    /// #[derive(Serialize)]
+    /// pub struct AddonInstallParameters {
+    ///     pub path: String,
+    ///     pub temporary: Option<bool>
+    /// }
+    ///
+    /// #[derive(Serialize)]
+    /// pub struct AddonUninstallParameters {
+    ///     pub id: String
+    /// }
+    ///
+    /// #[derive(Serialize)]
+    /// enum GeckoExtensionCommand {
+    ///     InstallAddon(AddonInstallParameters),
+    ///     UninstallAddon(AddonUninstallParameters)
+    /// }
+    ///
+    /// impl ExtensionCommand for GeckoExtensionCommand {
+    ///     fn parameters_json(&self)-> Option<serde_json::Value>{
+    ///        Some( match self {
+    ///             Self::InstallAddon(param)=>serde_json::to_value(param).unwrap(),
+    ///             Self::UninstallAddon(param)=>serde_json::to_value(param).unwrap()
+    ///        })
+    ///     }
+    ///
+    ///     fn method(&self)-> RequestMethod {
+    ///         RequestMethod::POST
+    ///     }
+    ///
+    ///     fn endpoint(&self)->String {
+    ///         match self {
+    ///             Self::InstallAddon(_)=>String::from("/moz/addon/install"),
+    ///             Self::UninstallAddon(param)=>String::from("/moz/addon/uninstall")
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// # fn main()-> WebDriverResult<()> {
+    /// #   let caps = DesiredCapabilities::firefox();
+    /// #   let driver = WebDriver::new("http://localhost:4444", &caps)?;
+    /// #   
+    ///   let install_command = GeckoExtensionCommand::InstallAddon(AddonInstallParameters {
+    ///       path: String::from("/path/to/addon.xpi"),
+    ///       temporary: Some(true)
+    ///   });
+    ///
+    ///   driver.extension_command(install_command);
+    /// # }
+    ///
+    /// ```
+    fn extension_command<T: ExtensionCommand + Send>(
+        &self,
+        ext_cmd: T,
+    ) -> WebDriverResult<serde_json::Value> {
+        self.cmd(Command::ExtensionCommand(Box::new(ext_cmd)))
     }
 }
 

--- a/src/sync/webdrivercommands.rs
+++ b/src/sync/webdrivercommands.rs
@@ -1020,14 +1020,14 @@ pub trait WebDriverCommands {
         Ok(())
     }
 
-    /// Running an extension command
+    /// Running an extension command.
     /// Extension commands are browser specific commands and using browser specific endpoints and
     /// parameters.
     ///
     /// # Example
     /// ```no_run
-    /// # use serde::Serialize;
-    /// # use thirtyfour::sync::prelude::*;
+    /// use serde::Serialize;
+    /// use thirtyfour::sync::prelude::*;
     /// use thirtyfour::{ExtensionCommand, RequestMethod};
     ///
     /// #[derive(Serialize)]
@@ -1049,21 +1049,18 @@ pub trait WebDriverCommands {
     ///    }
     /// }
     ///
-    /// # fn main() -> WebDriverResult<()> {
-    /// #        let caps = DesiredCapabilities::firefox();
-    /// #        let driver = WebDriver::new("http://localhost:4444", &caps)?;
+    /// let caps = DesiredCapabilities::firefox();
+    /// let driver = WebDriver::new("http://localhost:4444", &caps).unwrap();
     ///
-    ///        let install_command = AddonInstallCommand {
-    ///            path: String::from("/path/to/addon.xpi"),
-    ///           temporary: Some(true),
-    ///        };
+    /// let install_command = AddonInstallCommand {
+    ///     path: String::from("/path/to/addon.xpi"),
+    ///     temporary: Some(true),
+    /// };
     ///
-    ///        let response = driver.extension_command(install_command)?;
+    /// let response = driver.extension_command(install_command).unwrap();
     ///
-    ///        assert_eq!(response.is_string(), true);
+    /// assert_eq!(response.is_string(), true);
     ///
-    ///        Ok(())
-    /// # }
     /// ```
     fn extension_command<T: ExtensionCommand + Send>(
         &self,

--- a/src/sync/webdrivercommands.rs
+++ b/src/sync/webdrivercommands.rs
@@ -1025,65 +1025,53 @@ pub trait WebDriverCommands {
     /// parameters.
     ///
     /// # Example
-    /// ```rust
-    /// # use thirtyfour::sync::prelude::*;
+    /// ```no_run
     /// # use serde::Serialize;
+    /// # use thirtyfour::sync::prelude::*;
+    /// use thirtyfour::{ExtensionCommand, RequestMethod};
     ///
     /// #[derive(Serialize)]
-    /// pub struct AddonInstallParameters {
-    ///     pub path: String,
-    ///     pub temporary: Option<bool>
+    /// pub struct AddonInstallCommand {
+    ///    pub path: String,
+    ///    pub temporary: Option<bool>,
     /// }
     ///
-    /// #[derive(Serialize)]
-    /// pub struct AddonUninstallParameters {
-    ///     pub id: String
+    /// impl ExtensionCommand for AddonInstallCommand {
+    ///    fn parameters_json(&self) -> Option<serde_json::Value> {
+    ///        Some(serde_json::to_value(self).unwrap())
+    ///    }
+    ///    fn method(&self) -> RequestMethod {
+    ///        RequestMethod::Post
+    ///    }
+    ///
+    ///    fn endpoint(&self) -> String {
+    ///        String::from("/moz/addon/install")
+    ///    }
     /// }
     ///
-    /// #[derive(Serialize)]
-    /// enum GeckoExtensionCommand {
-    ///     InstallAddon(AddonInstallParameters),
-    ///     UninstallAddon(AddonUninstallParameters)
-    /// }
+    /// # fn main() -> WebDriverResult<()> {
+    /// #        let caps = DesiredCapabilities::firefox();
+    /// #        let driver = WebDriver::new("http://localhost:4444", &caps)?;
     ///
-    /// impl ExtensionCommand for GeckoExtensionCommand {
-    ///     fn parameters_json(&self)-> Option<serde_json::Value>{
-    ///        Some( match self {
-    ///             Self::InstallAddon(param)=>serde_json::to_value(param).unwrap(),
-    ///             Self::UninstallAddon(param)=>serde_json::to_value(param).unwrap()
-    ///        })
-    ///     }
+    ///        let install_command = AddonInstallCommand {
+    ///            path: String::from("/path/to/addon.xpi"),
+    ///           temporary: Some(true),
+    ///        };
     ///
-    ///     fn method(&self)-> RequestMethod {
-    ///         RequestMethod::POST
-    ///     }
+    ///        let response = driver.extension_command(install_command)?;
     ///
-    ///     fn endpoint(&self)->String {
-    ///         match self {
-    ///             Self::InstallAddon(_)=>String::from("/moz/addon/install"),
-    ///             Self::UninstallAddon(param)=>String::from("/moz/addon/uninstall")
-    ///         }
-    ///     }
-    /// }
+    ///        assert_eq!(response.is_string(), true);
     ///
-    /// # fn main()-> WebDriverResult<()> {
-    /// #   let caps = DesiredCapabilities::firefox();
-    /// #   let driver = WebDriver::new("http://localhost:4444", &caps)?;
-    /// #   
-    ///   let install_command = GeckoExtensionCommand::InstallAddon(AddonInstallParameters {
-    ///       path: String::from("/path/to/addon.xpi"),
-    ///       temporary: Some(true)
-    ///   });
-    ///
-    ///   driver.extension_command(install_command);
+    ///        Ok(())
     /// # }
-    ///
     /// ```
     fn extension_command<T: ExtensionCommand + Send>(
         &self,
         ext_cmd: T,
     ) -> WebDriverResult<serde_json::Value> {
-        self.cmd(Command::ExtensionCommand(Box::new(ext_cmd)))
+        let response = self.cmd(Command::ExtensionCommand(Box::new(ext_cmd)))?;
+
+        Ok(response["value"].clone())
     }
 }
 

--- a/src/sync/webdrivercommands.rs
+++ b/src/sync/webdrivercommands.rs
@@ -1049,17 +1049,21 @@ pub trait WebDriverCommands {
     ///    }
     /// }
     ///
-    /// let caps = DesiredCapabilities::firefox();
-    /// let driver = WebDriver::new("http://localhost:4444", &caps).unwrap();
+    /// fn main()-> WebDriverResult<()> {
+    ///     let caps = DesiredCapabilities::firefox();
+    ///     let driver = WebDriver::new("http://localhost:4444", &caps)?;
     ///
-    /// let install_command = AddonInstallCommand {
-    ///     path: String::from("/path/to/addon.xpi"),
-    ///     temporary: Some(true),
-    /// };
+    ///     let install_command = AddonInstallCommand {
+    ///         path: String::from("/path/to/addon.xpi"),
+    ///         temporary: Some(true),
+    ///     };
     ///
-    /// let response = driver.extension_command(install_command).unwrap();
+    ///     let response = driver.extension_command(install_command)?;
     ///
-    /// assert_eq!(response.is_string(), true);
+    ///     assert_eq!(response.is_string(), true);
+    ///
+    ///     Ok(())
+    /// }
     ///
     /// ```
     fn extension_command<T: ExtensionCommand + Send>(

--- a/src/webdrivercommands.rs
+++ b/src/webdrivercommands.rs
@@ -1154,17 +1154,17 @@ pub trait WebDriverCommands {
         Ok(())
     }
 
-    /// Running an extension command
+    /// Running an extension command.
     /// Extension commands are browser specific commands and using browser specific endpoints and
     /// parameters.
     ///
     /// # Example
     /// ```no_run
-    /// # use thirtyfour::prelude::*;
-    /// # use thirtyfour::{ExtensionCommand, RequestMethod};
-    /// # use thirtyfour::support::block_on;
-    /// # use serde::Serialize;
-    /// #
+    /// use thirtyfour::prelude::*;
+    /// use thirtyfour::{ExtensionCommand, RequestMethod};
+    /// use thirtyfour::support::block_on;
+    /// use serde::Serialize;
+    ///
     /// #[derive(Serialize)]
     /// pub struct AddonInstallCommand {
     ///     pub path: String,
@@ -1184,25 +1184,22 @@ pub trait WebDriverCommands {
     ///         String::from("/moz/addon/install")
     ///     }
     /// }
+    ///         
+    /// let install_command = AddonInstallCommand {
+    ///     path: String::from("/path/to/addon.xpi"),
+    ///     temporary: Some(true)
+    /// };
     ///
-    /// # fn main()-> WebDriverResult<()> {
-    /// #   block_on(async {
-
-    /// #       let caps = DesiredCapabilities::firefox();
-    /// #       let driver = WebDriver::new("http://localhost:4444", &caps).await?;
-    /// #   
-    ///         let install_command = AddonInstallCommand {
-    ///             path: String::from("/path/to/addon.xpi"),
-    ///             temporary: Some(true)
-    ///         };
+    /// block_on(async {
+    ///     let caps = DesiredCapabilities::firefox();
+    ///     let driver = WebDriver::new("http://localhost:4444", &caps).await?;
     ///
-    ///         let response = driver.extension_command(install_command).await?;
+    ///     let response = driver.extension_command(install_command).await?;
     ///
-    ///         assert_eq!(response.is_string(), true);
+    ///     assert_eq!(response.is_string(), true);
     ///
-    ///         Ok(())
-    ///     })
-    /// # }
+    ///     Ok(())
+    /// });
     ///
     /// ```
     async fn extension_command<T: ExtensionCommand + Send>(

--- a/src/webdrivercommands.rs
+++ b/src/webdrivercommands.rs
@@ -1185,21 +1185,24 @@ pub trait WebDriverCommands {
     ///     }
     /// }
     ///         
-    /// let install_command = AddonInstallCommand {
-    ///     path: String::from("/path/to/addon.xpi"),
-    ///     temporary: Some(true)
-    /// };
     ///
-    /// block_on(async {
-    ///     let caps = DesiredCapabilities::firefox();
-    ///     let driver = WebDriver::new("http://localhost:4444", &caps).await?;
+    /// fn main()->WebDriverResult<()>{
+    ///     block_on(async {
+    ///         let caps = DesiredCapabilities::firefox();
+    ///         let driver = WebDriver::new("http://localhost:4444", &caps).await?;
     ///
-    ///     let response = driver.extension_command(install_command).await?;
+    ///         let install_command = AddonInstallCommand {
+    ///             path: String::from("/path/to/addon.xpi"),
+    ///             temporary: Some(true)
+    ///         };
     ///
-    ///     assert_eq!(response.is_string(), true);
+    ///         let response = driver.extension_command(install_command).await?;
     ///
-    ///     Ok(())
-    /// });
+    ///         assert_eq!(response.is_string(), true);
+    ///
+    ///         Ok(())
+    ///     })
+    /// }
     ///
     /// ```
     async fn extension_command<T: ExtensionCommand + Send>(


### PR DESCRIPTION
**Description**

This PR will enable users to execute browser specific commands. [It is not breaking W3C standards](https://w3c.github.io/webdriver/#extensions-0) . And already implemented in [geckodriver](https://hg.mozilla.org/mozilla-central/file/tip/testing/geckodriver/src/command.rs#l118) and  [chromedriver](https://chromium.googlesource.com/chromium/src.git/+/refs/heads/master/chrome/test/chromedriver/client/command_executor.py#206). 

**My Usecase**

I want to install a browser addon to firefox using the geckodriver.