### PR TITLE
Use the same image as docker-compose.yml in the "docker run" in READM…

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ To install docker, see [https://docs.docker.com/install/](https://docs.docker.co
 
 Once you have docker installed, you can start the selenium server, as follows:
 
-    docker run --rm -d -p 4444:4444 -p 5900:5900 --name selenium-server -v /dev/shm:/dev/shm selenium/standalone-chrome-debug:3.141.59-zinc
+    docker run --rm -d -p 4444:4444 -p 5900:5900 --name selenium-server -v /dev/shm:/dev/shm selenium/standalone-chrome:4.1.0-20211123
 
 We will use the `-debug` container because it starts a VNC server, allowing us to view the browser session in real time.
 To connect to the VNC server you will need to use a VNC viewer application. Point it at `localhost:5900` (the default password is `secret`).


### PR DESCRIPTION
I used the "docker run" command according to README.md.
```
docker run --rm -d -p 4444:4444 -p 5900:5900 --name selenium-server -v /dev/shm:/dev/shm selenium/standalone-chrome-debug:3.141.59-zinc
```
And ran the example tokio_async.
```
cargo run --example tokio_async
```
I had the error.
```
cargo run --example tokio_async
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/examples/tokio_async`
Error: 
   0: error creating new session: webdriver server gave non-conformant response: String("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"UTF-8\">\n  <link rel=\"stylesheet\" type=\"text/css\" href=\"/assets/displayhelpservlet.css\" media=\"all\"/>\n  <link href=\"/assets/favicon.ico\" rel=\"icon\" type=\"image/x-icon\" />\n  <script src=\"/assets/jquery-3.1.1.min.js\" type=\"text/javascript\"></script>\n  <script src=\"/assets/displayhelpservlet.js\" type=\"text/javascript\"></script>\n  <script type=\"text/javascript\">\n    var json = Object.freeze('{\"consoleLink\": \"\\u002fwd\\u002fhub\",\"type\": \"Standalone\",\"class\": \"org.openqa.grid.web.servlet.DisplayHelpHandler$DisplayHelpServletConfig\",\"version\": \"3.141.59\"}');\n  </script>\n</head>\n<body>\n\n<div id=\"content\">\n  <div id=\"help-heading\">\n    <h1><span id=\"logo\"></span></h1>\n    <h2>Selenium <span class=\"se-type\"></span>&nbsp;v.<span class=\"se-version\"></span></h2>\n  </div>\n\n  <div id=\"content-body\">\n    <p>\n      Whoops! The URL specified routes to this help page.\n    </p>\n    <p>\n      For more information about Selenium <span class=\"se-type\"></span> please see the\n      <a class=\"se-docs\">docs</a> and/or visit the <a class=\"se-wiki\">wiki</a>.\n      <span id=\"console-item\">\n        Or perhaps you are looking for the Selenium <span class=\"se-type\"></span> <a class=\"se-console\">console</a>.\n      </span>\n    </p>\n    <p>\n      Happy Testing!\n    </p>\n  </div>\n\n  <div>\n    <footer id=\"help-footer\">\n      Selenium is made possible through the efforts of our open source community, contributions from\n      these <a href=\"https://github.com/SeleniumHQ/selenium/blob/master/AUTHORS\">people</a>, and our\n      <a href=\"http://www.seleniumhq.org/sponsors/\">sponsors</a>.\n   </footer>\n  </div>\n </div>\n\n</body>\n</html>")
   1: webdriver server gave non-conformant response: String("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"UTF-8\">\n  <link rel=\"stylesheet\" type=\"text/css\" href=\"/assets/displayhelpservlet.css\" media=\"all\"/>\n  <link href=\"/assets/favicon.ico\" rel=\"icon\" type=\"image/x-icon\" />\n  <script src=\"/assets/jquery-3.1.1.min.js\" type=\"text/javascript\"></script>\n  <script src=\"/assets/displayhelpservlet.js\" type=\"text/javascript\"></script>\n  <script type=\"text/javascript\">\n    var json = Object.freeze('{\"consoleLink\": \"\\u002fwd\\u002fhub\",\"type\": \"Standalone\",\"class\": \"org.openqa.grid.web.servlet.DisplayHelpHandler$DisplayHelpServletConfig\",\"version\": \"3.141.59\"}');\n  </script>\n</head>\n<body>\n\n<div id=\"content\">\n  <div id=\"help-heading\">\n    <h1><span id=\"logo\"></span></h1>\n    <h2>Selenium <span class=\"se-type\"></span>&nbsp;v.<span class=\"se-version\"></span></h2>\n  </div>\n\n  <div id=\"content-body\">\n    <p>\n      Whoops! The URL specified routes to this help page.\n    </p>\n    <p>\n      For more information about Selenium <span class=\"se-type\"></span> please see the\n      <a class=\"se-docs\">docs</a> and/or visit the <a class=\"se-wiki\">wiki</a>.\n      <span id=\"console-item\">\n        Or perhaps you are looking for the Selenium <span class=\"se-type\"></span> <a class=\"se-console\">console</a>.\n      </span>\n    </p>\n    <p>\n      Happy Testing!\n    </p>\n  </div>\n\n  <div>\n    <footer id=\"help-footer\">\n      Selenium is made possible through the efforts of our open source community, contributions from\n      these <a href=\"https://github.com/SeleniumHQ/selenium/blob/master/AUTHORS\">people</a>, and our\n      <a href=\"http://www.seleniumhq.org/sponsors/\">sponsors</a>.\n   </footer>\n  </div>\n </div>\n\n</body>\n</html>")

Location:
   examples/tokio_async.rs:19

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```
But I use the "docker-compose" command according to README.md, and the example worked fine.
The cause of this error when using "docker run" is that the docker image is old.

I fixed the "docker run" section of README.md.