### PR TITLE
Feature to persist sessions to file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ reqwest-native-tls = ["reqwest/native-tls"]
 reqwest-native-tls-vendored = ["reqwest/native-tls-vendored"]
 reqwest-rustls-tls = ["reqwest/rustls-tls"]
 
+persist = []
+
 [dependencies]
 async-trait = "0.1"
 futures = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,9 @@ pub use webdriver::WebDriver;
 pub use webdrivercommands::WebDriverCommands;
 pub use webelement::WebElement;
 
+#[cfg(feature = "persist")]
+pub use webdriver::persist::PersistedSession;
+
 /// Allow importing the common async structs via `use thirtyfour::prelude::*`.
 pub mod prelude {
     pub use crate::alert::Alert;


### PR DESCRIPTION
This PR adds a feature (behind the feature-flag `persist`) that allows a `WebDriver` session to be persisted to disk.

`WebDriver::persist` will consume `self` and return a `PersitedSession` that contains the session ID and capabilities. 

`PersistedSession::connect` allows to turn a persisted session back into a `WebDriver`.

`PersistedSession` is also `Serialize` and `Deserialize`, so it can easily be written to a file.


