### PR TITLE
update resolver to fight less over cache

### DIFF
--- a/thirtyfour/src/components/wrapper/resolver.rs
+++ b/thirtyfour/src/components/wrapper/resolver.rs
@@ -77,7 +77,9 @@ impl<T: Clone + 'static> ElementResolver<T> {
 
     /// Invalidate any cached element(s).
     pub fn invalidate(&self) {
-        self.element.store(Arc::new(OnceCell::new()));
+        if self.element.initialized() {
+            self.element.store(Arc::new(OnceCell::new()));
+        }
     }
 
     /// Run the query, ignoring any cached element(s).


### PR DESCRIPTION
only invalidate initialized `OnceCells` (the less `OnceCells` we create the less times we query the browser)