### PR TITLE
Added temporary js_drag_to method to WebElement

### DIFF
--- a/thirtyfour/src/js.rs
+++ b/thirtyfour/src/js.rs
@@ -1,8 +1,6 @@
-//! A place to store reusable JavaScript to pass to executeScript and executeScriptAsync.
+//! A place to store reusable JavaScript to pass to execute and execute_async.
 
-/// A javascript function for simulating drag and drop. Using this
-/// as a temporary measure until a bug in Selenium itself is fixed,
-/// as recommended here: https://github.com/SeleniumHQ/selenium/issues/8003.
+/// A javascript function for simulating drag and drop.
 pub const SIMULATE_DRAG_AND_DROP: &str = r#"
 function simulateDragDrop(sourceNode, destinationNode) {
     var EVENT_TYPES = {

--- a/thirtyfour/src/js.rs
+++ b/thirtyfour/src/js.rs
@@ -1,0 +1,51 @@
+//! A place to store reusable JavaScript to pass to executeScript and executeScriptAsync.
+
+/// A javascript function for simulating drag and drop. Using this
+/// as a temporary measure until a bug in Selenium itself is fixed,
+/// as recommended here: https://github.com/SeleniumHQ/selenium/issues/8003.
+pub const SIMULATE_DRAG_AND_DROP: &str = r#"
+function simulateDragDrop(sourceNode, destinationNode) {
+    var EVENT_TYPES = {
+        DRAG_END: 'dragend',
+        DRAG_START: 'dragstart',
+        DROP: 'drop'
+    }
+
+    function createCustomEvent(type) {
+        var event = new CustomEvent("CustomEvent")
+        event.initCustomEvent(type, true, true, null)
+        event.dataTransfer = {
+            data: {
+            },
+            setData: function(type, val) {
+                this.data[type] = val
+            },
+            getData: function(type) {
+                return this.data[type]
+            }
+        }
+        return event
+    }
+
+    function dispatchEvent(node, type, event) {
+        if (node.dispatchEvent) {
+            return node.dispatchEvent(event)
+        }
+        if (node.fireEvent) {
+            return node.fireEvent("on" + type, event)
+        }
+    }
+
+    var event = createCustomEvent(EVENT_TYPES.DRAG_START)
+    dispatchEvent(sourceNode, EVENT_TYPES.DRAG_START, event)
+
+    var dropEvent = createCustomEvent(EVENT_TYPES.DROP)
+    dropEvent.dataTransfer = event.dataTransfer
+    dispatchEvent(destinationNode, EVENT_TYPES.DROP, dropEvent)
+
+    var dragEndEvent = createCustomEvent(EVENT_TYPES.DRAG_END)
+    dragEndEvent.dataTransfer = event.dataTransfer
+    dispatchEvent(sourceNode, EVENT_TYPES.DRAG_END, dragEndEvent)
+}
+
+simulateDragDrop(arguments[0], arguments[1]);"#;

--- a/thirtyfour/src/lib.rs
+++ b/thirtyfour/src/lib.rs
@@ -189,6 +189,7 @@ pub mod session;
 /// Miscellaneous support functions for `thirtyfour` tests.
 pub mod support;
 
+mod js;
 mod switch_to;
 mod upstream;
 mod webdriver;

--- a/thirtyfour/src/webelement.rs
+++ b/thirtyfour/src/webelement.rs
@@ -761,9 +761,7 @@ impl WebElement {
         Ok(())
     }
 
-    /// Drag the element to a target element using JavaScript. This is a convenient replacement 
-    /// for dragging elements in an action chain, which is currently not working
-    /// due to a bug in Selenium. The idea is to deprecate this once the bug is fixed.
+    /// Drag the element to a target element using JavaScript.
     /// 
     /// # Example
     /// ```no_run

--- a/thirtyfour/src/webelement.rs
+++ b/thirtyfour/src/webelement.rs
@@ -8,6 +8,7 @@ use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
 use crate::error::WebDriverError;
+use crate::js::SIMULATE_DRAG_AND_DROP;
 use crate::session::handle::SessionHandle;
 use crate::upstream::ElementRef;
 use crate::{common::types::ElementRect, error::WebDriverResult, By, ElementRefHelper};
@@ -757,6 +758,34 @@ impl WebElement {
     /// ```
     pub async fn enter_frame(self) -> WebDriverResult<()> {
         self.element.enter_frame().await?;
+        Ok(())
+    }
+
+    /// Drag the element to a target element using JavaScript. This is a convenient replacement 
+    /// for dragging elements in an action chain, which is currently not working
+    /// due to a bug in Selenium. The idea is to deprecate this once the bug is fixed.
+    /// 
+    /// # Example
+    /// ```no_run
+    /// # use thirtyfour::prelude::*;
+    /// # use thirtyfour::support::block_on;
+    /// #
+    /// # fn main() -> WebDriverResult<()> {
+    /// #     block_on(async {
+    /// #         let caps = DesiredCapabilities::chrome();
+    /// #         let driver = WebDriver::new("http://localhost:4444", caps).await?;
+    /// let elem = driver.find(By::Id("draggable")).await?;
+    /// let target = driver.find(By::Id("target")).await?;
+    /// elem.js_drag_to(&target).await?;
+    /// #         driver.quit().await?;
+    /// #         Ok(())
+    /// #     })
+    /// # }
+    /// ```
+    pub async fn js_drag_to(&self, target: &Self) -> WebDriverResult<()> {
+        self.handle
+            .execute(SIMULATE_DRAG_AND_DROP, vec![self.to_json()?, target.to_json()?])
+            .await?;
         Ok(())
     }
 }

--- a/thirtyfour/tests/common.rs
+++ b/thirtyfour/tests/common.rs
@@ -182,3 +182,7 @@ pub fn sample_page_url(port: u16) -> String {
 pub fn other_page_url(port: u16) -> String {
     format!("http://localhost:{}/other_page.html", port)
 }
+
+pub fn drag_to_url(port: u16) -> String {
+    format!("http://localhost:{}/drag_to.html", port)
+}

--- a/thirtyfour/tests/custom_js.rs
+++ b/thirtyfour/tests/custom_js.rs
@@ -1,0 +1,43 @@
+//! Tests for validating functionality based on executing crate maintained JavaScript
+use crate::common::drag_to_url;
+use serial_test::serial;
+use thirtyfour::prelude::*;
+
+mod common;
+
+async fn drag_to(c: WebDriver, port: u16) -> Result<(), WebDriverError> {
+    let drag_to_url = drag_to_url(port);
+    c.goto(&drag_to_url).await?;
+
+    // Validate we are starting with a div and an image that are adjacent to one another.
+    c.find(By::XPath("//div[@id='target']/../img[@id='draggable']")).await?;
+
+    // Drag the image to the target div
+    let elem = c.find(By::Id("draggable")).await?;
+    let target = c.find(By::Id("target")).await?;
+    elem.js_drag_to(&target).await?;
+
+    // Validate that the image was moved into the target div
+    c.find(By::XPath("//div[@id='target']/img[@id='draggable']")).await?;
+    Ok(())
+}
+
+mod firefox {
+    use super::*;
+
+    #[test]
+    #[serial]
+    fn drag_to_test() {
+        local_tester!(drag_to, "firefox");
+    }
+}
+
+mod chrome {
+    use super::*;
+
+    #[test]
+    #[serial]
+    fn drag_to_test() {
+        local_tester!(drag_to, "chrome");
+    }
+}

--- a/thirtyfour/tests/test_html/drag_to.html
+++ b/thirtyfour/tests/test_html/drag_to.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<html>
+
+<!-- Modified from: https://www.w3schools.com/HTML/tryit.asp?filename=tryhtml5_draganddrop -->
+
+<head>
+    <style>
+        #target {
+            width: 350px;
+            height: 70px;
+            padding: 10px;
+            border: 1px solid #aaaaaa;
+        }
+    </style>
+    <script>
+        function allowDrop(ev) {
+            ev.preventDefault();
+        }
+
+        function drag(ev) {
+            ev.dataTransfer.setData("text", ev.target.id);
+        }
+
+        function drop(ev) {
+            ev.preventDefault();
+            var data = ev.dataTransfer.getData("text");
+            ev.target.appendChild(document.getElementById(data));
+        }
+    </script>
+</head>
+
+<body>
+    <div id="target" ondrop="drop(event)" ondragover="allowDrop(event)"></div>
+    <br>
+    <img id="draggable" src="https://www.w3schools.com/html/img_logo.gif" draggable="true" ondragstart="drag(event)" width="336" height="69">
+</body>
+
+</html>


### PR DESCRIPTION
Currently the drag and drop methods in action chain do not work due to a known bug in Selenium. The solution for the python library was to have a method which simulates drag and drop using JavaScript be part of an external library called seletools. Since thirtyfour is already a wrapper around fantoccini which provides it's own API's, it made more sense to me that the solution for thirtyfour would be to provide a convenience method that executed the same Javascript functionality, which could be deprecated when the bug is fixed in Selenium. This pull request implements that method. 