### PR TITLE
Add data-testid as a type of selector

### DIFF
--- a/thirtyfour-macros/src/component.rs
+++ b/thirtyfour-macros/src/component.rs
@@ -268,6 +268,7 @@ enum ByToken {
     XPath(Literal),
     Name(Literal),
     ClassName(Literal),
+    Testid(Literal),
     Multi,
     /// NotEmpty is the default but can be specified to be explicit.
     NotEmpty,
@@ -294,7 +295,8 @@ impl ByToken {
             | ByToken::Css(_)
             | ByToken::XPath(_)
             | ByToken::Name(_)
-            | ByToken::ClassName(_) => "selector",
+            | ByToken::ClassName(_)
+            | ByToken::Testid(_) => "selector",
             ByToken::Multi => "multi",
             ByToken::NotEmpty => "not_empty",
             ByToken::AllowEmpty => "allow_empty",
@@ -464,6 +466,13 @@ impl TryFrom<Meta> for ByToken {
                         lit: Lit::Str(v),
                         ..
                     }),
+                ) if k.is_ident("testid") => Ok(ByToken::Testid(v.token())),
+                (
+                    k,
+                    Expr::Lit(ExprLit {
+                        lit: Lit::Str(v),
+                        ..
+                    }),
                 ) if k.is_ident("description") => Ok(ByToken::Description(v.token())),
                 (k, expr) if k.is_ident("custom") => Ok(ByToken::CustomFn(expr)),
                 (k, ..) => Err(syn::Error::new(
@@ -525,6 +534,7 @@ impl ByTokens {
                 ByToken::XPath(xpath) => ret.push(quote! { By::XPath(#xpath) }),
                 ByToken::Name(name) => ret.push(quote! { By::Name(#name) }),
                 ByToken::ClassName(class_name) => ret.push(quote! { By::ClassName(#class_name) }),
+                ByToken::Testid(id) => ret.push(quote! { By::Testid(#id) }),
                 t => self.tokens.push(t),
             }
         }
@@ -679,6 +689,7 @@ impl ToTokens for DebugByTokens {
                 | ByToken::XPath(lit)
                 | ByToken::Name(lit)
                 | ByToken::ClassName(lit)
+                | ByToken::Testid(lit)
                 | ByToken::Description(lit) => lit.to_tokens(tokens),
                 // idents
                 ByToken::Multi

--- a/thirtyfour/src/common/command.rs
+++ b/thirtyfour/src/common/command.rs
@@ -65,6 +65,8 @@ pub enum BySelector {
     ClassName(Arc<str>),
     /// Select an element by CSS.
     Css(Arc<str>),
+    /// Select an element by data-testid.
+    Testid(Arc<str>),
 }
 
 /// Element Selector struct providing a convenient way to specify selectors.
@@ -130,6 +132,13 @@ impl By {
             selector: BySelector::Css(format!(".{}", name.into()).into()),
         }
     }
+
+    /// Select element by testid.
+    pub fn Testid(id: impl IntoArcStr) -> Self {
+        Self {
+            selector: BySelector::Css(format!("[data-testid=\"{}\"]", id.into()).into()),
+        }
+    }
 }
 
 impl fmt::Display for BySelector {
@@ -143,6 +152,7 @@ impl fmt::Display for BySelector {
             BySelector::Tag(tag) => write!(f, "Tag({})", tag),
             BySelector::ClassName(cname) => write!(f, "Class({})", cname),
             BySelector::Css(css) => write!(f, "CSS({})", css),
+            BySelector::Testid(id) => write!(f, "Testid({})", id),
         }
     }
 }
@@ -164,6 +174,7 @@ impl From<BySelector> for Selector {
             BySelector::Tag(x) => Selector::new("css selector", x),
             BySelector::ClassName(x) => Selector::new("css selector", format!(".{}", x)),
             BySelector::Css(x) => Selector::new("css selector", x),
+            BySelector::Testid(x) => Selector::new("testid selector", format!("[data-testid=\"{}\"]", x)),
         }
     }
 }


### PR DESCRIPTION
Marking up components with `data-testid` is a pretty popular way of providing somewhat namespaced access to DOM for the purpose of testing.  Other testing tools have support for `data-testid` but I'll admit it's somewhat arbitrary as a selector and I appreciate that we probably want to keep `By::{X, Y, Z}` to a minimum.  Feel free to reject PR on those grounds.

Creating my own helpers outside of `thirtyfour` does work mostly fine _except_ when it comes to creating Component with macros.  Typing out `#[by(css = "[data-testid=\"confirmation-confirm\"]")]` feels somewhat cumbersome.  That's really the motivation for this PR.

I've gone with referring to `data-testid` as `Testid` in Rust code.  (nb.  lowercase i).  This feels weird but reflects the commonly used casing when adding testids in markup.