### PR TITLE
Rename accept_ssl_certs -> accept_insecure_certs (in line with webdriver spec)

### DIFF
--- a/thirtyfour/src/common/capabilities/desiredcapabilities.rs
+++ b/thirtyfour/src/common/capabilities/desiredcapabilities.rs
@@ -115,8 +115,14 @@ pub trait CapabilitiesHelper {
     }
 
     /// Set whether the session should accept all SSL certificates by default.
+    #[deprecated(since = "0.32.0-rc.5", note = "please use `accept_insecure_certs` instead")]
     fn accept_ssl_certs(&mut self, enabled: bool) -> WebDriverResult<()> {
         self.set_base_capability("acceptSslCerts", enabled)
+    }
+
+    /// Set whether the session should accept insecure SSL certificates by default.
+    fn accept_insecure_certs(&mut self, enabled: bool) -> WebDriverResult<()> {
+        self.set_base_capability("acceptInsecureCerts", enabled)
     }
 
     /// Set whether the session can rotate the current page's layout between portrait and landscape


### PR DESCRIPTION
it appears that a spec change made a long time ago has renamed the respective capability:

https://github.com/w3c/webdriver/commit/df3b04aebbcc755f2bd429383b2a60cbbaf1b3fd
https://www.w3.org/2016/09/19-webdriver-minutes.html
https://www.w3.org/TR/2022/WD-webdriver2-20221216/#capabilities

the new name works with up to date webdriver implementations while the old one does not.

until this is stable, the following workaround can be used for `v0.31.0`:
```
    use thirtyfour::CapabilitiesHelper;                                                             
    let mut caps = DesiredCapabilities::chrome();                                                   
    caps.add("acceptInsecureCerts", true);                  
```

thank you for your work.