### PR TITLE
Add timeout option for session creation

### DIFF
--- a/src/webdriver.rs
+++ b/src/webdriver.rs
@@ -105,12 +105,29 @@ where
     where
         C: Serialize,
     {
-        Self::new_with_initial_timeout(remote_server_addr, capabilities, None).await
+        Self::new_with_timeout(remote_server_addr, capabilities, None).await
     }
 
     /// Creates a new GenericWebDriver just like the `new` function. Allows a
     /// configurable timeout for all HTTP requests including the session creation.
-    pub async fn new_with_initial_timeout<C>(
+    ///
+    /// Create a new WebDriver as follows:
+    ///
+    /// # Example
+    /// ```rust
+    /// # use thirtyfour::prelude::*;
+    /// # use thirtyfour::support::block_on;
+    /// # use std::time::Duration;
+    /// #
+    /// # fn main() -> WebDriverResult<()> {
+    /// #     block_on(async {
+    /// let caps = DesiredCapabilities::chrome();
+    /// let driver = WebDriver::new_with_timeout("http://localhost:4444/wd/hub", &caps, Some(Duration::from_secs(120))).await?;
+    /// #         Ok(())
+    /// #     })
+    /// # }
+    /// ```
+    pub async fn new_with_timeout<C>(
         remote_server_addr: &str,
         capabilities: C,
         timeout: Option<Duration>,

--- a/src/webdriver.rs
+++ b/src/webdriver.rs
@@ -105,7 +105,25 @@ where
     where
         C: Serialize,
     {
-        let conn = T::create(remote_server_addr)?;
+        Self::new_with_initial_timeout(remote_server_addr, capabilities, None).await
+    }
+
+    /// Creates a new GenericWebDriver just like the `new` function. Allows a
+    /// configurable timeout for all HTTP requests including the session creation.
+    pub async fn new_with_initial_timeout<C>(
+        remote_server_addr: &str,
+        capabilities: C,
+        timeout: Option<Duration>,
+    ) -> WebDriverResult<Self>
+    where
+        C: Serialize,
+    {
+        let mut conn = T::create(remote_server_addr)?;
+
+        if let Some(timeout) = timeout {
+            conn.set_request_timeout(timeout);
+        }
+
         let (session_id, session_capabilities) = start_session(&conn, capabilities).await?;
         let tx = spawn_session_task(Box::new(conn));
 


### PR DESCRIPTION
Currently, the `WebDriver::new` method does not allow the user to set a timeout for the `POST /session` request. This value is hardcoded to 120 seconds in case of the reqwest driver (haven't looked up the others).

Especially in a cloud context where sessions are not available immediately, this can cause issues. I'm currently in the process of evaluating [WebGrid](https://github.com/TilBlechschmidt/WebGrid) in GCE where nodes take about a minute or two to scale up, causing the session creation to take up to three minutes (running into the hardcoded timeout).

I presume that similar issues can be encountered when using Zalenium.