### PR TITLE
Add socks_version proxy setting

### DIFF
--- a/src/common/capabilities/desiredcapabilities.rs
+++ b/src/common/capabilities/desiredcapabilities.rs
@@ -265,6 +265,8 @@ pub enum Proxy {
         #[serde(skip_serializing_if = "Option::is_none")]
         socks_proxy: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
+        socks_version: Option<u8>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         socks_username: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         socks_password: Option<String>,


### PR DESCRIPTION
Tested that `socks_proxy.is_some()` && `socks_version.is_none()` causes an error.
Setting `sock_version` to some number eliminate the issue.

closes #27 