### PR TITLE
Add missing body params for the ExecuteCdpCommand

### DIFF
--- a/thirtyfour/src/extensions/cdp/chromecommand.rs
+++ b/thirtyfour/src/extensions/cdp/chromecommand.rs
@@ -43,10 +43,11 @@ impl FormatRequestData for ChromeCommand {
                 format!("/session/{}/chromium/network_conditions", session_id),
             )
             .add_body(json!({ "network_conditions": conditions })),
-            ChromeCommand::ExecuteCdpCommand(..) => RequestData::new(
+            ChromeCommand::ExecuteCdpCommand(command, params) => RequestData::new(
                 RequestMethod::Post,
                 format!("/session/{}/goog/cdp/execute", session_id),
-            ),
+            )
+            .add_body(json!({ "cmd": command, "params": params })),
             ChromeCommand::GetSinks => RequestData::new(
                 RequestMethod::Get,
                 format!("/session/{}/goog/cast/get_sinks", session_id),


### PR DESCRIPTION
The `execute_cdp_with_params` function is not working on v0.32.0-rc.9, this patch re-adds the missing body params for the command