### PR TITLE
Allow constructing By::PartialLinkText

### DIFF
--- a/thirtyfour/src/common/command.rs
+++ b/thirtyfour/src/common/command.rs
@@ -88,6 +88,13 @@ impl By {
         }
     }
 
+    /// Select element by partial link text.
+    pub fn PartialLinkText(text: impl IntoArcStr) -> Self {
+        Self {
+            selector: BySelector::PartialLinkText(text.into()),
+        }
+    }
+
     /// Select element by CSS.
     pub fn Css(css: impl IntoArcStr) -> Self {
         Self {


### PR DESCRIPTION
Seems like this was forgotten while refactoring.
