### PR TITLE
Edition update

### DIFF
--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -2,7 +2,7 @@
 name = "thirtyfour"
 version = "0.36.1"
 authors = ["Steve Pryde <steve@stevepryde.com>", "Vrtgs <vrtgs@vrtgs.xyz>"]
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 description = """
 Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI testing.
@@ -28,9 +28,9 @@ categories = [
 ]
 
 [features]
-default = ["reqwest", "rustls-tls", "component", "selenium-manager"]
+default = ["reqwest", "rustls", "component", "selenium-manager"]
 reqwest = ["dep:reqwest"]
-rustls-tls = ["reqwest/rustls-tls"]
+rustls = ["reqwest/rustls"]
 native-tls = ["reqwest/native-tls"]
 selenium-manager = ["dep:selenium-manager", "libc"]
 tokio-multi-threaded = ["tokio/rt-multi-thread"]
@@ -46,7 +46,7 @@ futures-util = { version = "0.3.31", default-features = false, features = ["allo
 http = "1"
 indexmap = "2"
 libc = { version = "0.2", optional = true }
-pastey = "0.1"
+pastey = "0.2"
 selenium-manager = { path = "../selenium/rust", optional = true }
 serde = { version = "1.0.210", features = ["derive", "rc"] }
 serde_json = { version = "1.0.132", features = ["preserve_order"] }
@@ -68,7 +68,7 @@ url = "2.5.2"
 const_format = "0.2.33"
 
 # Optional HTTP client. Not needed if you supply your own.
-reqwest = { version = "0.12.8", default-features = false, features = [
+reqwest = { version = "0.13", default-features = false, features = [
     "json",
 ], optional = true }
 

--- a/thirtyfour/examples/firefox_preferences.rs
+++ b/thirtyfour/examples/firefox_preferences.rs
@@ -3,7 +3,7 @@
 //!     cargo run --example firefox_preferences
 
 use thirtyfour::common::capabilities::firefox::FirefoxPreferences;
-use thirtyfour::{start_webdriver_process, FirefoxCapabilities, WebDriver};
+use thirtyfour::{FirefoxCapabilities, WebDriver, start_webdriver_process};
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {

--- a/thirtyfour/examples/shadowroot.rs
+++ b/thirtyfour/examples/shadowroot.rs
@@ -7,7 +7,9 @@ use thirtyfour::prelude::*;
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
-    std::env::set_var("RUST_BACKTRACE", "1");
+    unsafe {
+        std::env::set_var("RUST_BACKTRACE", "1");
+    }
 
     let caps = DesiredCapabilities::chrome();
     let server_url = "http://localhost:9515";

--- a/thirtyfour/src/action_chain.rs
+++ b/thirtyfour/src/action_chain.rs
@@ -1,12 +1,12 @@
 use crate::session::handle::SessionHandle;
 use crate::{
+    WebElement,
     common::{
         action::{ActionSource, KeyAction, PointerAction, PointerActionType},
         command::{Actions, Command},
         keys::TypingData,
     },
     error::WebDriverResult,
-    WebElement,
 };
 use std::sync::Arc;
 use std::time::Duration;

--- a/thirtyfour/src/alert.rs
+++ b/thirtyfour/src/alert.rs
@@ -1,7 +1,7 @@
+use crate::TypingData;
 use crate::common::command::Command;
 use crate::error::WebDriverResult;
 use crate::session::handle::SessionHandle;
-use crate::TypingData;
 use std::sync::Arc;
 
 /// Struct for managing alerts.

--- a/thirtyfour/src/common/capabilities/chrome.rs
+++ b/thirtyfour/src/common/capabilities/chrome.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::common::capabilities::chromium::ChromiumLikeCapabilities;
 use crate::{BrowserCapabilitiesHelper, Capabilities, CapabilitiesHelper};

--- a/thirtyfour/src/common/capabilities/chromium.rs
+++ b/thirtyfour/src/common/capabilities/chromium.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::{Engine, prelude::BASE64_STANDARD};
 use pastey::paste;
 use serde::Serialize;
-use serde_json::{json, to_value, Value};
+use serde_json::{Value, json, to_value};
 
 use crate::error::WebDriverResult;
 use crate::{BrowserCapabilitiesHelper, Capabilities, CapabilitiesHelper};

--- a/thirtyfour/src/common/capabilities/desiredcapabilities.rs
+++ b/thirtyfour/src/common/capabilities/desiredcapabilities.rs
@@ -1,7 +1,8 @@
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use serde_json::{from_value, json, to_value, Value};
+use serde_json::{Value, from_value, json, to_value};
 
+use crate::ChromiumCapabilities;
 use crate::common::capabilities::chrome::ChromeCapabilities;
 use crate::common::capabilities::edge::EdgeCapabilities;
 use crate::common::capabilities::firefox::FirefoxCapabilities;
@@ -9,7 +10,6 @@ use crate::common::capabilities::ie::InternetExplorerCapabilities;
 use crate::common::capabilities::opera::OperaCapabilities;
 use crate::common::capabilities::safari::SafariCapabilities;
 use crate::error::WebDriverResult;
-use crate::ChromiumCapabilities;
 
 /// Type alias for a generic Capabilities struct.
 pub type Capabilities = serde_json::Map<String, Value>;

--- a/thirtyfour/src/common/capabilities/edge.rs
+++ b/thirtyfour/src/common/capabilities/edge.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::common::capabilities::chromium::ChromiumLikeCapabilities;
 use crate::{BrowserCapabilitiesHelper, Capabilities, CapabilitiesHelper};

--- a/thirtyfour/src/common/capabilities/firefox.rs
+++ b/thirtyfour/src/common/capabilities/firefox.rs
@@ -1,9 +1,9 @@
 use pastey::paste;
 use serde::{Deserialize, Serialize};
-use serde_json::{from_value, json, to_value, Value};
+use serde_json::{Value, from_value, json, to_value};
 
-use crate::error::WebDriverResult;
 use crate::CapabilitiesHelper;
+use crate::error::WebDriverResult;
 use crate::{BrowserCapabilitiesHelper, Capabilities};
 
 /// Capabilities for Firefox.

--- a/thirtyfour/src/common/capabilities/ie.rs
+++ b/thirtyfour/src/common/capabilities/ie.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{BrowserCapabilitiesHelper, Capabilities, CapabilitiesHelper};
 

--- a/thirtyfour/src/common/capabilities/opera.rs
+++ b/thirtyfour/src/common/capabilities/opera.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::common::capabilities::chromium::ChromiumLikeCapabilities;
 use crate::{BrowserCapabilitiesHelper, Capabilities, CapabilitiesHelper};

--- a/thirtyfour/src/common/capabilities/safari.rs
+++ b/thirtyfour/src/common/capabilities/safari.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{Capabilities, CapabilitiesHelper};
 

--- a/thirtyfour/src/common/command.rs
+++ b/thirtyfour/src/common/command.rs
@@ -1,6 +1,8 @@
 use http::Method;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
+use crate::IntoArcStr;
+use crate::RequestData;
 use crate::common::{
     capabilities::desiredcapabilities::make_w3c_caps,
     cookie::Cookie,
@@ -8,8 +10,6 @@ use crate::common::{
     print::PrintParameters,
     types::{ElementId, OptionRect, SessionId, TimeoutConfiguration, WindowHandle},
 };
-use crate::IntoArcStr;
-use crate::RequestData;
 use std::fmt;
 use std::fmt::Debug;
 use std::sync::Arc;

--- a/thirtyfour/src/common/print.rs
+++ b/thirtyfour/src/common/print.rs
@@ -1,4 +1,4 @@
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use std::sync::Arc;
 
 /// Enum representing the ranges of pages to print

--- a/thirtyfour/src/common/types.rs
+++ b/thirtyfour/src/common/types.rs
@@ -5,8 +5,8 @@ use std::{fmt, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::WebDriverResult;
 use crate::WebElement;
+use crate::error::WebDriverResult;
 
 mod sealed {
     use crate::error::{WebDriverError, WebDriverResult};

--- a/thirtyfour/src/components/select.rs
+++ b/thirtyfour/src/components/select.rs
@@ -19,7 +19,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::{no_such_element, WebDriverErrorInner, WebDriverResult};
+use crate::error::{WebDriverErrorInner, WebDriverResult, no_such_element};
 use crate::{By, WebElement};
 use std::fmt::{Display, Formatter};
 

--- a/thirtyfour/src/components/wrapper/resolver.rs
+++ b/thirtyfour/src/components/wrapper/resolver.rs
@@ -99,9 +99,9 @@ mod sealed {
 
     use futures_util::{StreamExt, TryStreamExt};
 
+    use crate::WebElement;
     use crate::components::Component;
     use crate::error::WebDriverResult;
-    use crate::WebElement;
 
     pub trait Resolve: Sized {
         fn is_present(&self) -> impl Future<Output = WebDriverResult<bool>> + Send;

--- a/thirtyfour/src/extensions/addons/firefox/firefoxcommand.rs
+++ b/thirtyfour/src/extensions/addons/firefox/firefoxcommand.rs
@@ -1,7 +1,7 @@
 use http::Method;
 use serde_json::json;
 
-use crate::{common::command::FormatRequestData, RequestData};
+use crate::{RequestData, common::command::FormatRequestData};
 
 /// Extra commands specific to Firefox.
 #[derive(Debug)]

--- a/thirtyfour/src/extensions/addons/firefox/firefoxtools.rs
+++ b/thirtyfour/src/extensions/addons/firefox/firefoxtools.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
 
 use super::FirefoxCommand;
 use crate::error::WebDriverResult;

--- a/thirtyfour/src/extensions/cdp/chromecommand.rs
+++ b/thirtyfour/src/extensions/cdp/chromecommand.rs
@@ -1,8 +1,8 @@
-use crate::{common::command::FormatRequestData, RequestData};
+use crate::{RequestData, common::command::FormatRequestData};
 
 use super::NetworkConditions;
 use http::Method;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Extra commands specific to Chrome.
 #[derive(Debug)]

--- a/thirtyfour/src/extensions/cdp/devtools.rs
+++ b/thirtyfour/src/extensions/cdp/devtools.rs
@@ -2,7 +2,7 @@ use super::ChromeCommand;
 use super::NetworkConditions;
 use crate::error::WebDriverResult;
 use crate::session::handle::SessionHandle;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
 /// The ChromeDevTools struct allows you to interact with Chromium-based browsers via

--- a/thirtyfour/src/extensions/query/conditions.rs
+++ b/thirtyfour/src/extensions/query/conditions.rs
@@ -1,5 +1,5 @@
-use crate::error::WebDriverResult;
 use crate::IntoArcStr;
+use crate::error::WebDriverResult;
 use crate::{ElementPredicate, WebElement};
 use std::sync::Arc;
 use stringmatch::Needle;

--- a/thirtyfour/src/extensions/query/element_query.rs
+++ b/thirtyfour/src/extensions/query/element_query.rs
@@ -1,9 +1,9 @@
 use super::conditions::{collect_arg_slice, handle_errors, negate};
-use super::{conditions, ElementPollerNoWait, ElementPollerWithTimeout, IntoElementPoller};
+use super::{ElementPollerNoWait, ElementPollerWithTimeout, IntoElementPoller, conditions};
+use crate::IntoArcStr;
 use crate::error::{WebDriverError, WebDriverErrorInner};
 use crate::prelude::WebDriverResult;
 use crate::session::handle::SessionHandle;
-use crate::IntoArcStr;
 use crate::{By, DynElementPredicate, ElementPredicate, WebElement};
 use indexmap::IndexMap;
 use std::borrow::Cow;
@@ -129,9 +129,10 @@ pub enum ElementQuerySource {
 }
 
 /// Options for wait characteristics for an element query.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum ElementQueryWaitOptions {
     /// Use the default poller.
+    #[default]
     WaitDefault,
     /// Use a poller with the specified timeout and interval.
     Wait {
@@ -142,12 +143,6 @@ pub enum ElementQueryWaitOptions {
     },
     /// Do not wait. This uses a poller that quits immediately.
     NoWait,
-}
-
-impl Default for ElementQueryWaitOptions {
-    fn default() -> Self {
-        Self::WaitDefault
-    }
 }
 
 /// All options applicable to an ElementQuery.

--- a/thirtyfour/src/extensions/query/element_waiter.rs
+++ b/thirtyfour/src/extensions/query/element_waiter.rs
@@ -1,8 +1,8 @@
 use super::conditions::{collect_arg_slice, handle_errors};
-use super::{conditions, ElementPollerWithTimeout, IntoElementPoller};
+use super::{ElementPollerWithTimeout, IntoElementPoller, conditions};
+use crate::IntoArcStr;
 use crate::error::WebDriverError;
 use crate::prelude::WebDriverResult;
-use crate::IntoArcStr;
 use crate::{DynElementPredicate, ElementPredicate, WebElement};
 use std::ops::Deref;
 use std::sync::Arc;

--- a/thirtyfour/src/lib.rs
+++ b/thirtyfour/src/lib.rs
@@ -175,13 +175,15 @@ pub use switch_to::SwitchTo;
 pub use web_driver::WebDriver;
 #[cfg(feature = "selenium-manager")]
 pub use web_driver_process::{
-    start_webdriver_process, start_webdriver_process_full, WebDriverProcess,
-    WebDriverProcessBrowser, WebDriverProcessPort,
+    WebDriverProcess, WebDriverProcessBrowser, WebDriverProcessPort, start_webdriver_process,
+    start_webdriver_process_full,
 };
 pub use web_element::WebElement;
 
 /// Allow importing the common types via `use thirtyfour::prelude::*`.
 pub mod prelude {
+    pub use crate::WebDriver;
+    pub use crate::WebElement;
     pub use crate::alert::Alert;
     pub use crate::error::{WebDriverError, WebDriverResult};
     pub use crate::extensions::query::{ElementPoller, ElementQueryable, ElementWaitable};
@@ -189,8 +191,6 @@ pub mod prelude {
     #[cfg(feature = "selenium-manager")]
     pub use crate::start_webdriver_process;
     pub use crate::switch_to::SwitchTo;
-    pub use crate::WebDriver;
-    pub use crate::WebElement;
     pub use crate::{
         BrowserCapabilitiesHelper, By, Capabilities, CapabilitiesHelper, ChromiumLikeCapabilities,
         DesiredCapabilities,

--- a/thirtyfour/src/session/create.rs
+++ b/thirtyfour/src/session/create.rs
@@ -4,13 +4,13 @@ use url::Url;
 use super::http::HttpClient;
 use crate::error::WebDriverErrorInner;
 use crate::{
+    Capabilities, SessionId, TimeoutConfiguration,
     common::{
         command::{Command, FormatRequestData},
         config::WebDriverConfig,
     },
     prelude::WebDriverResult,
     session::http::run_webdriver_cmd,
-    Capabilities, SessionId, TimeoutConfiguration,
 };
 
 /// Start a new WebDriver session, returning the session id and the

--- a/thirtyfour/src/session/handle.rs
+++ b/thirtyfour/src/session/handle.rs
@@ -18,11 +18,11 @@ use crate::prelude::WebDriverError;
 use crate::session::scriptret::ScriptRet;
 use crate::support::base64_decode;
 use crate::web_driver::AlreadyQuit;
-use crate::{support, By, OptionRect, Rect, SessionId, SwitchTo, WebDriverStatus, WebElement};
+use crate::{By, OptionRect, Rect, SessionId, SwitchTo, WebDriverStatus, WebElement, support};
 use crate::{IntoArcStr, IntoUrl};
 use crate::{TimeoutConfiguration, WindowHandle};
 
-use super::http::{run_webdriver_cmd, CmdResponse, HttpClient};
+use super::http::{CmdResponse, HttpClient, run_webdriver_cmd};
 
 /// The SessionHandle contains a shared reference to the HTTP client
 /// to allow sending commands to the underlying WebDriver.

--- a/thirtyfour/src/session/http.rs
+++ b/thirtyfour/src/session/http.rs
@@ -3,16 +3,16 @@ use std::sync::Arc;
 use base64::Engine;
 use bytes::Bytes;
 use http::{
-    header::{ACCEPT, AUTHORIZATION, CONNECTION, CONTENT_TYPE, USER_AGENT},
     HeaderValue, Request, Response,
+    header::{ACCEPT, AUTHORIZATION, CONNECTION, CONTENT_TYPE, USER_AGENT},
 };
 use serde_json::Value;
 use url::Url;
 
 use crate::{
+    ElementId, ElementRef, RequestData, WebElement,
     common::config::WebDriverConfig,
     prelude::{WebDriverError, WebDriverResult},
-    ElementId, ElementRef, RequestData, WebElement,
 };
 
 use super::handle::SessionHandle;

--- a/thirtyfour/src/session/scriptret.rs
+++ b/thirtyfour/src/session/scriptret.rs
@@ -1,6 +1,6 @@
+use crate::WebElement;
 use crate::error::WebDriverResult;
 use crate::session::handle::SessionHandle;
-use crate::WebElement;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::sync::Arc;

--- a/thirtyfour/src/support.rs
+++ b/thirtyfour/src/support.rs
@@ -1,5 +1,5 @@
 use crate::error::WebDriverResult;
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::{Engine, prelude::BASE64_STANDARD};
 use std::convert::Infallible;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
@@ -120,9 +120,7 @@ where
                 }
             }
         }};
-        ($future: expr) => {{
-            spawn_off!($future, tokio::runtime::Handle::try_current())
-        }};
+        ($future: expr) => {{ spawn_off!($future, tokio::runtime::Handle::try_current()) }};
     }
 
     cfg_if::cfg_if! {

--- a/thirtyfour/src/switch_to.rs
+++ b/thirtyfour/src/switch_to.rs
@@ -1,10 +1,10 @@
+use crate::WindowHandle;
 use crate::common::command::Command;
 use crate::error::WebDriverErrorInfo;
 use crate::session::handle::SessionHandle;
-use crate::WindowHandle;
 use crate::{
-    error::{WebDriverError, WebDriverResult},
     Alert, WebElement,
+    error::{WebDriverError, WebDriverResult},
 };
 use std::sync::Arc;
 

--- a/thirtyfour/src/web_driver.rs
+++ b/thirtyfour/src/web_driver.rs
@@ -1,15 +1,15 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
+use crate::Capabilities;
 use crate::common::config::WebDriverConfig;
 use crate::error::WebDriverResult;
 use crate::prelude::WebDriverError;
 use crate::session::create::start_session;
 use crate::session::handle::SessionHandle;
+use crate::session::http::HttpClient;
 #[cfg(feature = "reqwest")]
 use crate::session::http::create_reqwest_client;
-use crate::session::http::HttpClient;
-use crate::Capabilities;
 
 /// The `WebDriver` struct encapsulates an async Selenium WebDriver browser
 /// session.

--- a/thirtyfour/src/web_driver_process.rs
+++ b/thirtyfour/src/web_driver_process.rs
@@ -6,9 +6,9 @@ use std::time::Duration;
 use libc::atexit;
 use selenium_manager::get_manager_by_browser;
 
+use crate::CapabilitiesHelper;
 use crate::error::WebDriverResult;
 use crate::prelude::WebDriverError;
-use crate::CapabilitiesHelper;
 
 #[derive(Debug)]
 /// This uses the Selenium Manager to automatically download the appropriate web

--- a/thirtyfour/src/web_element.rs
+++ b/thirtyfour/src/web_element.rs
@@ -9,9 +9,9 @@ use crate::error::{WebDriverError, WebDriverErrorInner};
 use crate::js::SIMULATE_DRAG_AND_DROP;
 use crate::session::handle::SessionHandle;
 use crate::support::base64_decode;
-use crate::{common::types::ElementRect, error::WebDriverResult, By, ElementRef};
-use crate::{support, IntoArcStr};
+use crate::{By, ElementRef, common::types::ElementRect, error::WebDriverResult};
 use crate::{ElementId, TypingData};
+use crate::{IntoArcStr, support};
 
 /// The WebElement struct encapsulates a single element on a page.
 ///

--- a/thirtyfour/tests/common.rs
+++ b/thirtyfour/tests/common.rs
@@ -7,10 +7,10 @@ use std::{
 };
 
 use rstest::fixture;
+use thirtyfour::{ChromeCapabilities, support::block_on};
 use thirtyfour::{
-    prelude::*, start_webdriver_process_full, WebDriverProcessBrowser, WebDriverProcessPort,
+    WebDriverProcessBrowser, WebDriverProcessPort, prelude::*, start_webdriver_process_full,
 };
-use thirtyfour::{support::block_on, ChromeCapabilities};
 use tokio::sync::{Semaphore, SemaphorePermit};
 
 static SERVER: OnceLock<Arc<JoinHandle<()>>> = OnceLock::new();
@@ -76,7 +76,7 @@ pub fn start_server() -> Arc<JoinHandle<()>> {
 
 pub fn init_logging() {
     LOGINIT.get_or_init(|| {
-        use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+        use tracing_subscriber::{EnvFilter, fmt, prelude::*};
         tracing_subscriber::registry()
             .with(fmt::layer())
             .with(EnvFilter::from_default_env())

--- a/thirtyfour/tests/misc.rs
+++ b/thirtyfour/tests/misc.rs
@@ -2,7 +2,7 @@
 use std::time::Duration;
 
 use rstest::rstest;
-use thirtyfour::{prelude::*, support::block_on, SameSite};
+use thirtyfour::{SameSite, prelude::*, support::block_on};
 
 use crate::common::*;
 

--- a/thirtyfour/tests/window.rs
+++ b/thirtyfour/tests/window.rs
@@ -70,9 +70,9 @@ fn new_window_switch(test_harness: TestHarness) -> WebDriverResult<()> {
 
         let window_3 = c.window().await?;
         assert_ne!(
-        window_3, window_2,
-        "After switching to a new window, the window handle returned from window() should differ now."
-    );
+            window_3, window_2,
+            "After switching to a new window, the window handle returned from window() should differ now."
+        );
 
         c.close_window().await
     })
@@ -101,9 +101,9 @@ fn new_tab_switch(test_harness: TestHarness) -> WebDriverResult<()> {
 
         let window_3 = c.window().await?;
         assert_ne!(
-        window_3, window_2,
-        "After switching to a new window, the window handle returned from window() should differ now."
-    );
+            window_3, window_2,
+            "After switching to a new window, the window handle returned from window() should differ now."
+        );
 
         c.close_window().await
     })


### PR DESCRIPTION
- Update to the Rust 2024 edition and fix the resulting lints.
- Update to the latest release of Selenium.
- Update dependencies to the current version.