### PR TITLE
Update fs4 from 0.13 to 1.1

### DIFF
--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -79,7 +79,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 
 # Optional dependencies pulled in by the `manager` feature.
 dirs = { version = "6", optional = true }
-fs4 = { version = "0.13", default-features = false, features = ["tokio"], optional = true }
+fs4 = { version = "1.1", default-features = false, features = ["tokio"], optional = true }
 zip = { version = "8", default-features = false, features = ["deflate"], optional = true }
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }

--- a/thirtyfour/src/manager/download.rs
+++ b/thirtyfour/src/manager/download.rs
@@ -422,15 +422,14 @@ pub(crate) async fn ensure_driver(
     // download+extract, so concurrent test processes don't race the same cache
     // entry. The lock is released when `lock_file` drops at end of scope.
     //
-    // `AsyncFileExt::lock_exclusive` is sync under the hood (it calls flock /
+    // `AsyncFileExt::lock` is sync under the hood (it calls flock /
     // LockFileEx) — it briefly blocks this executor thread while waiting. Hold
     // time is bounded by download+extract; contention only happens between
     // concurrent test processes touching the same cache entry.
     let lock_file = tokio::fs::File::create(&lock_path)
         .await
         .map_err(|e| ManagerError::Lock(format!("create lock: {e}")))?;
-    AsyncFileExt::lock_exclusive(&lock_file)
-        .map_err(|e| ManagerError::Lock(format!("acquire: {e}")))?;
+    AsyncFileExt::lock(&lock_file).map_err(|e| ManagerError::Lock(format!("acquire: {e}")))?;
 
     // Re-check after acquiring the lock — another process may have downloaded.
     if bin_path.exists() {


### PR DESCRIPTION
## Summary

- Picks up the major-version bump for `fs4` (0.13 → 1.1) that dependabot opened in [#301](https://github.com/stevepryde/thirtyfour/pull/301) and closed because it required a code change.
- `fs4` 1.0 renamed `AsyncFileExt::lock_exclusive` → `lock`. Updated the single call site in `manager/download.rs` and the surrounding comment to match.

## Why this is the only dep change

I audited every direct dependency against crates.io. Within current `Cargo.toml` constraints, fs4 was the only crate with a major bump available — everything else is already at the latest within its declared major.

I deliberately did **not** bump the patched-minimum versions (`serde = "1.0.210"`, `tokio = "1.30"`, `thiserror = "2.0.12"`, etc.) even though newer patches exist. Those pins act as effective minimum-version floors for downstream consumers of this lib, so tightening them without a reason would just pressure consumers without buying the lib anything.

## Notes for the reviewer

- `fs4` 1.1 consolidated the per-backend `AsyncFileExt` traits into a single crate-root trait, but `fs4::tokio` re-exports it so the existing import keeps compiling.
- The `lock` method on the async backend is still synchronous (returns `io::Result<()>` directly, not a Future) — verified by reading `src/file_ext/async_impl.rs` upstream — so no `.await` is needed at the call site. The existing comment about it being "sync under the hood" is still accurate.
- We don't use `try_lock_exclusive` anywhere, so the `try_lock` return-type change (`io::Result<bool>` → `Result<(), TryLockError>`) doesn't affect us.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo test -p thirtyfour --lib` (70 passed)
- [x] `cargo test -p thirtyfour --doc` (112 passed)
- [x] `cargo test -p thirtyfour --features manager-tests --test managed -- --test-threads=1` (not run locally — downloads a real driver; CI will exercise it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)