### PR TITLE
feat: add common headers for async-std-runtime

### DIFF
--- a/src/common/connection_common.rs
+++ b/src/common/connection_common.rs
@@ -18,6 +18,39 @@ where
     Ok(v)
 }
 
+#[cfg(feature = "async-std-runtime")]
+pub mod surf_support {
+    use base64::encode;
+    use std::collections::HashMap;
+
+    use urlparse::urlparse;
+
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+    const ACCEPT: &'static str = "accept";
+    const AUTHORIZATION: &str = "authorization";
+    const CONNECTION: &str = "connection";
+    const CONTENT_TYPE: &str = "content-type";
+    const USER_AGENT: &str = "user-agent";
+
+    /// Construct the request headers used for every WebDriver request (surf only).
+    pub fn build_isahc_headers(remote_server_addr: &str) -> HashMap<&'static str, String> {
+        let mut headers = HashMap::new();
+        headers.insert(ACCEPT, "application/json".parse().unwrap());
+        headers.insert(CONTENT_TYPE, "application/json;charset=UTF-8".parse().unwrap());
+        headers.insert(USER_AGENT, format!("thirtyfour/{} (rust)", VERSION).parse().unwrap());
+
+        let parsed_url = urlparse(remote_server_addr);
+        if let (Some(username), Some(password)) = (parsed_url.username, parsed_url.password) {
+            let base64_string = encode(&format!("{}:{}", username, password));
+            headers.insert(AUTHORIZATION, format!("Basic {}", base64_string).parse().unwrap());
+        }
+        headers.insert(CONNECTION, "keep-alive".parse().unwrap());
+
+        headers
+    }
+}
+
 #[cfg(feature = "tokio-runtime")]
 pub mod reqwest_support {
     use base64::encode;


### PR DESCRIPTION
This PRs adds the equivalent to build_reqwest_headers for surf in order to add support for authentication. Without this change, I am getting this error: UnknownResponse(401, "Authorization required").

Solves #52