### PR TITLE
Fixed typo rusttls into correct rustls (no double t)

### DIFF
--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -18,8 +18,8 @@ keywords = ["selenium", "webdriver", "chromedriver", "geckodriver", "automation"
 categories = ["api-bindings", "development-tools::testing", "web-programming::http-client"]
 
 [features]
-default = ["rusttls-tls", "component"]
-rusttls-tls = ["fantoccini/rustls-tls"]
+default = ["rustls-tls", "component"]
+rustls-tls = ["fantoccini/rustls-tls"]
 native-tls = ["fantoccini/native-tls"]
 component = ["thirtyfour-macros"]
 

--- a/thirtyfour/README.md
+++ b/thirtyfour/README.md
@@ -50,7 +50,7 @@ aim to migrate code away from the deprecated methods as soon as is practical.
 
 ## Feature Flags
 
-- `rusttls-tls`: (Default) Use rusttls to provide TLS support (via fantoccini/hyper).
+- `rustls-tls`: (Default) Use rustls to provide TLS support (via fantoccini/hyper).
 - `native-tls`: Use native TLS (via fantoccini/hyper).
 - `component`: (Default) Enable the `Component` derive macro (via thirtyfour_macros).
 

--- a/thirtyfour/src/lib.rs
+++ b/thirtyfour/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! ## Feature Flags
 //!
-//! * `rusttls-tls`: (Default) Use rusttls to provide TLS support (via fantoccini/hyper).
+//! * `rustls-tls`: (Default) Use rustls to provide TLS support (via fantoccini/hyper).
 //! * `native-tls`: Use native TLS (via fantoccini/hyper).
 //! * `component`: (Default) Enable the `Component` derive macro (via thirtyfour-macros).
 //!

--- a/thirtyfour/src/webdriver.rs
+++ b/thirtyfour/src/webdriver.rs
@@ -58,10 +58,10 @@ impl WebDriver {
     where
         C: Into<Capabilities>,
     {
-        #[cfg(not(any(feature = "rusttls-tls", feature = "native-tls")))]
-        panic!("please set either the rusttls-tls or native-tls feature");
+        #[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
+        panic!("please set either the rustls-tls or native-tls feature");
 
-        #[cfg(any(feature = "rusttls-tls", feature = "native-tls"))]
+        #[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
         {
             use crate::TimeoutConfiguration;
             use fantoccini::ClientBuilder;
@@ -69,7 +69,7 @@ impl WebDriver {
 
             #[cfg(feature = "native-tls")]
             let mut builder = ClientBuilder::native();
-            #[cfg(feature = "rusttls-tls")]
+            #[cfg(feature = "rustls-tls")]
             let mut builder = ClientBuilder::rustls();
 
             let client = builder.capabilities(caps.clone()).connect(server_url).await?;


### PR DESCRIPTION
Found it by accident as I entered `rusttls` into [crates.io](https://crates.io/search?page=1&per_page=10&q=rusttls).

NOTE: ignore typo in branch name