### PR TITLE
Set default-features to false for fantoccini

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ async-trait = "0.1"
 base64 = "0.13"
 chrono = { version = "0.4", features = ["serde"] }
 cookie = { version = "0.16.0", features = ["percent-encode"] }
-fantoccini = "0.19.0"
+fantoccini = { version = "0.19.0", default-features = false }
 futures = "0.3"
 http = "0.2.6"
 log = "0.4"

--- a/src/webdriver.rs
+++ b/src/webdriver.rs
@@ -54,7 +54,13 @@ impl WebDriver {
     {
         use fantoccini::ClientBuilder;
         let caps: Capabilities = capabilities.into();
-        let client = ClientBuilder::native().capabilities(caps.clone()).connect(server_url).await?;
+
+        #[cfg(feature = "native-tls")]
+        let mut builder = ClientBuilder::native();
+        #[cfg(feature = "rusttls-tls")]
+        let mut builder = ClientBuilder::rustls();
+
+        let client = builder.capabilities(caps.clone()).connect(server_url).await?;
 
         // Set default timeouts.
         let timeouts = TimeoutConfiguration::default();


### PR DESCRIPTION
This prevents `hyper-tls` from being pulled in accidentally.