### PR TITLE
Add full-page screenshot Firefox extension

### DIFF
--- a/src/extensions/firefox/firefoxcommand.rs
+++ b/src/extensions/firefox/firefoxcommand.rs
@@ -9,6 +9,7 @@ pub enum FirefoxCommand {
         path: String,
         temporary: Option<bool>,
     },
+    FullScreenshot {},
 }
 
 impl WebDriverCompatibleCommand for FirefoxCommand {
@@ -18,6 +19,7 @@ impl WebDriverCompatibleCommand for FirefoxCommand {
             FirefoxCommand::InstallAddon {
                 ..
             } => base.join("moz/addon/install"),
+            FirefoxCommand::FullScreenshot {} => base.join("moz/screenshot/full"),
         }
     }
 
@@ -27,6 +29,7 @@ impl WebDriverCompatibleCommand for FirefoxCommand {
                 path,
                 temporary,
             } => (Method::POST, Some(json!({"path": path, "temporary": temporary}).to_string())),
+            FirefoxCommand::FullScreenshot {} => (Method::GET, None),
         }
     }
 }


### PR DESCRIPTION
Add support for a Firefox extension, enabling to screenshot the whole page, not just the part into the viewport.

This extension has been added to geckodriver following this bug report:
https://bugzilla.mozilla.org/show_bug.cgi?id=1431148

The implementation and the WebDriver endpoint can be found here:
https://hg.mozilla.org/mozilla-central/file/fef96678ad06/testing/geckodriver/src/command.rs#l53

I tried to follow the the naming conventions, but of course feel free to rename the functions or change how errors are handled.