### PR TITLE
Bump fantoccini version to 0.19.3

### DIFF
--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -28,7 +28,7 @@ async-trait = "0.1.56"
 base64 = "0.13.0"
 chrono = { version = "0.4.22", features = ["serde"] }
 cookie = { version = "0.16.0", features = ["percent-encode"] }
-fantoccini = { version = "0.19.2", default-features = false }
+fantoccini = { version = "0.19.3", default-features = false }
 futures = "0.3.21"
 http = "0.2.8"
 log = "0.4.17"


### PR DESCRIPTION
Fixes #103

Selenium version >= 4 requires the parameter `charset=utf-8` included on the `Content-Type` header. Version `0.19.3` of Fantoccini includes this fix.