### PR TITLE
make proxy settings optional

### DIFF
--- a/src/common/capabilities/desiredcapabilities.rs
+++ b/src/common/capabilities/desiredcapabilities.rs
@@ -256,12 +256,19 @@ pub enum Proxy {
     Direct,
     #[serde(rename_all = "camelCase")]
     Manual {
+        #[serde(skip_serializing_if = "Option::is_none")]
         ftp_proxy: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         http_proxy: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         ssl_proxy: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         socks_proxy: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         socks_username: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         socks_password: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         no_proxy: Option<String>,
     },
     #[serde(rename = "pac")]


### PR DESCRIPTION
Setting any options to `None`, causes this type of error
with geckodriver.

```
An argument passed to the WebDriver server was invalid:
    Status: 400
    Additional info:
        noProxy is not an array: null
        Error: invalid argument
        Stacktrace:
```

Not de-serialize settings if they are equal `None` resolves
the issue.

I am not confident to say if the issue relates only to `geckodriver`.