### PR TITLE
Document WebDriverManager and overhaul user-facing docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,7 +11,7 @@
 - [Element Queries](./features/queries.md)
 - [Waiting For Element Changes](./features/waiting.md)
 - [Components](./features/components.md)
-- [Managed WebDriver](./features/manager.md)
+- [WebDriver Manager](./features/manager.md)
 # Useful Tools
 - [Selenium](./tools/selenium.md)
 # Contributing

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,10 +11,12 @@
 - [Element Queries](./features/queries.md)
 - [Waiting For Element Changes](./features/waiting.md)
 - [Components](./features/components.md)
+- [Managed WebDriver](./features/manager.md)
 # Useful Tools
 - [Selenium](./tools/selenium.md)
 # Contributing
 - [Running Tests For Thirtyfour](./contributing/testing.md)
 # Appendix
+- [Manual WebDriver Setup](./appendix/manual-webdriver.md)
 - [Frequently Asked Questions](./appendix/faq.md)
 - [Further Reading](./appendix/reading.md)

--- a/docs/src/appendix/manual-webdriver.md
+++ b/docs/src/appendix/manual-webdriver.md
@@ -1,17 +1,16 @@
 # Manual WebDriver Setup
 
-The default [Managed WebDriver](../features/manager.md) feature handles
-downloading and running the appropriate webdriver subprocess for you. This
-appendix is for the cases where you want to do it yourself:
+This appendix covers running the webdriver yourself instead of letting
+`thirtyfour` manage it. Common reasons:
 
-- You have disabled the `manager` feature.
-- You're connecting to an externally-managed driver server, like a remote
-  [Selenium grid](../tools/selenium.md) or a driver running in a container.
+- You're connecting to a remote [Selenium grid](../tools/selenium.md) or
+  a driver running in a container.
 - You want a long-lived driver process you can reuse across many runs of
   your program.
+- You've disabled the `manager` Cargo feature to slim your build.
 
-In any of these scenarios you'll need to download the webdriver binary,
-start it on a known port, and pass that URL to `WebDriver::new(...)`.
+In any of these cases you'll need to download a webdriver binary, start
+it on a known port, and pass that URL to `WebDriver::new(...)`.
 
 ## Downloading A WebDriver Binary
 
@@ -27,11 +26,10 @@ The webdriver may be zipped. Unzip it and place the binary somewhere in
 your `PATH`. Make sure it is executable and that you have permission to
 run it.
 
-> If the webdriver is not the right version for your browser, it will
-> show an error message when you try to start a new session using
-> `thirtyfour`. Browser auto-updates are a common cause; the
-> [Managed WebDriver](../features/manager.md) feature exists in part to
-> sidestep this problem.
+> Make sure the webdriver version matches the version of the browser you
+> have installed. If they don't match, the driver returns an error when
+> you try to start a session. Browser auto-updates are a common cause of
+> drift here.
 
 ## Starting The WebDriver
 

--- a/docs/src/appendix/manual-webdriver.md
+++ b/docs/src/appendix/manual-webdriver.md
@@ -1,7 +1,7 @@
 # Manual WebDriver Setup
 
 This appendix covers running the webdriver yourself instead of letting
-`thirtyfour` manage it. Common reasons:
+`thirtyfour` [manage it for you](../features/manager.md). Common reasons:
 
 - You're connecting to a remote [Selenium grid](../tools/selenium.md) or
   a driver running in a container.

--- a/docs/src/appendix/manual-webdriver.md
+++ b/docs/src/appendix/manual-webdriver.md
@@ -1,0 +1,65 @@
+# Manual WebDriver Setup
+
+The default [Managed WebDriver](../features/manager.md) feature handles
+downloading and running the appropriate webdriver subprocess for you. This
+appendix is for the cases where you want to do it yourself:
+
+- You have disabled the `manager` feature.
+- You're connecting to an externally-managed driver server, like a remote
+  [Selenium grid](../tools/selenium.md) or a driver running in a container.
+- You want a long-lived driver process you can reuse across many runs of
+  your program.
+
+In any of these scenarios you'll need to download the webdriver binary,
+start it on a known port, and pass that URL to `WebDriver::new(...)`.
+
+## Downloading A WebDriver Binary
+
+Pick the binary that matches your browser:
+
+* For Chrome, download [chromedriver](https://developer.chrome.com/docs/chromedriver/downloads)
+* For Firefox, download [geckodriver](https://github.com/mozilla/geckodriver/releases)
+* For Microsoft Edge, download [msedgedriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/)
+* For Safari (macOS), `safaridriver` ships with the OS — run
+  `safaridriver --enable` once to allow remote automation.
+
+The webdriver may be zipped. Unzip it and place the binary somewhere in
+your `PATH`. Make sure it is executable and that you have permission to
+run it.
+
+> If the webdriver is not the right version for your browser, it will
+> show an error message when you try to start a new session using
+> `thirtyfour`. Browser auto-updates are a common cause; the
+> [Managed WebDriver](../features/manager.md) feature exists in part to
+> sidestep this problem.
+
+## Starting The WebDriver
+
+Open a terminal and run the binary directly:
+
+    chromedriver        # listens on port 9515 by default
+    geckodriver         # listens on port 4444 by default
+    msedgedriver        # listens on port 9515 by default
+
+Leave it running in that terminal — it's the server that `thirtyfour`
+will talk to.
+
+## Connecting From Your Code
+
+Pass the driver's URL to `WebDriver::new(...)`:
+
+```rust
+use thirtyfour::prelude::*;
+
+#[tokio::main]
+async fn main() -> WebDriverResult<()> {
+    let caps = DesiredCapabilities::chrome();
+    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    driver.goto("https://www.rust-lang.org/").await?;
+    driver.quit().await?;
+    Ok(())
+}
+```
+
+For Firefox, use `DesiredCapabilities::firefox()` and the geckodriver URL
+(`http://localhost:4444`).

--- a/docs/src/features/components.md
+++ b/docs/src/features/components.md
@@ -1,96 +1,285 @@
 # Components
 
-Components are a more structured way to automate an element or page.
+When you automate a real web app, the same selectors and helper
+methods tend to show up over and over: "find the search bar," "click
+the submit button," "read the cart count." Without structure, that
+logic spreads across your code and gets brittle. **Components** let
+you wrap a piece of UI — a single button, a form, a whole page — in
+a Rust struct, attach methods to it, and then reuse it anywhere.
 
-This approach may seem familiar to anyone who has used a 
-[Page Object Model](https://www.selenium.dev/documentation/test_practices/encouraged/page_object_models/) before. 
-However, a `Component` can wrap any node in the DOM, not just "pages".
+This is the same idea as the
+[Page Object Model](https://www.selenium.dev/documentation/test_practices/encouraged/page_object_models/)
+from other Selenium ecosystems. In `thirtyfour` it's just a derive
+macro on a struct, and any DOM node — not only "pages" — can be a
+Component.
 
-It uses smart element resolvers that can lazily resolve elements within the component and cache them for further 
-use. You can also nest components, making them an extremely powerful feature for automating any modern web app.
+## A Quick Example
 
-## Example
-
-Given the following HTML structure:
+Suppose your page contains a search form:
 
 ```html
-<div id="checkbox-section">
-    <label>
-        <input type="checkbox" id="checkbox-option-1" />
-        Option 1
-    </label>
-
-    <label>
-        <input type="checkbox" id="checkbox-disabled" disabled />
-        Option 2
-    </label>
-
-    <label>
-        <input type="checkbox" id="checkbox-hidden" style="display: none;" />
-        Option 3
-    </label>
-</div>
+<form id="search-form">
+    <input type="text" id="search-input" />
+    <button type="submit">Search</button>
+</form>
 ```
 
+Wrap it in a Component:
+
 ```rust
-/// This component shows how to wrap a simple web component.
+use thirtyfour::prelude::*;
+use thirtyfour::components::ElementResolver;
+
 #[derive(Debug, Clone, Component)]
-pub struct CheckboxComponent {
-    base: WebElement, // This is the <label> element
-    #[by(css = "input[type='checkbox']", first)]
-    input: ElementResolver<WebElement>, // This is the <input /> element
+pub struct SearchForm {
+    base: WebElement,                              // The <form> itself.
+    #[by(id = "search-input")]
+    input: ElementResolver<WebElement>,            // The <input>.
+    #[by(css = "button[type='submit']")]
+    submit: ElementResolver<WebElement>,           // The <button>.
 }
 
-impl CheckboxComponent {
-    /// Return true if the checkbox is ticked.
+impl SearchForm {
+    pub async fn search(&self, term: &str) -> WebDriverResult<()> {
+        self.input.resolve().await?.send_keys(term).await?;
+        self.submit.resolve().await?.click().await?;
+        Ok(())
+    }
+}
+```
+
+Find the `<form>` and turn it into a `SearchForm`:
+
+```rust
+let form_el = driver.query(By::Id("search-form")).single().await?;
+let form: SearchForm = form_el.into();         // From<WebElement> is derived.
+form.search("Selenium").await?;
+```
+
+A few things are happening here:
+
+- The `base: WebElement` field is mandatory — it holds the outer
+  element the component wraps. The derive macro implements
+  `From<WebElement>` for you, so any `WebElement` becomes a
+  `SearchForm` with `.into()`.
+- Each `#[by(...)]` field is an `ElementResolver`. It doesn't query
+  anything until you call `.resolve()`, and it caches the result so
+  subsequent calls don't hit WebDriver again.
+- Resolvers always search relative to `base`, so a `SearchForm` can
+  only ever find elements inside its own `<form>`. That scoping is one
+  of the big wins over scattered `driver.query(...)` calls — you can't
+  accidentally match elements from a different form on the page.
+
+## The `#[by(...)]` Attribute
+
+Every resolver field needs a `#[by(...)]` attribute. The first part
+picks the selector:
+
+| Attribute            | Selector used    |
+| -------------------- | ---------------- |
+| `id = "..."`         | `By::Id`         |
+| `css = "..."`        | `By::Css`        |
+| `xpath = "..."`      | `By::XPath`      |
+| `tag = "..."`        | `By::Tag`        |
+| `class = "..."`      | `By::ClassName`  |
+| `name = "..."`       | `By::Name`       |
+| `link = "..."`       | `By::LinkText`   |
+| `testid = "..."`     | `By::Testid`     |
+
+Pair the selector with extra options, comma-separated. Which options
+apply depends on whether the resolver is single or multi (the macro
+infers that from the field type — `ElementResolver<T>` is single,
+`ElementResolver<Vec<T>>` is multi):
+
+| Option                     | Applies to | Effect                                                    |
+| -------------------------- | ---------- | --------------------------------------------------------- |
+| `single`                   | single     | Match exactly one element. Errors if 0 or 2+. Default.    |
+| `first`                    | single     | Match the first element instead.                          |
+| `not_empty`                | multi      | Match at least one element. Errors if empty. Default.     |
+| `allow_empty`              | multi      | Match zero or more elements. Empty Vec is OK.             |
+| `description = "..."`      | both       | Attach a label that shows up in timeout error messages.   |
+| `wait(timeout_ms = N, interval_ms = N)` | both | Override the poll cadence for this field.            |
+| `nowait`                   | both       | Try once without polling.                                 |
+| `ignore_errors`            | both       | Forward `ignore_errors` to the underlying query.          |
+| `multi`                    | multi      | Force multi-resolver behaviour. Only needed for custom type aliases. |
+| `custom = my_resolver_fn`  | both       | Use a custom resolver function (see [Custom Resolvers](#custom-resolvers)). Mutually exclusive with the other options. |
+
+Examples:
+
+```rust
+// Use the first match if there are several.
+#[by(id = "search-input", first)]
+input: ElementResolver<WebElement>,
+
+// All <li> elements; empty list is fine.
+#[by(tag = "li", allow_empty)]
+items: ElementResolver<Vec<WebElement>>,
+
+// Wait up to 60 seconds, polling every second, with a friendly description.
+#[by(css = ".loading-spinner", description = "loading spinner",
+     wait(timeout_ms = 60_000, interval_ms = 1_000))]
+spinner: ElementResolver<WebElement>,
+```
+
+## ElementResolver Methods
+
+Every resolver field exposes the same handful of methods:
+
+| Method                       | Behaviour                                                                            |
+| ---------------------------- | ------------------------------------------------------------------------------------ |
+| `.resolve().await?`          | Run the query (or return the cached value) and return the result.                    |
+| `.resolve_present().await?`  | Like `.resolve()`, but if the cached value is stale (detached from the DOM), re-query first. Use this when the page may have re-rendered. |
+| `.resolve_force().await?`    | Drop the cache and re-query unconditionally.                                         |
+| `.invalidate()`              | Drop the cache without querying. The next `.resolve()` will run the query again.     |
+| `.validate().await?`         | Return the cached value if it's still in the DOM, or `None`.                         |
+
+Two macros wrap the most common calls:
+
+```rust
+let elem = resolve!(self.input);            // self.input.resolve().await?
+let elem = resolve_present!(self.input);    // self.input.resolve_present().await?
+```
+
+The macros are useful for chained method calls without scattering
+`.await?` around:
+
+```rust
+resolve!(self.submit).click().await?;
+```
+
+## Caching And Staleness
+
+Resolvers cache the resolved value, which is what makes them cheap to
+call repeatedly inside helper methods. If the page changes underneath
+you — a re-render, a SPA route change, a click that swapped the DOM —
+the cached `WebElement` may go stale. Two strategies:
+
+- Use `resolve_present!(field)` instead of `resolve!(field)`. It checks
+  whether the cached value is still attached to the DOM and re-queries
+  if not.
+- Call `.invalidate()` (or `.resolve_force()`) when you *know* the
+  underlying DOM has moved.
+
+For elements that change frequently, `resolve_present` is the safe
+default. For elements that are stable for the lifetime of the
+component, plain `resolve` is faster.
+
+## Nested Components
+
+`ElementResolver<T>` works whenever `T` implements `Component`, so a
+Component can contain other Components:
+
+```rust
+#[derive(Debug, Clone, Component)]
+pub struct CheckboxOption {
+    base: WebElement,                              // The <label>.
+    #[by(css = "input[type='checkbox']")]
+    input: ElementResolver<WebElement>,
+}
+
+impl CheckboxOption {
     pub async fn is_ticked(&self) -> WebDriverResult<bool> {
-        let elem = self.input.resolve().await?;
-        let prop = elem.prop("checked").await?;
-        Ok(prop.unwrap_or_default() == "true")
+        let input = resolve!(self.input);
+        Ok(input.prop("checked").await?.unwrap_or_default() == "true")
     }
 
-    /// Tick the checkbox if it is clickable and isn't already ticked.
     pub async fn tick(&self) -> WebDriverResult<()> {
-        // This checks that the element is present before returning the element.
-        // If the element had become stale, this would implicitly re-query the element.
-        let elem = self.input.resolve_present().await?;
-        if elem.is_clickable().await? && !self.is_ticked().await? {
-            elem.click().await?;
-            // Now make sure it's ticked.
-            assert!(self.is_ticked().await?);
+        let input = resolve_present!(self.input);
+        if input.is_clickable().await? && !self.is_ticked().await? {
+            input.click().await?;
         }
-
         Ok(())
     }
 }
 
-/// This component shows how to nest components inside others.
 #[derive(Debug, Clone, Component)]
-pub struct CheckboxSectionComponent {
-    base: WebElement, // This is the outer <div>
+pub struct CheckboxSection {
+    base: WebElement,
     #[by(tag = "label", allow_empty)]
-    boxes: ElementResolver<Vec<CheckboxComponent>>, // ElementResolver works with Components too.
-    // Other fields will be initialized with Default::default().
-    my_field: bool,
+    options: ElementResolver<Vec<CheckboxOption>>,
 }
 ```
 
-So how do you construct a Component?
-
-Simple. The `Component` derive automatically implements `From<WebElement>`.
+When the resolver's element type is itself a Component, the derive
+calls `From<WebElement>` on each match, so you get a
+`Vec<CheckboxOption>` back — already wrapped, ready to call methods
+on:
 
 ```rust
-let elem = driver.query(By::Id("checkbox-section")).await?;
-let component = CheckboxSectionComponent::from(elem);
+let section_el = driver.query(By::Id("checkbox-section")).single().await?;
+let section: CheckboxSection = section_el.into();
 
-// Now you can get the checkbox components easily like this.
-let checkboxes = component.boxes.resolve().await?;
-for checkbox in checkboxes {
-    checkbox.tick().await?;
+for option in section.options.resolve().await? {
+    option.tick().await?;
 }
 ```
 
-This allows you to wrap any component using `ElementResolver` to resolve elements and nested components easily.
+## Non-Element Fields
 
-For more details see the documentation for [Component](https://docs.rs/thirtyfour/latest/thirtyfour/components/index.html)
-and the [Component derive macro](https://docs.rs/thirtyfour-macros/latest/thirtyfour_macros/derive.Component.html).
+Fields without a `#[by(...)]` attribute are initialised via
+`Default::default()`, so you can tack on bookkeeping state without
+extra boilerplate:
+
+```rust
+#[derive(Debug, Clone, Component, Default)]
+pub struct LoginForm {
+    base: WebElement,
+    #[by(id = "username")]
+    username: ElementResolver<WebElement>,
+    attempt_count: u32,                            // Initialised to 0.
+}
+```
+
+## Custom Resolvers
+
+If a built-in selector can't express what you need — say, "find the
+button whose text starts with 'Run'" — write the resolver yourself
+and reference it from `custom = ...`:
+
+```rust
+use thirtyfour::stringmatch::StringMatchable;
+
+async fn resolve_run_button(elem: WebElement) -> WebDriverResult<WebElement> {
+    elem.query(By::Tag("button"))
+        .with_text("Run".match_partial().case_insensitive())
+        .first()
+        .await
+}
+
+#[derive(Debug, Clone, Component)]
+pub struct Header {
+    base: WebElement,
+    #[by(custom = resolve_run_button)]
+    run_button: ElementResolver<WebElement>,
+}
+```
+
+A custom resolver receives the component's base element and returns a
+`WebDriverResult<T>` matching the field's type. `custom = ...` is
+mutually exclusive with the selector and modifier options — the
+function is doing all of that work itself.
+
+## When To Reach For A Component
+
+Any time you're going to interact with the same UI element in more
+than one place, wrapping it in a Component is usually worth it. You
+get:
+
+- A single place to update if the underlying selectors change.
+- Scoped queries that can't accidentally match unrelated elements.
+- Methods named after what the user does ("`form.search(...)`,
+  `option.tick()`") instead of low-level click/type plumbing.
+- Cheap repeated access via the resolver cache.
+
+For a one-off lookup deep in a single test, a plain `driver.query(...)`
+is fine. Once a piece of UI shows up in two or three places, lift it
+into a Component.
+
+## API Reference
+
+For the full list of methods and attribute combinations, see:
+
+- [`thirtyfour::components`](https://docs.rs/thirtyfour/latest/thirtyfour/components/index.html) —
+  the `Component` trait, `ElementResolver`, and helper wrappers.
+- [`thirtyfour_macros::Component`](https://docs.rs/thirtyfour-macros/latest/thirtyfour_macros/derive.Component.html) —
+  the derive macro and every supported attribute.

--- a/docs/src/features/manager.md
+++ b/docs/src/features/manager.md
@@ -1,25 +1,9 @@
-# Managed WebDriver
+# WebDriver Manager
 
-Normally, before you can use `thirtyfour` you have to download a webdriver
-binary (`chromedriver`, `geckodriver`, etc.) that matches your installed
-browser, run it on a known port, and pass that URL to `WebDriver::new(...)`.
-The `manager` feature does all of that for you: it picks a compatible driver
-version, downloads it into a cache directory, spawns it as a subprocess,
-waits for it to be ready, and tears it down when your last `WebDriver`
-handle is dropped.
-
-The `manager` feature is enabled by default. If you have disabled default
-features, re-enable it with:
-
-    [dependencies]
-    thirtyfour = { version = "THIRTYFOUR_CRATE_VERSION", features = ["manager"] }
-
-Currently supported browsers: Chrome / Chromium, Firefox, Microsoft Edge,
-and Safari (macOS only — uses the system `safaridriver`, no download).
-
-## Quick Start
-
-The simplest path is `WebDriver::managed()`:
+`thirtyfour` automatically downloads and runs the appropriate webdriver
+binary (`chromedriver`, `geckodriver`, `msedgedriver`) for your
+installed browser, so you don't have to manage the driver process
+yourself. The simple form is `WebDriver::managed()`:
 
 ```rust
 use thirtyfour::prelude::*;
@@ -33,13 +17,18 @@ async fn main() -> WebDriverResult<()> {
 }
 ```
 
-No `chromedriver` running in another terminal. No port to remember. The
-first run downloads a matching `chromedriver` into your system cache
-directory; subsequent runs reuse the cached binary.
+The first run downloads a matching driver into your system cache
+directory; subsequent runs reuse the cached binary. The driver
+subprocess starts when you create the session and is torn down when
+your last `WebDriver` handle drops.
 
-By default, the manager probes your locally installed browser, reads its
-version, and downloads a matching driver. Swap in
-`DesiredCapabilities::firefox()` to drive Firefox instead — same code path.
+Supported browsers: Chrome / Chromium, Firefox, Microsoft Edge, and
+Safari (macOS only — uses the system `safaridriver`, no download).
+
+The rest of this chapter covers what else the manager can do — version
+pinning, sharing one manager across many sessions, supplying a
+pre-installed driver binary, and observing what's happening as the
+manager works.
 
 ## Picking A Driver Version
 

--- a/docs/src/features/manager.md
+++ b/docs/src/features/manager.md
@@ -1,0 +1,203 @@
+# Managed WebDriver
+
+Normally, before you can use `thirtyfour` you have to download a webdriver
+binary (`chromedriver`, `geckodriver`, etc.) that matches your installed
+browser, run it on a known port, and pass that URL to `WebDriver::new(...)`.
+The `manager` feature does all of that for you: it picks a compatible driver
+version, downloads it into a cache directory, spawns it as a subprocess,
+waits for it to be ready, and tears it down when your last `WebDriver`
+handle is dropped.
+
+The `manager` feature is enabled by default. If you have disabled default
+features, re-enable it with:
+
+    [dependencies]
+    thirtyfour = { version = "THIRTYFOUR_CRATE_VERSION", features = ["manager"] }
+
+Currently supported browsers: Chrome / Chromium, Firefox, Microsoft Edge,
+and Safari (macOS only — uses the system `safaridriver`, no download).
+
+## Quick Start
+
+The simplest path is `WebDriver::managed()`:
+
+```rust
+use thirtyfour::prelude::*;
+
+#[tokio::main]
+async fn main() -> WebDriverResult<()> {
+    let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
+    driver.goto("https://www.rust-lang.org/").await?;
+    driver.quit().await?;
+    Ok(())
+}
+```
+
+No `chromedriver` running in another terminal. No port to remember. The
+first run downloads a matching `chromedriver` into your system cache
+directory; subsequent runs reuse the cached binary.
+
+By default, the manager probes your locally installed browser, reads its
+version, and downloads a matching driver. Swap in
+`DesiredCapabilities::firefox()` to drive Firefox instead — same code path.
+
+## Picking A Driver Version
+
+`WebDriver::managed(caps)` returns a builder. Awaiting it directly uses the
+defaults; chained methods customize what gets downloaded:
+
+```rust
+# use thirtyfour::prelude::*;
+# use thirtyfour::manager::BrowserKind;
+# async fn run() -> WebDriverResult<()> {
+let caps = DesiredCapabilities::chrome();
+
+// Default: match the locally-installed browser.
+let driver = WebDriver::managed(caps.clone()).await?;
+
+// Latest stable from upstream metadata.
+let driver = WebDriver::managed(caps.clone()).latest().await?;
+
+// Pin a specific version (full or major-only for Chrome/Edge).
+let driver = WebDriver::managed(caps.clone()).exact("126").await?;
+
+// Read `browserVersion` from the capabilities object.
+let driver = WebDriver::managed(caps.clone()).from_caps().await?;
+
+// Skip the download/cache flow entirely — use an already-installed
+// driver binary at this path. See "Using A Pre-Installed Driver" below.
+let driver = WebDriver::managed(caps)
+    .driver_binary(BrowserKind::Chrome, "/usr/local/bin/chromedriver")
+    .await?;
+# Ok(()) }
+```
+
+> **Note on Firefox:** Firefox releases and `geckodriver` releases don't
+> share version numbers (Firefox is on `150.x` while `geckodriver` is on
+> `0.36.0`). The manager picks a compatible `geckodriver` from an embedded
+> compatibility table. For `.exact(...)` on Firefox, pass a `geckodriver`
+> tag like `"0.36.0"` — not a Firefox version.
+
+## Sharing One Manager Across Sessions
+
+Each `WebDriver::managed(caps)` call constructs its own manager and
+spawns its own driver subprocess. To share one manager — and the driver
+subprocesses it owns — across many sessions, construct it explicitly
+with `WebDriverManager::builder()` and call `.launch(caps)` for each
+session:
+
+```rust
+# use thirtyfour::prelude::*;
+# use thirtyfour::manager::WebDriverManager;
+# async fn run() -> WebDriverResult<()> {
+let manager = WebDriverManager::builder().latest().build();
+
+// One manager, multiple browsers.
+let chrome  = manager.launch(DesiredCapabilities::chrome()).await?;
+let firefox = manager.launch(DesiredCapabilities::firefox()).await?;
+# Ok(()) }
+```
+
+A single manager can drive any combination of supported browsers; it
+spawns one driver subprocess per `(browser, version, host)` combination
+as needed, and reuses an existing subprocess when a later `.launch()`
+call matches one that's still alive.
+
+## Configuration
+
+The most useful builder methods (all available on both
+`WebDriverManager::builder()` and `WebDriver::managed(caps)`):
+
+| Method                            | Purpose                                               |
+| --------------------------------- | ----------------------------------------------------- |
+| `.latest()`                       | Use the latest stable driver from upstream metadata.  |
+| `.match_local()`                  | Match the locally-installed browser (default).        |
+| `.from_caps()`                    | Read `browserVersion` from the capabilities.          |
+| `.exact("126")`                   | Pin a specific driver version.                        |
+| `.driver_binary(browser, path)`   | Use an already-installed driver binary; skip the download/cache flow for that browser. |
+| `.cache_dir(path)`                | Override the on-disk driver cache.                    |
+| `.host(addr)`                     | Bind the driver to an address other than `127.0.0.1`. |
+| `.download_timeout(d)`            | Cap upstream metadata + download time (default 60s).  |
+| `.ready_timeout(d)`               | Cap how long to wait for `/status` (default 30s).     |
+| `.offline()` / `.online()`        | Forbid / allow downloads (default: online).           |
+| `.stdio(StdioMode::Inherit)`      | Show driver stdout/stderr in the parent terminal.     |
+| `.on_status(fn)`                  | Attach a permanent status-event subscriber.           |
+| `.on_driver_log(fn)`              | Attach a permanent driver-log subscriber.             |
+
+The default cache directory is `<system cache dir>/thirtyfour/drivers`.
+
+## Using A Pre-Installed Driver
+
+If you'd rather manage the driver binary yourself — for instance because
+you ship a pinned `chromedriver` in a CI image — point the manager at it
+with `.driver_binary(browser, path)`:
+
+```rust
+# use thirtyfour::prelude::*;
+# use thirtyfour::manager::{WebDriverManager, BrowserKind};
+# async fn run() -> WebDriverResult<()> {
+let manager = WebDriverManager::builder()
+    .driver_binary(BrowserKind::Chrome, "/usr/local/bin/chromedriver")
+    .build();
+let driver = manager.launch(DesiredCapabilities::chrome()).await?;
+# Ok(()) }
+```
+
+Bare command names (e.g. `"chromedriver"`) are resolved against the OS
+`PATH`. The version-resolution and download/cache flow is skipped for
+that browser; the binary is spawned as-is. If it doesn't match the
+installed browser's version, expect a runtime error from the driver
+when the session is started.
+
+## Offline Mode
+
+If the driver you want is already in the cache, you can launch with no
+network access at all:
+
+```rust
+# use thirtyfour::prelude::*;
+# use thirtyfour::manager::WebDriverManager;
+# async fn run() -> WebDriverResult<()> {
+let manager = WebDriverManager::builder().offline().build();
+let driver = manager.launch(DesiredCapabilities::chrome()).await?;
+# Ok(()) }
+```
+
+In offline mode, a cache miss returns an error rather than reaching out
+to the network.
+
+## Observing What The Manager Is Doing
+
+The manager emits structured `Status` events at every step (resolving the
+version, hitting the cache, downloading, spawning the process, waiting
+for `/status`, starting / ending sessions, shutting the driver down).
+These events are also forwarded to the `tracing` ecosystem under the
+`thirtyfour::manager` target — for human-readable logs, just install a
+`tracing-subscriber` and you're done.
+
+For programmatic access, register a subscriber:
+
+```rust
+# use thirtyfour::prelude::*;
+# use thirtyfour::manager::{WebDriverManager, Status};
+# async fn run() -> WebDriverResult<()> {
+let manager = WebDriverManager::builder()
+    .on_status(|s: &Status| println!("manager: {s}"))
+    .build();
+let driver = manager.launch(DesiredCapabilities::chrome()).await?;
+# Ok(()) }
+```
+
+You can also subscribe to raw stdout/stderr lines from the driver process
+itself via `WebDriverManager::on_driver_log` (manager-wide) or
+`WebDriver::on_driver_log` (just one session's driver).
+
+## Further Reading
+
+See the [`thirtyfour::manager`](https://docs.rs/thirtyfour/latest/thirtyfour/manager/index.html)
+module documentation for the full API, including
+[`WebDriverManager`](https://docs.rs/thirtyfour/latest/thirtyfour/manager/struct.WebDriverManager.html),
+[`WebDriverManagerBuilder`](https://docs.rs/thirtyfour/latest/thirtyfour/manager/struct.WebDriverManagerBuilder.html),
+[`DriverVersion`](https://docs.rs/thirtyfour/latest/thirtyfour/manager/enum.DriverVersion.html),
+and the [`Status`](https://docs.rs/thirtyfour/latest/thirtyfour/manager/enum.Status.html)
+event vocabulary.

--- a/docs/src/features/queries.md
+++ b/docs/src/features/queries.md
@@ -1,18 +1,20 @@
 # Element Queries
 
-`ElementQuery` is the way to find elements in `thirtyfour`. Whenever
-you'd reach for `find()` or `find_all()`, reach for `query()` instead.
-The `find*()` methods exist only to mirror the W3C WebDriver spec —
-they don't poll, don't wait for the element to appear, and produce
-thin error messages when something's missing. Almost every real
-automation needs at least one of those things, so `query()` is what
-the rest of this chapter assumes.
-
-## How It Works
+To find elements on a page, call `.query(...)` on a `WebDriver` or a
+`WebElement`. `query()` is the recommended way to locate elements:
+it knows how to wait for the element to appear, can describe what
+you were looking for in error messages, and lets you chain filters
+and alternatives until the query returns exactly what you want.
 
 ```rust
 let elem = driver.query(By::Id("search-form")).single().await?;
 ```
+
+That's the basic shape. The rest of this chapter unpacks each piece —
+the selectors you can pass, the filters you can chain, and the
+terminator at the end that decides what comes back.
+
+## How It Works
 
 A query has three parts:
 
@@ -202,12 +204,16 @@ let cart = driver
 If the query times out, the error includes `"shopping cart badge"`
 instead of just the raw CSS selector.
 
-## When To Use `find()` / `find_all()`
+## A Note On `find()` / `find_all()`
 
-Almost never. They exist for spec parity and for the rare case where
-you genuinely want a one-shot lookup with no polling. Anywhere a
-flickering DOM, an in-flight network request, or a slow load could
-matter, `query()` is more reliable and gives better diagnostics.
+You may run across `find()` and `find_all()` methods on `WebDriver`
+and `WebElement`. They exist to mirror the W3C WebDriver
+specification — a one-shot lookup with no polling, no filters, and a
+thin error if nothing matches. They're fine for the rare case where
+you genuinely want exactly that, but for everyday automation prefer
+`query()`: it handles slow loads, missing elements, and flickering
+DOMs more gracefully and gives better diagnostics when something
+goes wrong.
 
 ## API Reference
 

--- a/docs/src/features/queries.md
+++ b/docs/src/features/queries.md
@@ -1,28 +1,216 @@
 # Element Queries
 
-## Basic queries
-The `find()` and `find_all()` methods in both `WebDriver` and `WebElement` provide a simple
-way to perform direct element queries, returning a result instantly.
+`ElementQuery` is the way to find elements in `thirtyfour`. Whenever
+you'd reach for `find()` or `find_all()`, reach for `query()` instead.
+The `find*()` methods exist only to mirror the W3C WebDriver spec —
+they don't poll, don't wait for the element to appear, and produce
+thin error messages when something's missing. Almost every real
+automation needs at least one of those things, so `query()` is what
+the rest of this chapter assumes.
 
-However, for many types of queries, these methods are inadequate. For example, there is no polling,
-and no way to wait for something to show up on a page.
-If an element doesn't exist at the instant you look for it, you'll get an error.
-
-This isn't helpful for the majority of element queries, so `thirtyfour` provides a
-more powerful query interface, called `ElementQuery`.
-We recommend using this query interface instead of the `find*()` methods.
-
-## ElementQuery
-
-The `WebDriver::query()` and `WebElement::query()` methods return an `ElementQuery` struct.
-
-Using `ElementQuery`, you can do things like:
+## How It Works
 
 ```rust
-let elem_text =
-    driver.query(By::Css("match.this")).or(By::Id("orThis")).first().await?;
+let elem = driver.query(By::Id("search-form")).single().await?;
 ```
 
-This will execute both queries once per poll iteration and return the first one that matches.
+A query has three parts:
 
-See [ElementQuery](https://docs.rs/thirtyfour/latest/thirtyfour/extensions/query/struct.ElementQuery.html) for more details.
+1. A **starting selector** (`By::Id("search-form")`).
+2. Optional **filters and chained alternatives** (e.g. `.with_text("Hello")`,
+   `.or(By::Css("..."))`).
+3. A **terminator** that decides what to return: a single element, all
+   matches, just a boolean for existence, etc.
+
+The query polls under the hood. By default it tries every 500ms for up
+to 20 seconds; if the selector matches at any point, the query returns
+immediately. If the timeout elapses with no match, you get a structured
+error that includes the selector(s) you used and any descriptions you
+attached.
+
+`WebElement::query()` works the same way and scopes the search to the
+element's subtree.
+
+## Selectors
+
+Pass any of these `By` variants to `query()`:
+
+| Selector              | Matches                                  |
+| --------------------- | ---------------------------------------- |
+| `By::Id("foo")`       | Element with `id="foo"`                  |
+| `By::Css("...")`      | CSS selector                             |
+| `By::XPath("...")`    | XPath expression                         |
+| `By::Tag("button")`   | Element by tag name                      |
+| `By::ClassName("x")`  | Element with class `x`                   |
+| `By::Name("user")`    | Element with `name="user"`               |
+| `By::LinkText("...")` | `<a>` whose visible text matches exactly |
+| `By::PartialLinkText("...")` | `<a>` whose visible text contains the string |
+| `By::Testid("...")`   | Element with `data-testid="..."`         |
+
+`By::Css` and `By::XPath` are the most expressive; the others are
+convenience wrappers and most are implemented as CSS under the hood.
+
+## Picking An Element
+
+The terminator at the end of the chain decides what comes back. Pick
+the one that matches what you actually need:
+
+| Terminator                              | Returns                                                |
+| --------------------------------------- | ------------------------------------------------------ |
+| `.first().await?`                       | The first matching element. Errors if none.            |
+| `.single().await?`                      | The matching element. Errors if 0 or 2+.               |
+| `.first_opt().await?`                   | `Option<WebElement>` — `None` if none match.           |
+| `.all_from_selector().await?`           | Elements from the first branch that matched.           |
+| `.all_from_selector_required().await?`  | Same, but errors if empty.                             |
+| `.any().await?`                         | Elements from every branch combined, possibly empty.   |
+| `.any_required().await?`                | Same, but errors if empty.                             |
+| `.exists().await?`                      | `bool` — does it exist?                                |
+| `.not_exists().await?`                  | `bool` — does it stay absent for the timeout?          |
+
+`.any()` and `.all_from_selector()` differ when you've used `.or()`:
+`.any()` runs every branch and returns the union of matches;
+`.all_from_selector()` short-circuits on the first branch that
+finds something.
+
+The semantic difference between `single()` and `first()` is worth
+calling out: `single()` is a contract that there should be exactly one
+match. If two elements appear it returns an error rather than silently
+picking one — useful for catching a sloppy selector.
+
+## Multiple Selectors With `.or()`
+
+Chain `.or()` to try multiple selectors in parallel. The first branch
+that matches wins:
+
+```rust
+let elem = driver
+    .query(By::Css(".legacy-button"))
+    .or(By::Css(".new-button"))
+    .first()
+    .await?;
+```
+
+Each branch is checked once per poll iteration, so a slow page that
+serves either layout will resolve as soon as one appears.
+
+## Filters
+
+Narrow a branch with chained filters. State filters short-circuit on
+the WebDriver side (cheap):
+
+```rust
+let button = driver
+    .query(By::Css("button.submit"))
+    .and_displayed()
+    .and_enabled()
+    .and_clickable()
+    .first()
+    .await?;
+```
+
+Negative variants are also available: `.and_not_displayed()`,
+`.and_not_enabled()`, `.and_not_selected()`, `.and_not_clickable()`.
+
+Attribute, property, text, and class filters take a `Needle` — any
+type that implements the [`stringmatch`](https://crates.io/crates/stringmatch)
+crate's matching trait. A plain `&str` is exact-match; use `StringMatch`
+for partial / case-insensitive / word-boundary matches:
+
+```rust
+use thirtyfour::stringmatch::StringMatchable;
+
+let btn = driver
+    .query(By::Tag("button"))
+    .with_text("Submit".match_partial().case_insensitive())
+    .first()
+    .await?;
+```
+
+Available filter families (each has a `with_*` and a `without_*` form):
+
+- **Text:** `.with_text(needle)` — visible text content
+- **Class:** `.with_class("name")` — `class` attribute contains `name`
+- **Tag:** `.with_tag("button")`
+- **Id:** `.with_id("submit")`
+- **Value:** `.with_value(needle)` — for inputs
+- **Attribute(s):** `.with_attribute("data-state", "ready")`,
+  `.with_attributes([(name, needle), ...])`
+- **Property(ies):** `.with_property(name, needle)`,
+  `.with_properties(...)`
+- **CSS property(ies):** `.with_css_property("color", "rgb(0, 0, 0)")`,
+  `.with_css_properties(...)`
+
+Each filter triggers an extra WebDriver round trip per poll iteration,
+so prefer narrowing the initial `By` selector when you can. CSS and
+XPath are usually the right tool for complex matches.
+
+## Custom Predicates
+
+When a built-in filter isn't enough, supply your own:
+
+```rust
+let chosen = driver
+    .query(By::Tag("li"))
+    .with_filter(|elem| async move {
+        Ok(elem.text().await?.starts_with("Status:"))
+    })
+    .first()
+    .await?;
+```
+
+A predicate is any async function returning `WebDriverResult<bool>` for
+a given `&WebElement`.
+
+## Timeouts And Polling
+
+Override the poll cadence on a single query:
+
+```rust
+use std::time::Duration;
+
+let slow = driver
+    .query(By::Id("late-loader"))
+    .wait(Duration::from_secs(60), Duration::from_secs(1))
+    .single()
+    .await?;
+```
+
+Use `.nowait()` to opt out of polling entirely (one attempt, return
+immediately):
+
+```rust
+let exists = driver.query(By::Id("maybe")).nowait().exists().await?;
+```
+
+The default poller is 20 seconds with 500ms intervals. To change it for
+the whole `WebDriver`, supply a custom `WebDriverConfig` — see
+[`ElementPollerWithTimeout`] in the API docs.
+
+## Better Error Messages
+
+Attach a human-readable description so timeout errors say what you were
+looking for:
+
+```rust
+let cart = driver
+    .query(By::Css("[data-cart-count]"))
+    .desc("shopping cart badge")
+    .first()
+    .await?;
+```
+
+If the query times out, the error includes `"shopping cart badge"`
+instead of just the raw CSS selector.
+
+## When To Use `find()` / `find_all()`
+
+Almost never. They exist for spec parity and for the rare case where
+you genuinely want a one-shot lookup with no polling. Anywhere a
+flickering DOM, an in-flight network request, or a slow load could
+matter, `query()` is more reliable and gives better diagnostics.
+
+## API Reference
+
+For the full method list and per-method semantics, see
+[`ElementQuery`](https://docs.rs/thirtyfour/latest/thirtyfour/extensions/query/struct.ElementQuery.html)
+on docs.rs.

--- a/docs/src/features/queries.md
+++ b/docs/src/features/queries.md
@@ -4,12 +4,13 @@
 The `find()` and `find_all()` methods in both `WebDriver` and `WebElement` provide a simple
 way to perform direct element queries, returning a result instantly.
 
-However, for many types of queries, these methods are inadequate. For example, there is no polling, 
+However, for many types of queries, these methods are inadequate. For example, there is no polling,
 and no way to wait for something to show up on a page.
 If an element doesn't exist at the instant you look for it, you'll get an error.
 
-This isn't helpful for the majority of element queries, so `thirtyfour` provides a 
-more advanced query interface, called `ElementQuery`.
+This isn't helpful for the majority of element queries, so `thirtyfour` provides a
+more powerful query interface, called `ElementQuery`.
+We recommend using this query interface instead of the `find*()` methods.
 
 ## ElementQuery
 

--- a/docs/src/features/waiting.md
+++ b/docs/src/features/waiting.md
@@ -1,28 +1,143 @@
 # Waiting For Element Changes
 
-Sometimes you already have a reference to an element, but you want to perform an action that
-might change the element in some way. One way to do this would be to call `WebDriver::query()`
-and poll for the element with its new attributes. But it might be challenging to get the right
-query, and the query might return a different element that already has the attribute you specified.
-
-If you already have a reference to the element, why not use that to poll for the changes you expect?
-
-The `thirtyfour` crate provides a way to wait for virtually any desired change on an existing element.
-It's called `ElementWaiter`.
-
-## ElementWaiter
-
-The `WebElement::wait_until()` method returns an `ElementWaiter` struct.
-
-Using `ElementWaiter` you can do things like this:
+`ElementQuery` waits for an element to *appear*. `ElementWaiter` waits
+for an element you already have to reach a particular state — visible,
+clickable, gone, with certain text, etc. Reach for it whenever you've
+clicked something and need the page to settle before you continue.
 
 ```rust
-elem.wait_until().displayed().await?;
-// You can optionally provide a nicer error message like this.
-elem.wait_until().error("Timed out waiting for element to disappear").not_displayed().await?;
-
-elem.wait_until().enabled().await?;
-elem.wait_until().clickable().await?;
+let button = driver.query(By::Css(".save")).single().await?;
+button.click().await?;
+button.wait_until().not_displayed().await?;
 ```
 
-And so on. See the [ElementWaiter](https://docs.rs/thirtyfour/latest/thirtyfour/extensions/query/struct.ElementWaiter.html) docs for more details.
+`wait_until()` is available on every `WebElement`. It returns an
+`ElementWaiter` that polls the element until either a predicate
+matches or the timeout elapses.
+
+## Built-In Predicates
+
+State predicates polled directly via WebDriver:
+
+| Method                      | Waits until the element is...                |
+| --------------------------- | -------------------------------------------- |
+| `.displayed().await?`       | rendered (`isDisplayed` returns `true`)      |
+| `.not_displayed().await?`   | hidden                                       |
+| `.enabled().await?`         | not disabled                                 |
+| `.not_enabled().await?`     | disabled                                     |
+| `.selected().await?`        | selected (checkboxes, options, radios)       |
+| `.not_selected().await?`    | deselected                                   |
+| `.clickable().await?`       | both displayed and enabled                   |
+| `.not_clickable().await?`   | hidden or disabled                           |
+| `.stale().await?`           | detached from the DOM                        |
+
+`.stale()` is especially useful right after a click — it lets you wait
+for the element you just acted on to disappear before assuming the
+next page is loaded.
+
+## Text, Class, Attribute, Property Waits
+
+Each of these takes a `Needle` (from the
+[`stringmatch`](https://crates.io/crates/stringmatch) crate) — a plain
+`&str` for exact match, or a `StringMatch` for partial /
+case-insensitive / word-boundary matches.
+
+| Method                           | Waits until...                          |
+| -------------------------------- | --------------------------------------- |
+| `.has_text(needle)`              | the element's text matches              |
+| `.lacks_text(needle)`            | the element's text does *not* match     |
+| `.has_class("name")`             | the element's class list contains it    |
+| `.lacks_class("name")`           | the class is no longer present          |
+| `.has_value(needle)`             | the input's value matches               |
+| `.lacks_value(needle)`           | the input's value no longer matches     |
+| `.has_attribute(name, needle)`   | a single attribute matches              |
+| `.lacks_attribute(name, needle)` | a single attribute no longer matches    |
+| `.has_attributes([...])`         | several attributes match together       |
+| `.lacks_attributes([...])`       | none of those attributes match          |
+| `.has_property(name, needle)`    | a JS property matches                   |
+| `.lacks_property(name, needle)`  | a JS property does not match            |
+| `.has_properties([...])`         | several properties match together       |
+| `.lacks_properties([...])`       | none of those properties match          |
+| `.has_css_property(name, needle)`   | a computed CSS property matches      |
+| `.lacks_css_property(name, needle)` | a computed CSS property does not match |
+| `.has_css_properties([...])`     | several CSS properties match together   |
+| `.lacks_css_properties([...])`   | none of those CSS properties match      |
+
+```rust
+use thirtyfour::stringmatch::StringMatchable;
+
+elem.wait_until()
+    .has_text("Order received".match_partial().case_insensitive())
+    .await?;
+```
+
+## Custom Timeouts And Error Messages
+
+Override the poll cadence on a single wait:
+
+```rust
+use std::time::Duration;
+
+elem.wait_until()
+    .wait(Duration::from_secs(60), Duration::from_secs(1))
+    .clickable()
+    .await?;
+```
+
+Attach a custom error message so a timeout reads in plain English:
+
+```rust
+elem.wait_until()
+    .error("Timed out waiting for the spinner to disappear")
+    .stale()
+    .await?;
+```
+
+## Custom Predicates
+
+For anything the built-ins don't cover, pass your own predicate. It
+gets a `&WebElement` and returns `WebDriverResult<bool>`:
+
+```rust
+elem.wait_until()
+    .condition(|elem| async move {
+        let value = elem.value().await?.unwrap_or_default();
+        Ok(value.parse::<u32>().map_or(false, |n| n > 100))
+    })
+    .await?;
+```
+
+Pre-built predicate constructors live in the
+[`thirtyfour::extensions::query::conditions`](https://docs.rs/thirtyfour/latest/thirtyfour/extensions/query/conditions/index.html)
+module. They share the same shape, so you can compose several into
+one wait:
+
+```rust
+use thirtyfour::extensions::query::conditions;
+
+elem.wait_until()
+    .conditions(vec![
+        conditions::element_is_displayed(true),
+        conditions::element_is_clickable(true),
+    ])
+    .await?;
+```
+
+The `conditions` module is also useful as a source of filter functions
+for `ElementQuery::with_filter()`.
+
+## When To Reach For Which
+
+- **Looking for an element on the page?** Use [`ElementQuery`](./queries.md).
+- **Already have an element and waiting for it to change?** Use
+  `ElementWaiter` (this chapter).
+- **Waiting for an element to disappear?** Either works.
+  `query(...).not_exists()` polls until the selector returns nothing;
+  `elem.wait_until().stale()` polls until *that specific element* is
+  detached.
+
+## API Reference
+
+For the full method list, see
+[`ElementWaiter`](https://docs.rs/thirtyfour/latest/thirtyfour/extensions/query/struct.ElementWaiter.html)
+on docs.rs.

--- a/docs/src/getting-started/explaining-the-code.md
+++ b/docs/src/getting-started/explaining-the-code.md
@@ -31,6 +31,11 @@ The session opens the browser in a new profile (so it won't add anything to your
 history etc.) and navigates to the default start page. When the last `WebDriver`
 handle drops, the browser closes and the driver subprocess is torn down with it.
 
+See [WebDriver Manager](../features/manager.md) for everything else the manager
+can do — pinning a specific driver version, sharing one manager across many
+sessions, supplying a pre-installed driver binary, and observing what's
+happening as the manager works.
+
 > If you'd rather run the webdriver yourself — for example to point `thirtyfour` at a
 > remote Selenium grid — see [Manual WebDriver Setup](../appendix/manual-webdriver.md)
 > in the Appendix. The remaining sections work the same either way.

--- a/docs/src/getting-started/explaining-the-code.md
+++ b/docs/src/getting-started/explaining-the-code.md
@@ -18,13 +18,22 @@ running, `thirtyfour` can do just about anything a human can do in a web browser
 So let's go through the code and see what is going on.
 
 ```rust
-    let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
 ```
 
-This is where we actually make the initial connection to the webdriver and start a new
-session in the web browser. This will open the browser in a new profile (so it won't add
-anything to your history etc.) and navigate to the default start page.
+This single line does a lot of work for you:
+
+1. Picks a `chromedriver` version that matches your installed Chrome (downloading and caching the binary the first time, reusing it after).
+2. Spawns it as a child process on a free local port and waits for it to be ready.
+3. Connects to it and starts a new browser session.
+
+The session opens the browser in a new profile (so it won't add anything to your
+history etc.) and navigates to the default start page. When the last `WebDriver`
+handle drops, the browser closes and the driver subprocess is torn down with it.
+
+> If you'd rather run the webdriver yourself — for example to point `thirtyfour` at a
+> remote Selenium grid — see [Manual WebDriver Setup](../appendix/manual-webdriver.md)
+> in the Appendix. The remaining sections work the same either way.
 
 ## Capabilities
 
@@ -32,12 +41,6 @@ The way we tell it what browser we want is by using `DesiredCapabilities`. In th
 we construct a new `ChromeCapabilities` instance. Each `*Capabilities` struct will have
 additional helper methods for setting options like headless mode, proxy, and so on.
 See the [documentation](https://docs.rs/thirtyfour/latest/thirtyfour/common/capabilities/chrome/struct.ChromeCapabilities.html) for more details.
-
-> You may have heard of `selenium`. `Selenium` is simply a proxy that forwards requests to one or
-> more webdriver servers. Using `Selenium` you can interact with multiple browsers at once. You simply
-> tell `Selenium` where each of the webdrivers are, and some details of each browser, and then in your
-> code you give `thirtyfour` the address of the selenium server, not the webdriver, and use the
-> `DesiredCapabilities` to request a particular browser.
 
 ## Element Queries
 

--- a/docs/src/getting-started/feature-flags.md
+++ b/docs/src/getting-started/feature-flags.md
@@ -3,5 +3,6 @@
 - `rustls-tls`: (Default) Use rustls to provide TLS support (via reqwest).
 - `native-tls`: Use native TLS (via reqwest).
 - `component`: (Default) Enable the `Component` derive macro (via thirtyfour_macros).
-- `manager`: (Default) Enable [`WebDriver::managed`](../features/manager.md), which auto-downloads
-  and lifetime-manages the appropriate webdriver subprocess. See [Managed WebDriver](../features/manager.md).
+- `manager`: (Default) Automatic webdriver download and process management.
+  Disable this if you'd rather manage the webdriver yourself — see
+  [Manual WebDriver Setup](../appendix/manual-webdriver.md).

--- a/docs/src/getting-started/feature-flags.md
+++ b/docs/src/getting-started/feature-flags.md
@@ -3,6 +3,7 @@
 - `rustls-tls`: (Default) Use rustls to provide TLS support (via reqwest).
 - `native-tls`: Use native TLS (via reqwest).
 - `component`: (Default) Enable the `Component` derive macro (via thirtyfour_macros).
-- `manager`: (Default) Automatic webdriver download and process management.
-  Disable this if you'd rather manage the webdriver yourself — see
+- `manager`: (Default) Automatic webdriver download and process management;
+  see [WebDriver Manager](../features/manager.md). Disable this if you'd
+  rather manage the webdriver yourself — see
   [Manual WebDriver Setup](../appendix/manual-webdriver.md).

--- a/docs/src/getting-started/feature-flags.md
+++ b/docs/src/getting-started/feature-flags.md
@@ -3,3 +3,5 @@
 - `rustls-tls`: (Default) Use rustls to provide TLS support (via reqwest).
 - `native-tls`: Use native TLS (via reqwest).
 - `component`: (Default) Enable the `Component` derive macro (via thirtyfour_macros).
+- `manager`: (Default) Enable [`WebDriver::managed`](../features/manager.md), which auto-downloads
+  and lifetime-manages the appropriate webdriver subprocess. See [Managed WebDriver](../features/manager.md).

--- a/docs/src/getting-started/first-code.md
+++ b/docs/src/getting-started/first-code.md
@@ -66,7 +66,9 @@ navigate to the "Selenium" article on Wikipedia, and then close again.
 
 The first run will take a few seconds longer than subsequent runs — `thirtyfour`
 downloads a matching `chromedriver` into your system cache directory the first time,
-then reuses it on every later run.
+then reuses it on every later run. See [WebDriver Manager](../features/manager.md)
+for the version-pinning, offline-mode, and observability options that the manager
+provides.
 
 ## Running on Firefox
 

--- a/docs/src/getting-started/first-code.md
+++ b/docs/src/getting-started/first-code.md
@@ -30,8 +30,8 @@ use thirtyfour::prelude::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
-    let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
+
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;
     let elem_form = driver.find(By::Id("search-form")).await?;
@@ -57,37 +57,26 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 }
 ```
 
-Next we need to make sure our webdriver is running.
-
-Open your terminal application and run:
-
-    chromedriver
-
-> **NOTE:** This tutorial is currently set up for Chrome.
-> If you'd prefer to run on Firefox instead, this is explained below.
-
-Now open a new tab in your terminal and run your code:
+Make sure Chrome is installed, then run:
 
     cargo run
 
 If everything worked correctly you should have seen a Chrome browser window open up,
 navigate to the "Selenium" article on Wikipedia, and then close again.
 
+The first run will take a few seconds longer than subsequent runs — `thirtyfour`
+downloads a matching `chromedriver` into your system cache directory the first time,
+then reuses it on every later run.
+
 ## Running on Firefox
 
-To run the code using Firefox instead, we first need to tell `thirtyfour` to use the 
-configuration for Firefox. To do this, change the first to lines of your `main` function to this:
+To run the code using Firefox instead, change the capabilities in `main`:
 
 ```rust
-    let caps = DesiredCapabilities::firefox();
-    let driver = WebDriver::new("http://localhost:4444", caps).await?;
+    let driver = WebDriver::managed(DesiredCapabilities::firefox()).await?;
 ```
 
-Now, instead of running `chromedriver` in your terminal, we'll run `geckodriver` instead:
-
-    geckodriver
-
-And again, in the other tab, run your code again:
+Make sure Firefox is installed, and re-run:
 
     cargo run
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,21 +1,17 @@
 # Installation
 
-To use the `thirtyfour` crate in your Rust project, you need to add it as a dependency in your `Cargo.toml` file:
+Add `thirtyfour` as a dependency in your `Cargo.toml`:
 
     [dependencies]
     thirtyfour = "THIRTYFOUR_CRATE_VERSION"
 
-To automate a web browser, `thirtyfour` needs to communicate with a webdriver
-server (`chromedriver`, `geckodriver`, etc.). With the default feature set
-this is taken care of for you: the [Managed WebDriver](../features/manager.md)
-feature auto-downloads a compatible driver for your locally-installed browser,
-caches it, and runs it as a child process for the lifetime of your `WebDriver`
-handle. You don't need to download or start anything yourself.
+You'll also need the corresponding web browser (Chrome, Firefox, Edge,
+or Safari on macOS) installed in your operating system. `thirtyfour`
+handles the webdriver itself — it auto-downloads a compatible
+`chromedriver` / `geckodriver` / `msedgedriver` for your installed
+browser, runs it as a child process, and tears it down with your code.
 
-You will still need the corresponding web browser (Chrome, Firefox, Edge, or
-Safari on macOS) to be installed in your operating system.
-
-> If you'd rather download and run a webdriver yourself — for example, to point
-> `thirtyfour` at a remote Selenium grid, or because you've disabled the
-> `manager` feature — see
-> [Manual WebDriver Setup](../appendix/manual-webdriver.md) in the Appendix.
+> Want to run the webdriver yourself instead — for example, to point
+> `thirtyfour` at a remote Selenium grid? See
+> [Manual WebDriver Setup](../appendix/manual-webdriver.md) in the
+> Appendix.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -5,17 +5,17 @@ To use the `thirtyfour` crate in your Rust project, you need to add it as a depe
     [dependencies]
     thirtyfour = "THIRTYFOUR_CRATE_VERSION"
 
-To automate a web browser, `thirtyfour` needs to communicate with a webdriver server. You will need
-to download the appropriate webdriver server for your browser.
+To automate a web browser, `thirtyfour` needs to communicate with a webdriver
+server (`chromedriver`, `geckodriver`, etc.). With the default feature set
+this is taken care of for you: the [Managed WebDriver](../features/manager.md)
+feature auto-downloads a compatible driver for your locally-installed browser,
+caches it, and runs it as a child process for the lifetime of your `WebDriver`
+handle. You don't need to download or start anything yourself.
 
-* For Chrome, download [chromedriver](https://developer.chrome.com/docs/chromedriver/downloads)
-* For Firefox, download [geckodriver](https://github.com/mozilla/geckodriver/releases)
+You will still need the corresponding web browser (Chrome, Firefox, Edge, or
+Safari on macOS) to be installed in your operating system.
 
-The webdriver may be zipped. Unzip it and place the webdriver binary somewhere in your `PATH`.
-Make sure it is executable and that you have permissions to run it.
-
-You will also need the corresponding web browser to be installed in your Operating System.
-Make sure the webdriver version you download corresponds to the version of the browser you have installed.
-
-> If the webdriver is not the right version for your browser, it will show an error message when
-> you try to start a new session using `thirtyfour`.
+> If you'd rather download and run a webdriver yourself — for example, to point
+> `thirtyfour` at a remote Selenium grid, or because you've disabled the
+> `manager` feature — see
+> [Manual WebDriver Setup](../appendix/manual-webdriver.md) in the Appendix.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -10,6 +10,8 @@ or Safari on macOS) installed in your operating system. `thirtyfour`
 handles the webdriver itself — it auto-downloads a compatible
 `chromedriver` / `geckodriver` / `msedgedriver` for your installed
 browser, runs it as a child process, and tears it down with your code.
+See [WebDriver Manager](../features/manager.md) for the details and
+configuration options.
 
 > Want to run the webdriver yourself instead — for example, to point
 > `thirtyfour` at a remote Selenium grid? See

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -25,5 +25,5 @@ Thirty-four (34) is the atomic number for the Selenium chemical element (Se) ⚛
 - Alert support
 - Capture / Save screenshot of browser or individual element as PNG
 - Chrome DevTools Protocol (CDP) support (limited)
-- [Advanced query interface](./features/queries.md) including explicit waits and various predicates
+- [Powerful query interface](./features/queries.md) (the recommended way to find elements) with explicit waits and various predicates
 - [Component](./features/components.md) Wrappers (similar to `Page Object Model`)

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -3,8 +3,8 @@
 Welcome to The Book for `thirtyfour`.
 
 `thirtyfour` is a crate for automating Web Browsers in Rust using the `WebDriver` / `Selenium` ecosystem.
-It also provides some support for the `Chrome DevTools Protocol`, which is used by popular frameworks
-such as Cypress and Playwright.
+It also provides some support for the `Chrome DevTools Protocol` — the lower-level inspection and
+control API that Chromium-based browsers expose for debugging, profiling, and automation.
 
 ## Why is it called "thirtyfour" ?
 

--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -102,10 +102,14 @@ tempfile = "3"
 
 [[example]]
 name = "tokio_async"
+required-features = ["manager"]
 
 [[example]]
 name = "tokio_basic"
+required-features = ["manager"]
 
+# Specifically about pointing thirtyfour at a Selenium server, so it does
+# *not* use WebDriver::managed.
 [[example]]
 name = "selenium_example"
 
@@ -114,26 +118,41 @@ name = "minimal_async"
 required-features = ["manager"]
 
 [[example]]
+name = "driver_logging"
+required-features = ["manager"]
+
+[[example]]
 name = "chrome_devtools"
+required-features = ["manager"]
 
 [[example]]
 name = "chrome_options"
+required-features = ["manager"]
+
+[[example]]
+name = "remote_debugging"
+required-features = ["manager"]
 
 [[example]]
 name = "wikipedia"
 path = "examples/query/wikipedia.rs"
+required-features = ["manager"]
 
 [[example]]
 name = "custom_poller"
 path = "examples/query/custom_poller.rs"
+required-features = ["manager"]
 
 [[example]]
 name = "firefox_preferences"
 path = "examples/firefox_preferences.rs"
+required-features = ["manager"]
 
 [[example]]
 name = "shadowroot"
+required-features = ["manager"]
 
 [[example]]
 name = "playground"
 path = "examples/components/playground.rs"
+required-features = ["manager"]

--- a/thirtyfour/README.md
+++ b/thirtyfour/README.md
@@ -23,7 +23,7 @@ Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI 
 - Alert support
 - Capture / Save screenshot of browser or individual element as PNG
 - Chrome DevTools Protocol (CDP) support (limited)
-- Advanced query interface including explicit waits and various predicates
+- Powerful query interface (the recommended way to find elements) with explicit waits and various predicates
 - Component Wrappers (similar to `Page Object Model`)
 
 ## Feature Flags

--- a/thirtyfour/examples/chrome_devtools.rs
+++ b/thirtyfour/examples/chrome_devtools.rs
@@ -1,6 +1,9 @@
 //! Run as follows:
 //!
 //!     cargo run --example chrome_devtools
+//!
+//! Uses `WebDriver::managed` (default `manager` feature), which auto-downloads
+//! the matching `chromedriver` for your installed Chrome and starts it locally.
 
 use thirtyfour::extensions::cdp::{ChromeDevTools, NetworkConditions};
 use thirtyfour::prelude::*;
@@ -11,8 +14,7 @@ async fn main() -> color_eyre::Result<()> {
     // it much easier to locate where the error occurred.
     color_eyre::install()?;
 
-    let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
 
     // Use Chrome Devtools Protocol (CDP).
     let dev_tools = ChromeDevTools::new(driver.handle.clone());

--- a/thirtyfour/examples/chrome_options.rs
+++ b/thirtyfour/examples/chrome_options.rs
@@ -1,6 +1,9 @@
 //! Run as follows:
 //!
 //!     cargo run --example chrome_options
+//!
+//! Uses `WebDriver::managed` (default `manager` feature), which auto-downloads
+//! the matching `chromedriver` for your installed Chrome and starts it locally.
 
 use thirtyfour::prelude::*;
 
@@ -20,7 +23,7 @@ async fn main() -> color_eyre::Result<()> {
             }
         }),
     )?;
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let driver = WebDriver::managed(caps).await?;
 
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;

--- a/thirtyfour/examples/components/playground.rs
+++ b/thirtyfour/examples/components/playground.rs
@@ -1,6 +1,9 @@
 //! Run as follows:
 //!
-//!     cargo run --example wikipedia
+//!     cargo run --example playground
+//!
+//! Uses `WebDriver::managed` (default `manager` feature), which auto-downloads
+//! the matching `chromedriver` for your installed Chrome and starts it locally.
 
 use std::time::Duration;
 
@@ -16,8 +19,7 @@ use thirtyfour::{
 async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
-    let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
     driver.goto("https://play.rust-lang.org").await?;
 
     let base_elem = driver.query(By::Id("playground")).single().await?;

--- a/thirtyfour/examples/firefox_preferences.rs
+++ b/thirtyfour/examples/firefox_preferences.rs
@@ -1,6 +1,9 @@
 //! Run as follows:
 //!
 //!     cargo run --example firefox_preferences
+//!
+//! Uses `WebDriver::managed` (default `manager` feature), which auto-downloads
+//! a matching `geckodriver` for your installed Firefox and starts it locally.
 
 use thirtyfour::common::capabilities::firefox::FirefoxPreferences;
 use thirtyfour::{FirefoxCapabilities, WebDriver};
@@ -20,7 +23,7 @@ async fn main() -> color_eyre::Result<()> {
     let mut caps = FirefoxCapabilities::new();
     caps.set_preferences(prefs)?;
 
-    let driver = WebDriver::new("http://localhost:4444", caps).await?;
+    let driver = WebDriver::managed(caps).await?;
     driver.goto("https://www.google.com").await?;
 
     // Get the user agent and verify.

--- a/thirtyfour/examples/query/custom_poller.rs
+++ b/thirtyfour/examples/query/custom_poller.rs
@@ -1,10 +1,9 @@
-//! Requires chromedriver running on port 9515:
-//!
-//!     chromedriver --port=9515
-//!
 //! Run as follows:
 //!
 //!     cargo run --example custom_poller
+//!
+//! Uses `WebDriver::managed` (default `manager` feature), which auto-downloads
+//! the matching `chromedriver` for your installed Chrome and starts it locally.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -17,8 +16,7 @@ use thirtyfour::prelude::*;
 async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
-    let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
 
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;

--- a/thirtyfour/examples/query/wikipedia.rs
+++ b/thirtyfour/examples/query/wikipedia.rs
@@ -1,6 +1,9 @@
 //! Run as follows:
 //!
 //!     cargo run --example wikipedia
+//!
+//! Uses `WebDriver::managed` (default `manager` feature), which auto-downloads
+//! the matching `chromedriver` for your installed Chrome and starts it locally.
 
 use thirtyfour::prelude::*;
 
@@ -8,8 +11,7 @@ use thirtyfour::prelude::*;
 async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
-    let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
 
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;

--- a/thirtyfour/examples/remote_debugging.rs
+++ b/thirtyfour/examples/remote_debugging.rs
@@ -1,10 +1,18 @@
-//! Requires chromedriver running on port 9515:
+//! Attach to an already-running Chrome that was launched with the
+//! `--remote-debugging-port` flag.
+//!
+//! Launch Chrome first:
 //!
 //!     chrome --remote-debugging-port=9222 --user-data-dir="C:\Users\username\my-browser-profile\"
 //!
-//! Run as follows:
+//! Then run as follows:
 //!
 //!     cargo run --example remote_debugging
+//!
+//! Uses `WebDriver::managed` (default `manager` feature), which auto-downloads
+//! a matching `chromedriver` and starts it locally; the capabilities below tell
+//! `chromedriver` to attach to the Chrome listening on the debugger port
+//! instead of launching a new one.
 
 use thirtyfour::prelude::*;
 
@@ -12,7 +20,7 @@ use thirtyfour::prelude::*;
 async fn main() -> color_eyre::Result<()> {
     let mut caps = DesiredCapabilities::chrome();
     caps.set_debugger_address("localhost:9222")?;
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let driver = WebDriver::managed(caps).await?;
     driver.goto("https://www.baidu.com").await?;
     Ok(())
 }

--- a/thirtyfour/examples/shadowroot.rs
+++ b/thirtyfour/examples/shadowroot.rs
@@ -1,6 +1,9 @@
 //! Run as follows:
 //!
 //!     cargo run --example shadowroot
+//!
+//! Uses `WebDriver::managed` (default `manager` feature), which auto-downloads
+//! the matching `chromedriver` for your installed Chrome and starts it locally.
 
 use thirtyfour::prelude::*;
 
@@ -11,8 +14,7 @@ async fn main() -> color_eyre::Result<()> {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
 
-    let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
 
     // Navigate to website containing example shadowroot.
     driver.goto("https://web.dev/shadowdom-v1/").await?;

--- a/thirtyfour/examples/tokio_async.rs
+++ b/thirtyfour/examples/tokio_async.rs
@@ -1,6 +1,9 @@
 //! Run as follows:
 //!
 //!     cargo run --example tokio_async
+//!
+//! Uses `WebDriver::managed` (default `manager` feature), which auto-downloads
+//! the matching `chromedriver` for your installed Chrome and starts it locally.
 
 use thirtyfour::prelude::*;
 
@@ -10,8 +13,7 @@ async fn main() -> color_eyre::Result<()> {
     // it much easier to locate where the error occurred.
     color_eyre::install()?;
 
-    let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;
     let elem_form = driver.find(By::Id("search-form")).await?;

--- a/thirtyfour/examples/tokio_basic.rs
+++ b/thirtyfour/examples/tokio_basic.rs
@@ -1,6 +1,9 @@
 //! Run as follows:
 //!
-//!     cargo run --example tokio_async
+//!     cargo run --example tokio_basic
+//!
+//! Uses `WebDriver::managed` (default `manager` feature), which auto-downloads
+//! the matching `chromedriver` for your installed Chrome and starts it locally.
 
 use thirtyfour::prelude::*;
 
@@ -14,8 +17,7 @@ async fn run() -> color_eyre::Result<()> {
     // it much easier to locate where the error occurred.
     color_eyre::install()?;
 
-    let caps = DesiredCapabilities::chrome();
-    let driver = WebDriver::new("http://localhost:9515", caps).await?;
+    let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;
     let elem_form = driver.find(By::Id("search-form")).await?;

--- a/thirtyfour/src/extensions/query/mod.rs
+++ b/thirtyfour/src/extensions/query/mod.rs
@@ -1,4 +1,5 @@
-//! Advanced query interface featuring powerful filtering and polling options.
+//! Powerful query interface featuring filtering and polling options. This is
+//! the recommended way to find elements in `thirtyfour`.
 //!
 //! See examples for more details.
 //!

--- a/thirtyfour/src/lib.rs
+++ b/thirtyfour/src/lib.rs
@@ -24,7 +24,7 @@
 //! - Alert support
 //! - Capture / Save screenshot of browser or individual element as PNG
 //! - Some Chrome DevTools Protocol (CDP) support
-//! - Advanced query interface including explicit waits and various predicates
+//! - Powerful query interface (the recommended way to find elements) with explicit waits and various predicates
 //! - Component Wrappers (similar to `Page Object Model`)
 //!
 //! ## Feature Flags
@@ -83,14 +83,15 @@
 //! while quiting. you can use the feature `debug_sync_quit` to get a backtrace printed if your webdriver ever
 //! quits synchronously
 //!
-//! ### Advanced element queries and explicit waits
+//! ### Element queries and explicit waits
 //!
-//! You can use [`WebDriver::query`] to perform more advanced queries
-//! including polling and filtering. Custom filter functions are also supported.
+//! [`WebDriver::query`] is the recommended way to find elements. It polls
+//! until the element appears, supports filtering and chained alternatives,
+//! and produces clearer error messages when nothing matches. Custom filter
+//! functions are also supported.
 //!
-//! Also, the [`WebElement::wait_until`] method provides additional support for explicit waits
-//! using a variety of built-in predicates. You can also provide your own custom predicate if
-//! desired.
+//! The [`WebElement::wait_until`] method provides explicit waits using a
+//! variety of built-in predicates, plus an escape hatch for custom predicates.
 //!
 //! See the [`query`] documentation for more details and examples.
 //!

--- a/thirtyfour/src/manager/manager.rs
+++ b/thirtyfour/src/manager/manager.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::future::{Future, IntoFuture};
 use std::net::{IpAddr, Ipv4Addr};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, OnceLock, Weak};
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use serde_json::Value;
@@ -41,17 +41,12 @@ fn default_cache_dir() -> PathBuf {
     dirs::cache_dir().unwrap_or_else(std::env::temp_dir).join("thirtyfour").join("drivers")
 }
 
-/// Process-wide default manager.
-fn shared_manager() -> &'static Arc<WebDriverManager> {
-    static SHARED: OnceLock<Arc<WebDriverManager>> = OnceLock::new();
-    SHARED.get_or_init(|| WebDriverManager::builder().build())
-}
-
 /// Auto-download and lifetime-managed local WebDriver process manager.
 ///
-/// See the [module documentation](super) for the high-level usage; the most
-/// common entry points are [`WebDriver::managed`] (one-shot) and
-/// [`WebDriverManager::builder`] (for sharing one manager across many sessions).
+/// See the [module documentation](super) for the high-level usage. The two
+/// common entry points are [`WebDriver::managed`] (one-shot, fresh manager
+/// per call) and [`WebDriverManager::builder`] (for sharing one manager
+/// across many sessions).
 ///
 /// [`WebDriver::managed`]: crate::WebDriver::managed
 pub struct WebDriverManager {
@@ -86,6 +81,10 @@ pub(crate) struct ResolvedConfig {
     pub offline: bool,
     pub mirror: Mirror,
     pub stdio: StdioMode,
+    /// Per-browser driver-binary overrides. When a browser appears here,
+    /// `ensure_driver` skips download/cache and spawns the supplied binary
+    /// directly.
+    pub driver_paths: HashMap<BrowserKind, PathBuf>,
 }
 
 impl std::fmt::Debug for ResolvedConfig {
@@ -98,6 +97,7 @@ impl std::fmt::Debug for ResolvedConfig {
             .field("ready_timeout", &self.ready_timeout)
             .field("offline", &self.offline)
             .field("stdio", &self.stdio)
+            .field("driver_paths", &self.driver_paths)
             .finish_non_exhaustive()
     }
 }
@@ -161,6 +161,9 @@ pub struct WebDriverManagerBuilder {
     pub(crate) offline: Option<bool>,
     pub(crate) mirror: Option<Mirror>,
     pub(crate) stdio: Option<StdioMode>,
+    /// Per-browser driver-binary overrides registered via
+    /// [`WebDriverManagerBuilder::driver_binary`].
+    pub(crate) driver_paths: HashMap<BrowserKind, PathBuf>,
     /// Status subscribers registered before `build`.
     pub(crate) status_subscribers: Vec<StatusCallback>,
     /// Driver-log subscribers registered before `build`.
@@ -179,6 +182,7 @@ impl std::fmt::Debug for WebDriverManagerBuilder {
             .field("ready_timeout", &self.ready_timeout)
             .field("offline", &self.offline)
             .field("stdio", &self.stdio)
+            .field("driver_paths", &self.driver_paths)
             .field("status_subscribers", &self.status_subscribers.len())
             .field("log_subscribers", &self.log_subscribers.len())
             .finish_non_exhaustive()
@@ -196,6 +200,7 @@ impl Clone for WebDriverManagerBuilder {
             offline: self.offline,
             mirror: self.mirror.clone(),
             stdio: self.stdio,
+            driver_paths: self.driver_paths.clone(),
             status_subscribers: self.status_subscribers.iter().map(Arc::clone).collect(),
             log_subscribers: self.log_subscribers.iter().map(Arc::clone).collect(),
             preloaded_caps: self.preloaded_caps.clone(),
@@ -300,14 +305,37 @@ impl WebDriverManagerBuilder {
         self
     }
 
+    /// Use an already-installed driver binary at `path` for the given
+    /// browser instead of resolving and downloading one. Skips the
+    /// version-resolution and download/cache flow entirely; the binary is
+    /// spawned as-is. Bare command names (e.g. `"chromedriver"`) are
+    /// resolved against the OS `PATH`.
+    ///
+    /// This is intended for environments that ship their own driver — CI
+    /// images with pinned binaries, sandboxes with no network access, or
+    /// users who simply prefer to manage driver versions themselves. If
+    /// the binary doesn't match the installed browser's version, expect a
+    /// runtime error from the driver when the session is started.
+    ///
+    /// Call once per browser to override drivers for a multi-browser
+    /// manager:
+    ///
+    /// ```no_run
+    /// # use thirtyfour::manager::{WebDriverManager, BrowserKind};
+    /// let mgr = WebDriverManager::builder()
+    ///     .driver_binary(BrowserKind::Chrome, "/usr/local/bin/chromedriver")
+    ///     .driver_binary(BrowserKind::Firefox, "/usr/local/bin/geckodriver")
+    ///     .build();
+    /// ```
+    pub fn driver_binary(mut self, browser: BrowserKind, path: impl Into<PathBuf>) -> Self {
+        self.driver_paths.insert(browser, path.into());
+        self
+    }
+
     /// Register a closure to receive every [`Status`] event emitted by the
     /// resulting manager. Equivalent to calling
     /// [`WebDriverManager::subscribe`] right after `build`, except the
     /// subscriber is attached for the manager's whole lifetime — not removable.
-    ///
-    /// Registering at least one subscriber via this method opts out of the
-    /// process-wide shared singleton (see [`WebDriverManager::shared`]) so the
-    /// subscriber doesn't leak across calls of unrelated callers.
     pub fn on_status<F>(mut self, f: F) -> Self
     where
         F: Fn(&Status) + Send + Sync + 'static,
@@ -321,9 +349,6 @@ impl WebDriverManagerBuilder {
     /// [`WebDriverManager::on_driver_log`] applied right after `build`, except
     /// the subscriber is attached for the manager's whole lifetime — not
     /// removable.
-    ///
-    /// Registering at least one subscriber via this method opts out of the
-    /// shared singleton.
     pub fn on_driver_log<F>(mut self, f: F) -> Self
     where
         F: Fn(&DriverLogLine) + Send + Sync + 'static,
@@ -343,6 +368,7 @@ impl WebDriverManagerBuilder {
             offline: self.offline.unwrap_or(false),
             mirror: self.mirror.unwrap_or_default(),
             stdio: self.stdio.unwrap_or_default(),
+            driver_paths: self.driver_paths,
         };
         let emitter = Emitter::new();
         for cb in self.status_subscribers {
@@ -364,22 +390,6 @@ impl WebDriverManagerBuilder {
             next_driver_id: Arc::new(AtomicU64::new(0)),
         })
     }
-
-    /// `true` if every configuration field is at its default. Lets
-    /// `WebDriver::managed` route through the process-wide shared manager when
-    /// the user hasn't overridden anything.
-    fn is_all_defaults(&self) -> bool {
-        self.version == DriverVersion::default()
-            && self.cache_dir.is_none()
-            && self.host.is_none()
-            && self.download_timeout.is_none()
-            && self.ready_timeout.is_none()
-            && self.offline.is_none()
-            && self.mirror.is_none()
-            && self.stdio.is_none()
-            && self.status_subscribers.is_empty()
-            && self.log_subscribers.is_empty()
-    }
 }
 
 impl IntoFuture for WebDriverManagerBuilder {
@@ -392,12 +402,7 @@ impl IntoFuture for WebDriverManagerBuilder {
                 .preloaded_caps
                 .clone()
                 .ok_or_else(|| WebDriverError::from(ManagerError::NoCapabilities))?;
-            let mgr = if self.is_all_defaults() {
-                Arc::clone(shared_manager())
-            } else {
-                self.build()
-            };
-            mgr.launch(caps).await
+            self.build().launch(caps).await
         })
     }
 }
@@ -406,14 +411,6 @@ impl WebDriverManager {
     /// Construct an empty builder.
     pub fn builder() -> WebDriverManagerBuilder {
         WebDriverManagerBuilder::default()
-    }
-
-    /// Process-wide default manager. Used by [`WebDriver::managed`] when no
-    /// configuration is supplied. Multiple calls return the same `Arc`.
-    ///
-    /// [`WebDriver::managed`]: crate::WebDriver::managed
-    pub fn shared() -> Arc<Self> {
-        Arc::clone(shared_manager())
     }
 
     /// Register a closure to receive every [`Status`] event emitted by this
@@ -502,6 +499,15 @@ impl WebDriverManager {
             browser,
         });
 
+        // Manual binary override: skip the resolve/download flow entirely
+        // and spawn the supplied path directly. Version string for the
+        // DriverKey + Status events is synthesized from the path so manual
+        // entries don't collide with cache-keyed (browser, version) tuples.
+        if let Some(binary) = self.cfg.driver_paths.get(&browser).cloned() {
+            let version = format!("manual:{}", binary.display());
+            return self.spawn_or_reuse(browser, version, &binary).await;
+        }
+
         // For MatchLocalBrowser we probe the binary up front (potentially using a
         // capabilities-supplied path).
         let local = match self.cfg.version {
@@ -530,19 +536,18 @@ impl WebDriverManager {
         )
         .await?;
 
-        let key = DriverKey {
-            browser,
-            version: resolved.clone(),
-            host: self.cfg.host,
-        };
-
-        // Fast path: another live `Arc<ManagedDriver>` keyed the same way.
+        // Fast path: live driver matching `(browser, resolved, host)` already exists.
         {
+            let key = DriverKey {
+                browser,
+                version: resolved.clone(),
+                host: self.cfg.host,
+            };
             let map = self.drivers.lock().await;
             if let Some(existing) = map.get(&key).and_then(Weak::upgrade) {
                 self.emitter.emit(Status::DriverReused {
                     browser,
-                    version: resolved.clone(),
+                    version: resolved,
                     url: existing.url(),
                 });
                 return Ok(existing);
@@ -552,8 +557,37 @@ impl WebDriverManager {
         let driver_path =
             ensure_driver(&self.download_client, &download_cfg, browser, &resolved, &self.emitter)
                 .await?;
+        self.spawn_or_reuse(browser, resolved, &driver_path.binary).await
+    }
+
+    /// Cache-check, spawn, and register a managed driver process for
+    /// `(browser, version, host)`.
+    async fn spawn_or_reuse(
+        &self,
+        browser: BrowserKind,
+        version: String,
+        binary: &Path,
+    ) -> Result<Arc<ManagedDriverProcess>, ManagerError> {
+        let key = DriverKey {
+            browser,
+            version: version.clone(),
+            host: self.cfg.host,
+        };
+
+        {
+            let map = self.drivers.lock().await;
+            if let Some(existing) = map.get(&key).and_then(Weak::upgrade) {
+                self.emitter.emit(Status::DriverReused {
+                    browser,
+                    version: version.clone(),
+                    url: existing.url(),
+                });
+                return Ok(existing);
+            }
+        }
+
         let process = ManagedDriverProcess::spawn(
-            &driver_path.binary,
+            binary,
             browser,
             &SpawnConfig {
                 host: self.cfg.host,
@@ -562,7 +596,7 @@ impl WebDriverManager {
             },
             SpawnContext {
                 driver_id: self.mint_driver_id(),
-                version: &resolved,
+                version: &version,
                 emitter: &self.emitter,
                 manager_log_subscribers: self.log_subscribers.clone(),
             },
@@ -575,7 +609,7 @@ impl WebDriverManager {
         if let Some(existing) = map.get(&key).and_then(Weak::upgrade) {
             self.emitter.emit(Status::DriverReused {
                 browser,
-                version: resolved.clone(),
+                version,
                 url: existing.url(),
             });
             return Ok(existing);

--- a/thirtyfour/src/manager/tests.rs
+++ b/thirtyfour/src/manager/tests.rs
@@ -61,10 +61,32 @@ fn builder_stdio() {
 }
 
 #[test]
-fn shared_returns_same_arc() {
-    let a = WebDriverManager::shared();
-    let b = WebDriverManager::shared();
-    assert!(std::sync::Arc::ptr_eq(&a, &b));
+fn builder_driver_binary_records_per_browser_paths() {
+    let mgr = WebDriverManager::builder()
+        .driver_binary(BrowserKind::Chrome, "/usr/local/bin/chromedriver")
+        .driver_binary(BrowserKind::Firefox, "/usr/local/bin/geckodriver")
+        .build();
+    assert_eq!(
+        mgr.cfg.driver_paths.get(&BrowserKind::Chrome).map(|p| p.to_str().unwrap()),
+        Some("/usr/local/bin/chromedriver")
+    );
+    assert_eq!(
+        mgr.cfg.driver_paths.get(&BrowserKind::Firefox).map(|p| p.to_str().unwrap()),
+        Some("/usr/local/bin/geckodriver")
+    );
+    assert!(!mgr.cfg.driver_paths.contains_key(&BrowserKind::Edge));
+}
+
+#[test]
+fn builder_driver_binary_overwrites_same_browser() {
+    let mgr = WebDriverManager::builder()
+        .driver_binary(BrowserKind::Chrome, "/old/chromedriver")
+        .driver_binary(BrowserKind::Chrome, "/new/chromedriver")
+        .build();
+    assert_eq!(
+        mgr.cfg.driver_paths.get(&BrowserKind::Chrome).map(|p| p.to_str().unwrap()),
+        Some("/new/chromedriver")
+    );
 }
 
 fn hash_of<T: Hash>(t: &T) -> u64 {
@@ -291,36 +313,14 @@ async fn resolve_version_emits_resolving_then_resolved() {
 }
 
 #[test]
-fn builder_with_status_subscriber_opts_out_of_shared_singleton() {
-    // Two consecutive `WebDriver::managed(caps)` calls without options share
-    // the singleton. Once we register an `on_status` subscriber, we must opt
-    // out of the singleton so the subscriber doesn't leak across unrelated
-    // callers.
-    let mut caps = Capabilities::new();
-    caps.insert("browserName".into(), json!("chrome"));
-
-    // Sanity: bare builder is_all_defaults — covered indirectly by the shared
-    // singleton path.
-    let bare = WebDriverManager::builder();
-    assert!(bare.preloaded_caps.is_none());
-
-    // With a status subscriber, is_all_defaults should be false. We reach that
-    // through the public API: build the manager twice and ensure the Arcs
-    // differ. (`shared()` reuses; a non-shared build returns a fresh Arc each
-    // time.)
+fn builder_on_status_subscriber_receives_events() {
     let log = Arc::new(Mutex::new(Vec::<String>::new()));
     let captured = Arc::clone(&log);
-    let m1 = WebDriverManager::builder()
+    let mgr = WebDriverManager::builder()
         .on_status(move |s| captured.lock().unwrap().push(s.to_string()))
         .build();
-    let captured2 = Arc::clone(&log);
-    let m2 = WebDriverManager::builder()
-        .on_status(move |s| captured2.lock().unwrap().push(s.to_string()))
-        .build();
-    assert!(!std::sync::Arc::ptr_eq(&m1, &m2), "subscriber-bearing builders must not share state");
 
-    // And the subscriber receives manually-emitted events.
-    m1.emitter.emit(Status::BrowserKindResolved {
+    mgr.emitter.emit(Status::BrowserKindResolved {
         browser: BrowserKind::Chrome,
     });
     assert_eq!(log.lock().unwrap().len(), 1);

--- a/thirtyfour/src/web_driver.rs
+++ b/thirtyfour/src/web_driver.rs
@@ -157,23 +157,14 @@ impl WebDriver {
     /// # Ok(()) }
     /// ```
     ///
-    /// Use [`WebDriverManager::builder`] explicitly when you need a single
-    /// manager to drive multiple browsers in one process.
-    ///
-    /// ## Process sharing across calls
-    ///
-    /// When called with no chained customization, multiple `WebDriver::managed`
-    /// calls in the same process share a single underlying driver subprocess
-    /// (refcount-keyed on `(browser, resolved_version, host)`). The shared
-    /// driver lives only as long as at least one connected `WebDriver` exists.
-    ///
-    /// **Any chained customization** — `.latest()`, `.cache_dir(...)`,
-    /// `.host(...)`, etc. — opts out of sharing and builds a *fresh* manager
-    /// for that call. If you want to share one customized manager across many
-    /// sessions, construct it explicitly via [`WebDriverManager::builder`] and
-    /// call `.launch(caps)` on it for each session.
+    /// Each call constructs its own [`WebDriverManager`] and spawns its own
+    /// driver subprocess. To share one manager (and its driver subprocesses)
+    /// across many sessions, construct it explicitly via
+    /// [`WebDriverManager::builder`] and call `.launch(caps)` on it for each
+    /// session.
     ///
     /// [`WebDriverManagerBuilder`]: crate::manager::WebDriverManagerBuilder
+    /// [`WebDriverManager`]: crate::manager::WebDriverManager
     /// [`WebDriverManager::builder`]: crate::manager::WebDriverManager::builder
     #[cfg(feature = "manager")]
     pub fn managed<C>(capabilities: C) -> crate::manager::WebDriverManagerBuilder


### PR DESCRIPTION
## Summary

This branch covers two related changes:

1. **`WebDriverManager` API improvement.** Removed the implicit shared-singleton routing in `WebDriver::managed()` — every call now constructs its own manager, keeping behaviour predictable. Added `WebDriverManagerBuilder::driver_binary(browser, path)` so callers can point the manager at a pre-installed driver and skip the download/cache flow.
2. **Documentation overhaul.** The mdbook now treats `WebDriver::managed()` as the default flow throughout, with manual webdriver setup demoted to an appendix. The Element Queries, Waiting, and Components chapters were rewritten and expanded to be readable cold by someone new to thirtyfour. All examples (except `selenium_example`, which is intentionally about pointing at a Selenium server) were rewritten to use `WebDriver::managed()`.

## Code changes

- `WebDriverManager`
  - Removed `shared_manager()`, `WebDriverManager::shared()`, `WebDriverManagerBuilder::is_all_defaults()`, and the singleton branch in the `IntoFuture` impl. Each `WebDriver::managed(...).await` now builds a fresh manager.
  - Added `WebDriverManagerBuilder::driver_binary(BrowserKind, impl Into<PathBuf>)`. When a binary is registered for a browser, `ensure_driver` skips version resolution and download and spawns the supplied path directly. Live-driver reuse still works (keyed on `manual:<path>`).
  - Refactored `ensure_driver` to share a `spawn_or_reuse` helper between the manual-path and download paths.
  - Tests added for per-browser path threading and last-write-wins on the same browser; obsolete singleton-routing tests removed.
- Examples: every example except `selenium_example.rs` rewritten to use `WebDriver::managed()`. `Cargo.toml` `[[example]]` declarations gain `required-features = ["manager"]` for each rewritten example.

## Documentation changes

- New `WebDriver Manager` chapter (`docs/src/features/manager.md`) — version pinning, sharing one manager across many sessions, pre-installed driver binaries, offline mode, and observing manager status events.
- New `Manual WebDriver Setup` appendix (`docs/src/appendix/manual-webdriver.md`) for users running the driver themselves (Selenium grid, container, opting out of the `manager` Cargo feature).
- Slimmed `Installation`, rewrote `First Code` / `Explaining The Code` to use `WebDriver::managed()`, and softened the `manager` feature-flag entry.
- Element Queries chapter now leads with `query()` as the way to find elements, with `find()` / `find_all()` as a low-key aside. Adds full coverage of `By` selectors, terminators (`first`, `single`, `first_opt`, `all_from_selector(_required)`, `any(_required)`, `exists`, `not_exists`), `.or()`, state/value/attribute/CSS filters, custom predicates, custom timeouts, and `.desc()` for nicer errors.
- Waiting chapter expanded to cover the full set of state/text/class/value/attribute/property/CSS predicates, custom timeouts, custom error messages, custom predicates via `.condition()` / `.conditions(...)`, and a guide on when to reach for `query` vs `wait_until`.
- Components chapter rewritten as a walkthrough: motivation, a worked example, full `#[by(...)]` attribute reference (selectors + modifiers), `ElementResolver` methods, caching/staleness, nested components, custom resolvers, and a closing rubric for when to reach for a Component.
- Crate-wide rename of "advanced query interface" to "powerful / recommended" in the README, intro, and `lib.rs` rustdoc. CDP intro line no longer name-drops other frameworks.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo test -p thirtyfour --lib` (71 passing)
- [x] `cargo build --examples --all-features`
- [x] `mdbook build` clean

## Notes for reviewers

- `WebDriver::managed()` no longer routes through a shared singleton. Two consecutive `WebDriver::managed(caps).await` calls now spawn two driver subprocesses. To share, build a manager explicitly with `WebDriverManager::builder()` and call `.launch(caps)` on it. The chapter explains this.
- `WebDriverManager::shared()` was removed (was effectively unused once the singleton routing was removed).
- The `manager` Cargo feature is unchanged; it's still default-on. Docs only mention the feature in the context of *disabling* it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)