### PR TITLE
fix FirefoxCapabilities::get_args

### DIFF
--- a/src/common/capabilities/chrome.rs
+++ b/src/common/capabilities/chrome.rs
@@ -44,12 +44,8 @@ impl ChromeCapabilities {
     {
         self.capabilities
             .get("goog:chromeOptions")
-            .map(|options| {
-                options
-                    .get(key)
-                    .map(|option| from_value(option.clone()).unwrap_or_default())
-                    .unwrap_or_default()
-            })
+            .and_then(|options| options.get(key))
+            .and_then(|option| from_value(option.clone()).ok())
             .unwrap_or_default()
     }
 

--- a/src/common/capabilities/firefox.rs
+++ b/src/common/capabilities/firefox.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use fantoccini::wd::Capabilities;
+use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::{from_value, json, to_value, Value};
 
@@ -74,14 +75,21 @@ impl FirefoxCapabilities {
         self.add_firefox_option("args", to_value(args)?)
     }
 
+    /// Get the specified Firefox option.
+    pub fn get_firefox_option<T>(&self, key: &str) -> T
+    where
+        T: DeserializeOwned + Default,
+    {
+        self.capabilities
+            .get("moz:firefoxOptions")
+            .and_then(|options| options.get(key))
+            .and_then(|option| from_value(option.clone()).ok())
+            .unwrap_or_default()
+    }
+
     /// Get the current list of command-line arguments to `geckodriver` as a vec.
     pub fn get_args(&self) -> Vec<String> {
-        let caps =
-            self.capabilities.get("moz:firefoxOptions").and_then(|options| options.get("args"));
-        match caps {
-            None => vec![],
-            Some(caps) => from_value(caps.clone()).unwrap_or_default(),
-        }
+        self.get_firefox_option("args")
     }
 
     /// Set the browser to run headless.

--- a/src/common/capabilities/firefox.rs
+++ b/src/common/capabilities/firefox.rs
@@ -76,11 +76,8 @@ impl FirefoxCapabilities {
 
     /// Get the current list of command-line arguments to `geckodriver` as a vec.
     pub fn get_args(&self) -> Vec<String> {
-        let caps = self
-            .capabilities
-            .get("moz:firefoxOptions")
-            .map(|options| options.get("args"))
-            .flatten();
+        let caps =
+            self.capabilities.get("moz:firefoxOptions").and_then(|options| options.get("args"));
         match caps {
             None => vec![],
             Some(caps) => from_value(caps.clone()).unwrap_or_default(),

--- a/src/common/capabilities/firefox.rs
+++ b/src/common/capabilities/firefox.rs
@@ -76,7 +76,15 @@ impl FirefoxCapabilities {
 
     /// Get the current list of command-line arguments to `geckodriver` as a vec.
     pub fn get_args(&self) -> Vec<String> {
-        from_value(self.capabilities["moz:firefoxOptions"]["args"].clone()).unwrap_or_default()
+        let caps = self
+            .capabilities
+            .get("moz:firefoxOptions")
+            .map(|options| options.get("args"))
+            .flatten();
+        match caps {
+            None => vec![],
+            Some(caps) => from_value(caps.clone()).unwrap_or_default(),
+        }
     }
 
     /// Set the browser to run headless.

--- a/src/webelement.rs
+++ b/src/webelement.rs
@@ -746,13 +746,13 @@ impl WebElement {
     }
 }
 
-impl<'a> fmt::Display for WebElement {
+impl fmt::Display for WebElement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.element)
     }
 }
 
-impl<'a> Serialize for WebElement {
+impl Serialize for WebElement {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,


### PR DESCRIPTION
`FirefoxCapabilities::new` calls `FirefoxCapabilities::default` which only adds `"browserName"` as a key to `FirefoxCapabilities::capabilities`.
`FirefoxCapabilities::get_args` can therefor panic because it does not necessarily contain `"moz:firefoxOptions" `.
This PR fixes this issue.