### PR TITLE
Change type of x and y parameters to accept signed integer types instead of unsigned.

### DIFF
--- a/thirtyfour/src/session/handle.rs
+++ b/thirtyfour/src/session/handle.rs
@@ -635,14 +635,14 @@ impl SessionHandle {
     /// ```
     pub async fn set_window_rect(
         &self,
-        x: u32,
-        y: u32,
+        x: i64,
+        y: i64,
         width: u32,
         height: u32,
     ) -> WebDriverResult<()> {
         let rect = OptionRect {
-            x: Some(x as i64),
-            y: Some(y as i64),
+            x: Some(x),
+            y: Some(y),
             width: Some(width as i64),
             height: Some(height as i64),
         };


### PR DESCRIPTION
Change type of x and y parameters to accept signed integer types instead of unsigned.

I think thirtyfour should allow the `set_window_rect` method to accept signed values for the x and y parameters.
I had a case where I wanted to pass a negative value because the monitor that I wanted to open the browser window on was arranged to be on top of my main window.