### PR TITLE
Make WebDriver clonable

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -53,7 +53,7 @@ async fn session_runner(
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct WebDriverSession {
     session_id: SessionId,
     tx: UnboundedSender<SessionMessage>,

--- a/src/webdriver.rs
+++ b/src/webdriver.rs
@@ -68,7 +68,7 @@ pub type WebDriver = GenericWebDriver<SurfDriverAsync>;
 ///     })
 /// }
 /// ```
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GenericWebDriver<T: WebDriverHttpClientAsync> {
     pub session: WebDriverSession,
     capabilities: Value,


### PR DESCRIPTION
`SessionId`, capabilities can be trivially cloned. `UnboundedSender` is also clone, since it's a MPSC. So I see no reason to not make `WebDriverSession` and `GenericWebdriver` clonable.