### PR TITLE
Implement ElementQueryable for SessionHandle

### DIFF
--- a/src/extensions/query/element_query.rs
+++ b/src/extensions/query/element_query.rs
@@ -677,8 +677,20 @@ impl ElementQueryable for WebDriver {
     ///
     /// See [ElementQuery](query/struct.ElementQuery.html) for more documentation.
     fn query(&self, by: By) -> ElementQuery {
-        let poller: ElementPoller = self.handle.config.get_query_poller();
-        ElementQuery::new(ElementQuerySource::Driver(self.handle.clone()), poller, by)
+        self.handle.query(by)
+    }
+}
+
+impl ElementQueryable for SessionHandle {
+    /// Return an ElementQuery instance for more executing powerful element queries.
+    ///
+    /// This uses the builder pattern to construct queries that will return one or
+    /// more elements, depending on the method specified at the end of the chain.
+    ///
+    /// See [ElementQuery](query/struct.ElementQuery.html) for more documentation.
+    fn query(&self, by: By) -> ElementQuery {
+        let poller: ElementPoller = self.config.get_query_poller();
+        ElementQuery::new(ElementQuerySource::Driver(self.clone()), poller, by)
     }
 }
 


### PR DESCRIPTION
Make `ElementQueryable::query` accessible through `SessionHandle`s. Currently the trait is implemented for `WebDriver` and `WebElement` but not `SessionHandle`, which may be surprising to users.