### PR TITLE
Fix: provide a Result when starting the web driver process.

### DIFF
--- a/docs/src/getting-started/explaining-the-code.md
+++ b/docs/src/getting-started/explaining-the-code.md
@@ -8,27 +8,29 @@ So what did this code actually do?
 ## How Thirtyfour Works
 
 Well, the first thing to know is that `thirtyfour` doesn't talk directly to the Web Browser.
-It simply fires off commands to the webdriver server as HTTP Requests. 
-The webdriver then talks to the Web Browser and tells it to execute each command, and then 
+It simply fires off commands to the webdriver server as HTTP Requests.
+The webdriver then talks to the Web Browser and tells it to execute each command, and then
 returns the response from the Web Browser to `thirtyfour`. As long as the webdriver is
 running, `thirtyfour` can do just about anything a human can do in a web browser.
 
-## Explaining The Code 
+## Explaining The Code
 
 So let's go through the code and see what is going on.
 
 ```rust
     let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let server_url = "http://localhost:9515";
+    start_webdriver_process(server_url, &caps, true)?;
+    let driver = WebDriver::new(server_url, caps).await?;
 ```
 
 This is where we actually make the initial connection to the webdriver and start a new
-session in the web browser. This will open the browser in a new profile (so it won't add 
+session in the web browser. This will open the browser in a new profile (so it won't add
 anything to your history etc.) and navigate to the default start page.
 
 ## Capabilities
 
-The way we tell it what browser we want is by using `DesiredCapabilities`. In this case, 
+The way we tell it what browser we want is by using `DesiredCapabilities`. In this case,
 we construct a new `ChromeCapabilities` instance. Each `*Capabilities` struct will have
 additional helper methods for setting options like headless mode, proxy, and so on.
 See the [documentation](https://docs.rs/thirtyfour/latest/thirtyfour/common/capabilities/chrome/struct.ChromeCapabilities.html) for more details.
@@ -36,7 +38,7 @@ See the [documentation](https://docs.rs/thirtyfour/latest/thirtyfour/common/capa
 > You may have heard of `selenium`. `Selenium` is simply a proxy that forwards requests to one or
 > more webdriver servers. Using `Selenium` you can interact with multiple browsers at once. You simply
 > tell `Selenium` where each of the webdrivers are, and some details of each browser, and then in your
-> code you give `thirtyfour` the address of the selenium server, not the webdriver, and use the 
+> code you give `thirtyfour` the address of the selenium server, not the webdriver, and use the
 > `DesiredCapabilities` to request a particular browser.
 
 ## Element Queries
@@ -58,7 +60,7 @@ an element with the id of `search-form`.
 
 > If you actually navigate to [https://wikipedia.org](https://wikipedia.org) and open your browser's
 > devtools (F12 in most browsers), then go to the `Inspector` tab, you will see the raw HTML for
-> the page. In the search box at the top of the inspector, if you type `#search-form` 
+> the page. In the search box at the top of the inspector, if you type `#search-form`
 > (the # is how we specify an id) you will see that it highlights the search form element.
 
 This is the container element that contains both the input field and the button itself.
@@ -82,14 +84,14 @@ To type into a field, we just tell `thirtyfour` to send the keys we want to type
 
 This will literally type the text into the input field.
 
-Now we need to find the search button and click it. Finding the element means doing another 
+Now we need to find the search button and click it. Finding the element means doing another
 query:
 
 ```rust
     let elem_button = elem_form.find(By::Css("button[type='submit']")).await?;
 ```
 
-This time we use a `CSS` selector to locate a `<button>` element with an attribute `type` that 
+This time we use a `CSS` selector to locate a `<button>` element with an attribute `type` that
 has the value `submit`. To learn more about selectors, [click here](https://www.selenium.dev/documentation/webdriver/elements/locators/).
 
 ## Clicking The Button
@@ -109,9 +111,9 @@ to fail because that element hasn't loaded yet.
 
 **How do we solve this?**
 
-Well, one option is to simply tell our code to wait for a few seconds and then try to find the 
-element we are looking for. But this is brittle and likely to fail. Don't do this. There are 
-cases where you are forced to use this approach, but it should be a last resort. Incidentally, 
+Well, one option is to simply tell our code to wait for a few seconds and then try to find the
+element we are looking for. But this is brittle and likely to fail. Don't do this. There are
+cases where you are forced to use this approach, but it should be a last resort. Incidentally,
 from a website testing perspective, it probably also means a human is going to be unsure of when
 the page has actually finished loading, and this is an indicator of a poor user experience.
 
@@ -125,19 +127,19 @@ assert_eq!(driver.title().await?, "Selenium - Wikipedia");
 ## Better Element Queries
 
 To have `thirtyfour` "wait" until an element has loaded, we use the `query()` method which provides
-a "builder" interface for constructing more flexible queries. Again, this uses one of the `By` 
+a "builder" interface for constructing more flexible queries. Again, this uses one of the `By`
 selectors, and we tell it to return only the first matching element.
 
-The `query()` method will poll every half-second until it finds the element. If it cannot find the 
+The `query()` method will poll every half-second until it finds the element. If it cannot find the
 element within 30 seconds, it will timeout and return an error. The polling time and timeout duration
 can be changed using `WebDriverConfig`, or you can also override them for a given query.
 
 The `query()` method is the recommended way to search for elements. The `find()` and `find_all()`
-methods exist only for compatibility with the webdriver spec. The `query()` method uses these 
-under the hood, but adds polling and other niceties on top, including giving you more details about 
+methods exist only for compatibility with the webdriver spec. The `query()` method uses these
+under the hood, but adds polling and other niceties on top, including giving you more details about
 your query if an element was not found.
 
-See the [`ElementQuery`](https://docs.rs/thirtyfour/latest/thirtyfour/extensions/query/struct.ElementQuery.html) 
+See the [`ElementQuery`](https://docs.rs/thirtyfour/latest/thirtyfour/extensions/query/struct.ElementQuery.html)
 documentation for more details on the kinds of queries it supports.
 
 ## Closing The Browser

--- a/thirtyfour/README.md
+++ b/thirtyfour/README.md
@@ -31,18 +31,8 @@ Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI 
 - `rustls-tls`: (Default) Use rustls to provide TLS support (via reqwest).
 - `native-tls`: Use native TLS (via reqwest).
 - `component`: (Default) Enable the `Component` derive macro (via thirtyfour_macros).
-
-## Examples
-
-The examples assume you have `chromedriver` running on your system.
-
-You can use Selenium (see instructions below) or you can use chromedriver 
-directly by downloading the chromedriver that matches your Chrome version,
-from here: [https://chromedriver.chromium.org/downloads](https://chromedriver.chromium.org/downloads)
-
-Then run it like this:
-
-    chromedriver
+- `selenium-manager`: (Default) Enable the Selenium manager, which downloads then starts
+  the correct webdriver.
 
 ### Example (async):
 
@@ -56,7 +46,9 @@ use thirtyfour::prelude::*;
 #[tokio::main]
 async fn main() -> WebDriverResult<()> {
      let caps = DesiredCapabilities::chrome();
-     let driver = WebDriver::new("http://localhost:9515", caps).await?;
+     let server_url = "http://localhost:9515";
+     start_webdriver_process(server_url, &caps, true)?;
+     let driver = WebDriver::new(server_url, caps).await?;
 
      // Navigate to https://wikipedia.org.
      driver.goto("https://wikipedia.org").await?;
@@ -75,7 +67,7 @@ async fn main() -> WebDriverResult<()> {
      // Look for header to implicitly wait for the page to load.
      driver.find(By::ClassName("firstHeading")).await?;
      assert_eq!(driver.title().await?, "Selenium - Wikipedia");
-    
+
      // Always explicitly close the browser.
      driver.quit().await?;
 

--- a/thirtyfour/examples/chrome_devtools.rs
+++ b/thirtyfour/examples/chrome_devtools.rs
@@ -1,7 +1,3 @@
-//! Requires chromedriver running on port 9515:
-//!
-//!     chromedriver --port=9515
-//!
 //! Run as follows:
 //!
 //!     cargo run --example chrome_devtools
@@ -16,7 +12,9 @@ async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
     let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let server_url = "http://localhost:9515";
+    start_webdriver_process(server_url, &caps, true)?;
+    let driver = WebDriver::new(server_url, caps).await?;
 
     // Use Chrome Devtools Protocol (CDP).
     let dev_tools = ChromeDevTools::new(driver.handle.clone());

--- a/thirtyfour/examples/chrome_options.rs
+++ b/thirtyfour/examples/chrome_options.rs
@@ -1,7 +1,3 @@
-//! Requires chromedriver running on port 9515:
-//!
-//!     chromedriver --port=9515
-//!
 //! Run as follows:
 //!
 //!     cargo run --example chrome_options
@@ -24,7 +20,9 @@ async fn main() -> color_eyre::Result<()> {
             }
         }),
     )?;
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let server_url = "http://localhost:9515";
+    start_webdriver_process(server_url, &caps, true)?;
+    let driver = WebDriver::new(server_url, caps).await?;
 
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;

--- a/thirtyfour/examples/components/playground.rs
+++ b/thirtyfour/examples/components/playground.rs
@@ -1,7 +1,3 @@
-//! Requires chromedriver running on port 9515:
-//!
-//!     chromedriver --port=9515
-//!
 //! Run as follows:
 //!
 //!     cargo run --example wikipedia
@@ -21,7 +17,9 @@ async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
     let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let server_url = "http://localhost:9515";
+    start_webdriver_process(server_url, &caps, true)?;
+    let driver = WebDriver::new(server_url, caps).await?;
     driver.goto("https://play.rust-lang.org").await?;
 
     let base_elem = driver.query(By::Id("playground")).single().await?;

--- a/thirtyfour/examples/firefox_preferences.rs
+++ b/thirtyfour/examples/firefox_preferences.rs
@@ -1,13 +1,9 @@
-//! Requires geckodriver running on port 4444:
-//!
-//!     geckodriver --port=4444
-//!
 //! Run as follows:
 //!
 //!     cargo run --example firefox_preferences
 
 use thirtyfour::common::capabilities::firefox::FirefoxPreferences;
-use thirtyfour::{FirefoxCapabilities, WebDriver};
+use thirtyfour::{start_webdriver_process, FirefoxCapabilities, WebDriver};
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
@@ -24,7 +20,9 @@ async fn main() -> color_eyre::Result<()> {
     let mut caps = FirefoxCapabilities::new();
     caps.set_preferences(prefs)?;
 
-    let driver = WebDriver::new("http://localhost:4444", caps).await?;
+    let server_url = "http://localhost:4444";
+    start_webdriver_process(server_url, &caps, true)?;
+    let driver = WebDriver::new(server_url, caps).await?;
     driver.goto("https://www.google.com").await?;
 
     // Get the user agent and verify.

--- a/thirtyfour/examples/minimal_async.rs
+++ b/thirtyfour/examples/minimal_async.rs
@@ -1,7 +1,3 @@
-//! Requires chromedriver running on port 9515:
-//!
-//!     chromedriver --port=9515
-//!
 //! Run as follows:
 //!
 //!     cargo run --example minimal_async
@@ -9,9 +5,11 @@
 use thirtyfour::prelude::*;
 
 #[tokio::main]
-async fn main() -> WebDriverResult<()> {
+async fn main() -> color_eyre::Result<()> {
     let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let server_url = "http://localhost:9515";
+    start_webdriver_process(server_url, &caps, true)?;
+    let driver = WebDriver::new(server_url, caps).await?;
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;
 

--- a/thirtyfour/examples/query/wikipedia.rs
+++ b/thirtyfour/examples/query/wikipedia.rs
@@ -1,7 +1,3 @@
-//! Requires chromedriver running on port 9515:
-//!
-//!     chromedriver --port=9515
-//!
 //! Run as follows:
 //!
 //!     cargo run --example wikipedia
@@ -13,7 +9,9 @@ async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
     let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let server_url = "http://localhost:9515";
+    start_webdriver_process(server_url, &caps, true)?;
+    let driver = WebDriver::new(server_url, caps).await?;
 
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;

--- a/thirtyfour/examples/remote_debugging.rs
+++ b/thirtyfour/examples/remote_debugging.rs
@@ -1,6 +1,5 @@
 //! Requires chromedriver running on port 9515:
 //!
-//!     chromedriver --port=9515
 //!     chrome --remote-debugging-port=9222 --user-data-dir="C:\Users\username\my-browser-profile\"
 //!
 //! Run as follows:
@@ -10,10 +9,12 @@
 use thirtyfour::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<(), WebDriverError> {
+async fn main() -> color_eyre::Result<()> {
     let mut caps = DesiredCapabilities::chrome();
     caps.set_debugger_address("localhost:9222")?;
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let server_url = "http://localhost:9515";
+    start_webdriver_process(server_url, &caps, true)?;
+    let driver = WebDriver::new(server_url, caps).await?;
     driver.goto("https://www.baidu.com").await?;
     Ok(())
 }

--- a/thirtyfour/examples/shadowroot.rs
+++ b/thirtyfour/examples/shadowroot.rs
@@ -1,7 +1,3 @@
-//! Requires chromedriver running on port 9515:
-//!
-//!     chromedriver --port=9515
-//!
 //! Run as follows:
 //!
 //!     cargo run --example shadowroot
@@ -14,7 +10,9 @@ async fn main() -> color_eyre::Result<()> {
     std::env::set_var("RUST_BACKTRACE", "1");
 
     let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let server_url = "http://localhost:9515";
+    start_webdriver_process(server_url, &caps, true)?;
+    let driver = WebDriver::new(server_url, caps).await?;
 
     // Navigate to website containing example shadowroot.
     driver.goto("https://web.dev/shadowdom-v1/").await?;

--- a/thirtyfour/examples/tokio_async.rs
+++ b/thirtyfour/examples/tokio_async.rs
@@ -1,7 +1,3 @@
-//! Requires chromedriver running on port 9515:
-//!
-//!     chromedriver --port=9515
-//!
 //! Run as follows:
 //!
 //!     cargo run --example tokio_async
@@ -15,7 +11,9 @@ async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
     let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let server_url = "http://localhost:9515";
+    start_webdriver_process(server_url, &caps, true)?;
+    let driver = WebDriver::new(server_url, caps).await?;
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;
     let elem_form = driver.find(By::Id("search-form")).await?;

--- a/thirtyfour/examples/tokio_basic.rs
+++ b/thirtyfour/examples/tokio_basic.rs
@@ -1,7 +1,3 @@
-//! Requires chromedriver running on port 9515:
-//!
-//!     chromedriver --port=9515
-//!
 //! Run as follows:
 //!
 //!     cargo run --example tokio_async
@@ -19,7 +15,9 @@ async fn run() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
     let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let server_url = "http://localhost:9515";
+    start_webdriver_process(server_url, &caps, true)?;
+    let driver = WebDriver::new(server_url, caps).await?;
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;
     let elem_form = driver.find(By::Id("search-form")).await?;

--- a/thirtyfour/src/lib.rs
+++ b/thirtyfour/src/lib.rs
@@ -44,10 +44,10 @@
 //! use thirtyfour::prelude::*;
 //!
 //! #[tokio::main]
-//! async fn main() -> WebDriverResult<()> {
+//! async fn main() -> color_eyre::Result<()> {
 //!     let server_url = "http://localhost:4444";
 //!     let caps = DesiredCapabilities::chrome();
-//!     start_webdriver_process(server_url, &caps);
+//!     start_webdriver_process(server_url, &caps, false)?;
 //!     let driver = WebDriver::new(server_url, caps).await?;
 //!
 //!     // Navigate to https://wikipedia.org.

--- a/thirtyfour/src/web_driver.rs
+++ b/thirtyfour/src/web_driver.rs
@@ -19,11 +19,11 @@ use crate::Capabilities;
 /// use thirtyfour::prelude::*;
 /// # use thirtyfour::support::block_on;
 ///
-/// # fn main() -> WebDriverResult<()> {
+/// # fn main() -> color_eyre::Result<()> {
 /// #     block_on(async {
 /// let server_url = "http://localhost:4444";
 /// let caps = DesiredCapabilities::firefox();
-/// start_webdriver_process(server_url, &caps);
+/// start_webdriver_process(server_url, &caps, true)?;
 /// let driver = WebDriver::new(server_url, caps).await?;
 /// driver.goto("https://www.rust-lang.org/").await?;
 /// // Always remember to close the session.

--- a/thirtyfour/src/web_driver_process.rs
+++ b/thirtyfour/src/web_driver_process.rs
@@ -47,6 +47,7 @@ impl WebDriverProcess {
     pub fn new<C>(
         web_driver_process_port: WebDriverProcessPort<'_>,
         web_driver_process_browser: WebDriverProcessBrowser<'_, C>,
+        allow_offline: bool,
     ) -> WebDriverResult<Self>
     where
         C: CapabilitiesHelper,
@@ -80,8 +81,26 @@ impl WebDriverProcess {
         // The Selenium manager starts a Tokio runtime internally, which conflicts
         // with the Tokio runtime in this thread. So, run it in a separate thread.
         let driver_thread = thread::spawn(move || {
-            get_manager_by_browser(browser_name)
-                .map_or_else(Err, |mut selenium_manager| selenium_manager.setup())
+            let mut selenium_manager = match get_manager_by_browser(browser_name) {
+                Err(err) => return Err(err),
+                Ok(s) => s,
+            };
+            match selenium_manager.setup() {
+                Ok(p) => Ok(p),
+                Err(err) => {
+                    if selenium_manager.is_fallback_driver_from_cache() && allow_offline {
+                        if let Some(best_driver_from_cache) =
+                            selenium_manager.find_best_driver_from_cache().unwrap()
+                        {
+                            Ok(best_driver_from_cache)
+                        } else {
+                            Err(err)
+                        }
+                    } else {
+                        Err(err)
+                    }
+                }
+            }
         });
         let driver_path = driver_thread
             .join()
@@ -134,6 +153,7 @@ static WEB_DRIVER_PROCESS: OnceLock<WebDriverResult<Mutex<WebDriverProcess>>> = 
 pub fn start_webdriver_process_full<'a, C>(
     web_driver_process_port: WebDriverProcessPort,
     web_driver_process_browser: WebDriverProcessBrowser<C>,
+    allow_offline: bool,
 ) -> Result<(), &'a WebDriverError>
 where
     C: CapabilitiesHelper,
@@ -144,8 +164,11 @@ where
                 "Unable to register atexit handler.".to_string(),
             ));
         }
-        let webdriver_process =
-            WebDriverProcess::new(web_driver_process_port, web_driver_process_browser)?;
+        let webdriver_process = WebDriverProcess::new(
+            web_driver_process_port,
+            web_driver_process_browser,
+            allow_offline,
+        )?;
         Ok(Mutex::new(webdriver_process))
     }) {
         Err(e) => Err(e),
@@ -158,6 +181,7 @@ where
 pub fn start_webdriver_process<'a, C>(
     server_url: &str,
     capabilities: &C,
+    allow_offline: bool,
 ) -> Result<(), &'a WebDriverError>
 where
     C: CapabilitiesHelper,
@@ -165,6 +189,7 @@ where
     start_webdriver_process_full(
         WebDriverProcessPort::ServerUrl(server_url),
         WebDriverProcessBrowser::Caps(capabilities),
+        allow_offline,
     )
 }
 

--- a/thirtyfour/src/web_driver_process.rs
+++ b/thirtyfour/src/web_driver_process.rs
@@ -125,33 +125,40 @@ impl WebDriverProcess {
 /// A single instance of the web driver process. TODO: add one per type of
 /// support driver (chrome, firefox, safari, etc.) so we could have all
 /// drivers running at the same time.
-static WEB_DRIVER_PROCESS: OnceLock<Mutex<WebDriverProcess>> = OnceLock::new();
+static WEB_DRIVER_PROCESS: OnceLock<WebDriverResult<Mutex<WebDriverProcess>>> = OnceLock::new();
 
 /// Start a web driver process by downloading the appropriate driver if necessary,
 /// then starting the process. When this application exits, automatically stop
 /// the web driver process. This only starts the process once, regardless of
 /// how often it is called.
-pub fn start_webdriver_process_full<C>(
+pub fn start_webdriver_process_full<'a, C>(
     web_driver_process_port: WebDriverProcessPort,
     web_driver_process_browser: WebDriverProcessBrowser<C>,
-) where
+) -> Result<(), &'a WebDriverError>
+where
     C: CapabilitiesHelper,
 {
-    WEB_DRIVER_PROCESS.get_or_init(|| {
-        unsafe {
-            if atexit(on_exit_handler) != 0 {
-                panic!("Unable to register atexit handler.");
-            }
+    match WEB_DRIVER_PROCESS.get_or_init(|| {
+        if unsafe { atexit(on_exit_handler) } != 0 {
+            return Err(WebDriverError::FatalError(
+                "Unable to register atexit handler.".to_string(),
+            ));
         }
         let webdriver_process =
-            WebDriverProcess::new(web_driver_process_port, web_driver_process_browser).unwrap();
-        Mutex::new(webdriver_process)
-    });
+            WebDriverProcess::new(web_driver_process_port, web_driver_process_browser)?;
+        Ok(Mutex::new(webdriver_process))
+    }) {
+        Err(e) => Err(e),
+        Ok(_) => Ok(()),
+    }
 }
 
 /// The most common case: call `start_webdriver_process_full` with the provided
 /// parameters.
-pub fn start_webdriver_process<C>(server_url: &str, capabilities: &C)
+pub fn start_webdriver_process<'a, C>(
+    server_url: &str,
+    capabilities: &C,
+) -> Result<(), &'a WebDriverError>
 where
     C: CapabilitiesHelper,
 {
@@ -167,8 +174,12 @@ extern "C" fn on_exit_handler() {
     // Per the C spec, this function must not call `quit()`. Therefore, avoid
     // using `unwrap()`, `expect()`, etc. Instead, report any errors to stderr
     // then exit without shutting down the web driver process.
-    let Some(web_driver_process_mutex) = WEB_DRIVER_PROCESS.get() else {
+    let Some(web_driver_process_result) = WEB_DRIVER_PROCESS.get() else {
         eprintln!("Web driver process not initialized.");
+        return;
+    };
+    // If there was an error running the process, then don't do any shutdown.
+    let Ok(web_driver_process_mutex) = web_driver_process_result else {
         return;
     };
     let mut web_driver_process = match web_driver_process_mutex.lock() {

--- a/thirtyfour/tests/common.rs
+++ b/thirtyfour/tests/common.rs
@@ -160,7 +160,8 @@ pub fn test_harness() -> TestHarness {
     start_webdriver_process_full(
         WebDriverProcessPort::Port(port),
         WebDriverProcessBrowser::<ChromeCapabilities>::Name(browser.clone()),
-    );
+    )
+    .expect("Working startup.");
     block_on(TestHarness::new(&browser))
 }
 

--- a/thirtyfour/tests/common.rs
+++ b/thirtyfour/tests/common.rs
@@ -160,6 +160,7 @@ pub fn test_harness() -> TestHarness {
     start_webdriver_process_full(
         WebDriverProcessPort::Port(port),
         WebDriverProcessBrowser::<ChromeCapabilities>::Name(browser.clone()),
+        true,
     )
     .expect("Working startup.");
     block_on(TestHarness::new(&browser))


### PR DESCRIPTION
This allows the developer to handle web driver process startup errors, rather than a `panic!` which the code currently produces.