### PR TITLE
FirefoxProfile into FirefoxPreferences

### DIFF
--- a/src/common/capabilities/firefox.rs
+++ b/src/common/capabilities/firefox.rs
@@ -59,7 +59,7 @@ impl FirefoxCapabilities {
         self.add("pageLoadingStrategy", strategy)
     }
 
-    /// Set the firefox profile settings to use.
+    /// Set the firefox preferences to use.
     pub fn set_preferences(&mut self, preferences: FirefoxPreferences) -> WebDriverResult<()> {
         self.add_firefox_option("prefs", preferences)
     }

--- a/src/common/capabilities/firefox.rs
+++ b/src/common/capabilities/firefox.rs
@@ -60,8 +60,8 @@ impl FirefoxCapabilities {
     }
 
     /// Set the firefox profile settings to use.
-    pub fn set_profile(&mut self, profile: FirefoxProfile) -> WebDriverResult<()> {
-        self.add_firefox_option("profile", profile)
+    pub fn set_preferences(&mut self, preferences: FirefoxPreferences) -> WebDriverResult<()> {
+        self.add_firefox_option("prefs", preferences)
     }
 
     /// Add the specified command-line argument to `geckodriver`.
@@ -123,19 +123,103 @@ pub enum LoggingPrefsLogLevel {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct FirefoxProfile {
-    #[serde(rename = "webdriver_accept_untrusted_certs", skip_serializing_if = "Option::is_none")]
-    pub accept_untrusted_certs: Option<bool>,
-    #[serde(rename = "webdriver_assume_untrusted_issuer", skip_serializing_if = "Option::is_none")]
-    pub assume_untrusted_issuer: Option<bool>,
-    #[serde(rename = "webdriver.log.driver", skip_serializing_if = "Option::is_none")]
-    pub log_driver: Option<FirefoxProfileLogDriver>,
-    #[serde(rename = "webdriver.log.file", skip_serializing_if = "Option::is_none")]
-    pub log_file: Option<String>,
-    #[serde(rename = "webdriver.load.strategy", skip_serializing_if = "Option::is_none")]
-    pub load_strategy: Option<String>,
-    #[serde(rename = "webdriver_firefox_port", skip_serializing_if = "Option::is_none")]
-    pub webdriver_port: Option<u16>,
+#[serde(transparent)]
+pub struct FirefoxPreferences {
+    preferences: Value,
+}
+
+impl Default for FirefoxPreferences {
+    fn default() -> Self {
+        FirefoxPreferences {
+            preferences: json!({}),
+        }
+    }
+}
+
+impl FirefoxPreferences {
+    pub fn get(&self) -> &Value {
+        &self.preferences
+    }
+
+    pub fn get_mut(&mut self) -> &mut Value {
+        &mut self.preferences
+    }
+}
+
+impl FirefoxPreferences {
+    pub fn new() -> Self {
+        FirefoxPreferences::default()
+    }
+
+    pub fn set<T>(&mut self, key: &str, value: T) -> WebDriverResult<()>
+    where
+        T: Serialize,
+    {
+        let v = self.get_mut();
+        v[key] = to_value(value)?;
+        Ok(())
+    }
+    pub fn unset(&mut self, key: &str) -> WebDriverResult<()> {
+        let v = self.get_mut().as_object_mut().unwrap(); // This is safe because it should allways be an object
+        v.remove(key);
+        Ok(())
+    }
+
+    pub fn set_accept_untrusted_certs(&mut self, value: bool) -> WebDriverResult<()> {
+        self.set("webdriver_accept_untrusted_certs", value)
+    }
+
+    pub fn unset_accept_untrusted_certs(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver_accept_untrusted_certs")
+    }
+
+    pub fn set_assume_untrusted_issuer(&mut self, value: bool) -> WebDriverResult<()> {
+        self.set("webdriver_assume_untrusted_issuer", value)
+    }
+
+    pub fn unset_assume_untrusted_issuer(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver_assume_untrusted_issuer")
+    }
+
+    pub fn set_log_driver(&mut self, value: FirefoxProfileLogDriver) -> WebDriverResult<()> {
+        self.set("webdriver.log.driver", value)
+    }
+
+    pub fn unset_log_driver(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver.log.driver")
+    }
+
+    pub fn set_log_file(&mut self, value: String) -> WebDriverResult<()> {
+        self.set("webdriver.log.file", value)
+    }
+
+    pub fn unset_log_file(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver.log.file")
+    }
+
+    pub fn set_load_strategy(&mut self, value: String) -> WebDriverResult<()> {
+        self.set("webdriver.load.strategy", value)
+    }
+
+    pub fn unset_load_strategy(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver.load.strategy")
+    }
+
+    pub fn set_webdriver_port(&mut self, value: u16) -> WebDriverResult<()> {
+        self.set("webdriver_firefox_port", value)
+    }
+
+    pub fn unset_webdriver_port(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver_firefox_port")
+    }
+
+    pub fn set_user_agent(&mut self, value: String) -> WebDriverResult<()> {
+        self.set("general.useragent.override", value)
+    }
+
+    pub fn unset_user_agent(&mut self) -> WebDriverResult<()> {
+        self.unset("general.useragent.override")
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/common/capabilities/firefox.rs
+++ b/src/common/capabilities/firefox.rs
@@ -125,24 +125,14 @@ pub enum LoggingPrefsLogLevel {
 #[derive(Debug, Clone, Serialize)]
 #[serde(transparent)]
 pub struct FirefoxPreferences {
-    preferences: Value,
+    preferences: serde_json::Map<String, Value>,
 }
 
 impl Default for FirefoxPreferences {
     fn default() -> Self {
         FirefoxPreferences {
-            preferences: json!({}),
+            preferences: serde_json::Map::<String, Value>::default(),
         }
-    }
-}
-
-impl FirefoxPreferences {
-    pub fn get(&self) -> &Value {
-        &self.preferences
-    }
-
-    pub fn get_mut(&mut self) -> &mut Value {
-        &mut self.preferences
     }
 }
 
@@ -151,74 +141,91 @@ impl FirefoxPreferences {
         FirefoxPreferences::default()
     }
 
+    /// Sets the specified firefox preference. This is a helper method for the various
+    /// specific option methods.
     pub fn set<T>(&mut self, key: &str, value: T) -> WebDriverResult<()>
     where
         T: Serialize,
     {
-        let v = self.get_mut();
-        v[key] = to_value(value)?;
-        Ok(())
-    }
-    pub fn unset(&mut self, key: &str) -> WebDriverResult<()> {
-        let v = self.get_mut().as_object_mut().unwrap(); // This is safe because it should allways be an object
-        v.remove(key);
+        self.preferences[key] = to_value(value)?;
         Ok(())
     }
 
+    /// Resets the specified firefox preference. This is a helper method for the various
+    /// specific option methods.
+    pub fn reset(&mut self, key: &str) -> WebDriverResult<()> {
+        self.preferences.remove(key);
+        Ok(())
+    }
+
+    /// Sets accept untrusted certs
     pub fn set_accept_untrusted_certs(&mut self, value: bool) -> WebDriverResult<()> {
         self.set("webdriver_accept_untrusted_certs", value)
     }
 
-    pub fn unset_accept_untrusted_certs(&mut self) -> WebDriverResult<()> {
-        self.unset("webdriver_accept_untrusted_certs")
+    /// Resets accept untrusted certs
+    pub fn reset_accept_untrusted_certs(&mut self) -> WebDriverResult<()> {
+        self.reset("webdriver_accept_untrusted_certs")
     }
 
+    /// Sets assume untrusted issuer
     pub fn set_assume_untrusted_issuer(&mut self, value: bool) -> WebDriverResult<()> {
         self.set("webdriver_assume_untrusted_issuer", value)
     }
 
-    pub fn unset_assume_untrusted_issuer(&mut self) -> WebDriverResult<()> {
-        self.unset("webdriver_assume_untrusted_issuer")
+    /// Resets assume untrusted issuer
+    pub fn reset_assume_untrusted_issuer(&mut self) -> WebDriverResult<()> {
+        self.reset("webdriver_assume_untrusted_issuer")
     }
 
+    /// Sets the log driver
     pub fn set_log_driver(&mut self, value: FirefoxProfileLogDriver) -> WebDriverResult<()> {
         self.set("webdriver.log.driver", value)
     }
 
-    pub fn unset_log_driver(&mut self) -> WebDriverResult<()> {
-        self.unset("webdriver.log.driver")
+    /// Resets the log driver
+    pub fn reset_log_driver(&mut self) -> WebDriverResult<()> {
+        self.reset("webdriver.log.driver")
     }
 
+    /// Sets the log file
     pub fn set_log_file(&mut self, value: String) -> WebDriverResult<()> {
         self.set("webdriver.log.file", value)
     }
 
-    pub fn unset_log_file(&mut self) -> WebDriverResult<()> {
-        self.unset("webdriver.log.file")
+    /// Resets the log file
+    pub fn reset_log_file(&mut self) -> WebDriverResult<()> {
+        self.reset("webdriver.log.file")
     }
 
+    /// Sets the load strategy
     pub fn set_load_strategy(&mut self, value: String) -> WebDriverResult<()> {
         self.set("webdriver.load.strategy", value)
     }
 
-    pub fn unset_load_strategy(&mut self) -> WebDriverResult<()> {
-        self.unset("webdriver.load.strategy")
+    /// Resets the load strategy
+    pub fn reset_load_strategy(&mut self) -> WebDriverResult<()> {
+        self.reset("webdriver.load.strategy")
     }
 
+    /// Sets the webdriver port
     pub fn set_webdriver_port(&mut self, value: u16) -> WebDriverResult<()> {
         self.set("webdriver_firefox_port", value)
     }
 
-    pub fn unset_webdriver_port(&mut self) -> WebDriverResult<()> {
-        self.unset("webdriver_firefox_port")
+    /// Resets the webdriver port
+    pub fn reset_webdriver_port(&mut self) -> WebDriverResult<()> {
+        self.reset("webdriver_firefox_port")
     }
 
+    /// Sets the user agent
     pub fn set_user_agent(&mut self, value: String) -> WebDriverResult<()> {
         self.set("general.useragent.override", value)
     }
 
-    pub fn unset_user_agent(&mut self) -> WebDriverResult<()> {
-        self.unset("general.useragent.override")
+    /// Resets the user agent
+    pub fn reset_user_agent(&mut self) -> WebDriverResult<()> {
+        self.reset("general.useragent.override")
     }
 }
 

--- a/src/common/capabilities/firefox.rs
+++ b/src/common/capabilities/firefox.rs
@@ -147,7 +147,7 @@ impl FirefoxPreferences {
     where
         T: Serialize,
     {
-        self.preferences[key] = to_value(value)?;
+        self.preferences.insert(key.into(), to_value(value)?);
         Ok(())
     }
 

--- a/src/common/capabilities/firefox.rs
+++ b/src/common/capabilities/firefox.rs
@@ -151,9 +151,9 @@ impl FirefoxPreferences {
         Ok(())
     }
 
-    /// Resets the specified firefox preference. This is a helper method for the various
+    /// Unsets the specified firefox preference. This is a helper method for the various
     /// specific option methods.
-    pub fn reset(&mut self, key: &str) -> WebDriverResult<()> {
+    pub fn unset(&mut self, key: &str) -> WebDriverResult<()> {
         self.preferences.remove(key);
         Ok(())
     }
@@ -163,9 +163,9 @@ impl FirefoxPreferences {
         self.set("webdriver_accept_untrusted_certs", value)
     }
 
-    /// Resets accept untrusted certs
-    pub fn reset_accept_untrusted_certs(&mut self) -> WebDriverResult<()> {
-        self.reset("webdriver_accept_untrusted_certs")
+    /// Unsets accept untrusted certs
+    pub fn unset_accept_untrusted_certs(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver_accept_untrusted_certs")
     }
 
     /// Sets assume untrusted issuer
@@ -173,9 +173,9 @@ impl FirefoxPreferences {
         self.set("webdriver_assume_untrusted_issuer", value)
     }
 
-    /// Resets assume untrusted issuer
-    pub fn reset_assume_untrusted_issuer(&mut self) -> WebDriverResult<()> {
-        self.reset("webdriver_assume_untrusted_issuer")
+    /// Unsets assume untrusted issuer
+    pub fn unset_assume_untrusted_issuer(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver_assume_untrusted_issuer")
     }
 
     /// Sets the log driver
@@ -183,9 +183,9 @@ impl FirefoxPreferences {
         self.set("webdriver.log.driver", value)
     }
 
-    /// Resets the log driver
-    pub fn reset_log_driver(&mut self) -> WebDriverResult<()> {
-        self.reset("webdriver.log.driver")
+    /// Unsets the log driver
+    pub fn unset_log_driver(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver.log.driver")
     }
 
     /// Sets the log file
@@ -193,9 +193,9 @@ impl FirefoxPreferences {
         self.set("webdriver.log.file", value)
     }
 
-    /// Resets the log file
-    pub fn reset_log_file(&mut self) -> WebDriverResult<()> {
-        self.reset("webdriver.log.file")
+    /// Unsets the log file
+    pub fn unset_log_file(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver.log.file")
     }
 
     /// Sets the load strategy
@@ -203,9 +203,9 @@ impl FirefoxPreferences {
         self.set("webdriver.load.strategy", value)
     }
 
-    /// Resets the load strategy
-    pub fn reset_load_strategy(&mut self) -> WebDriverResult<()> {
-        self.reset("webdriver.load.strategy")
+    /// Unsets the load strategy
+    pub fn unset_load_strategy(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver.load.strategy")
     }
 
     /// Sets the webdriver port
@@ -213,9 +213,9 @@ impl FirefoxPreferences {
         self.set("webdriver_firefox_port", value)
     }
 
-    /// Resets the webdriver port
-    pub fn reset_webdriver_port(&mut self) -> WebDriverResult<()> {
-        self.reset("webdriver_firefox_port")
+    /// Unsets the webdriver port
+    pub fn unset_webdriver_port(&mut self) -> WebDriverResult<()> {
+        self.unset("webdriver_firefox_port")
     }
 
     /// Sets the user agent
@@ -223,9 +223,9 @@ impl FirefoxPreferences {
         self.set("general.useragent.override", value)
     }
 
-    /// Resets the user agent
-    pub fn reset_user_agent(&mut self) -> WebDriverResult<()> {
-        self.reset("general.useragent.override")
+    /// Unsets the user agent
+    pub fn unset_user_agent(&mut self) -> WebDriverResult<()> {
+        self.unset("general.useragent.override")
     }
 }
 


### PR DESCRIPTION
Renamed ReforefoxProfile into FirefoxPreferences,
Changed to work like Capabilities,
Added helper methods,

Without doc comments

#56 