### PR TITLE
Use WebDriver::managed in README and lib.rs example

### DIFF
--- a/thirtyfour/README.md
+++ b/thirtyfour/README.md
@@ -44,7 +44,7 @@ use thirtyfour::prelude::*;
 #[tokio::main]
 async fn main() -> WebDriverResult<()> {
      let caps = DesiredCapabilities::chrome();
-     let driver = WebDriver::new("http://localhost:9515", caps).await?;
+     let driver = WebDriver::managed(caps).await?;
 
      // Navigate to https://wikipedia.org.
      driver.goto("https://wikipedia.org").await?;

--- a/thirtyfour/src/lib.rs
+++ b/thirtyfour/src/lib.rs
@@ -36,7 +36,9 @@
 //! ## Example
 //!
 //! The following example assumes you have a compatible version of Chrome
-//! installed and `chromedriver` running on port 4444.
+//! installed. [`WebDriver::managed`] auto-downloads the matching
+//! `chromedriver`, starts it locally, and shuts it down when the session is
+//! dropped.
 //!
 //! ```no_run
 //! use thirtyfour::prelude::*;
@@ -44,7 +46,7 @@
 //! #[tokio::main]
 //! async fn main() -> color_eyre::Result<()> {
 //!     let caps = DesiredCapabilities::chrome();
-//!     let driver = WebDriver::new("http://localhost:4444", caps).await?;
+//!     let driver = WebDriver::managed(caps).await?;
 //!
 //!     // Navigate to https://wikipedia.org.
 //!     driver.goto("https://wikipedia.org").await?;


### PR DESCRIPTION
## Summary
- Switch the example in [thirtyfour/README.md](thirtyfour/README.md) (and the top-level `README.md` symlink) from `WebDriver::new("http://localhost:9515", caps)` to `WebDriver::managed(caps)`.
- Update the crate-root rustdoc example in [thirtyfour/src/lib.rs](thirtyfour/src/lib.rs) the same way, and rewrite the surrounding preamble: with `WebDriver::managed` the reader no longer has to start `chromedriver` on a port — it auto-downloads, runs, and tears down for them.

## Why
The book, the in-tree examples, and the `WebDriver::managed` rustdoc all already lead with the managed flow. The README and crate-root docs were the last surface still pointing newcomers at the manual `chromedriver`-on-a-port path, which made the recommended flow look optional. Now first impressions match the rest of the docs.

## Test plan
- [x] `cargo doc --no-deps --all-features` (intra-doc link to `WebDriver::managed` resolves cleanly)
- [ ] Render the README on GitHub to confirm the snippet still looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)