### PR TITLE
Re-export fantoccini's WindowHandle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub use common::{
 };
 
 pub use cookie;
-pub use fantoccini::wd::TimeoutConfiguration;
+pub use fantoccini::wd::{TimeoutConfiguration, WindowHandle};
 pub use switch_to::SwitchTo;
 pub use webdriver::WebDriver;
 pub use webelement::WebElement;


### PR DESCRIPTION
First, thank you again for this very useful crate and your quick release after my first PR #94.

This PR re-exports [`fantoccini::wd::WindowHandle`](https://docs.rs/fantoccini/0.19.0/fantoccini/wd/struct.WindowHandle.html) in a way similar to [`thirtyfour::TimeoutConfiguration`](https://docs.rs/thirtyfour/latest/thirtyfour/struct.TimeoutConfiguration.html).

Since [`fantoccini::wd::WindowHandle`](https://docs.rs/fantoccini/0.19.0/fantoccini/wd/struct.WindowHandle.html) is returned by [`thirtyfour::session::handle::SessionHandle::window_handles()`](https://docs.rs/thirtyfour/latest/thirtyfour/session/handle/struct.SessionHandle.html#method.window_handles), it is otherwise required to add the crate `fantoccini` to our project if we want to manipulate this type directly, for instance taking it as a function parameter or as return type, which can lead to incompatibility issues when the versions diverge. 