### PR TITLE
fix: change name of field in ConnectionResp

### DIFF
--- a/src/webdrivercommands.rs
+++ b/src/webdrivercommands.rs
@@ -66,7 +66,7 @@ where
 
     #[derive(Debug, Deserialize)]
     struct ConnectionResp {
-        #[serde(default)]
+        #[serde(default, rename(deserialize = "sessionId"))]
         session_id: String,
         value: ConnectionData,
     }


### PR DESCRIPTION
I have not found any specific place where this is described in the protocol, but it seems to me that this field should have this name. 
In the Response from the remote server in a third party service, I am receiving session_id as sessionId and also I think that this is the equivalent to this part in the python client.

https://github.com/SeleniumHQ/selenium/blob/0580ff2cace55c3e52f743356586c64865413677/py/selenium/webdriver/remote/webdriver.py#L309

What do you think? @stevepryde

I am not sure how to create a test or spawn a chromiumdriver server that will have a response with that format.