### PR TITLE
Fix Firefox's pageLoadStrategy setting

### DIFF
--- a/src/common/capabilities/firefox.rs
+++ b/src/common/capabilities/firefox.rs
@@ -56,7 +56,7 @@ impl FirefoxCapabilities {
     /// Set the page load strategy to use.
     /// Valid values are: `normal` (the default)
     pub fn set_page_load_strategy(&mut self, strategy: PageLoadStrategy) -> WebDriverResult<()> {
-        self.add("pageLoadingStrategy", strategy)
+        self.add("pageLoadStrategy", strategy)
     }
 
     /// Set the firefox preferences to use.


### PR DESCRIPTION
Firefox uses `pageLoadStrategy` (https://searchfox.org/mozilla-central/source/remote/shared/webdriver/Capabilities.jsm#441).