### PR TITLE
Set MSRV to Rust 1.88 and enforce in CI

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+name: msrv
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: cargo check on MSRV
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.88.0
+      - uses: actions/checkout@v2
+      - name: cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --workspace --all-features --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = ["thirtyfour", "thirtyfour-macros"]
 [workspace.package]
 authors = ["Steve Pryde <steve@stevepryde.com>", "Vrtgs <vrtgs@vrtgs.xyz>"]
 license = "MIT OR Apache-2.0"
+rust-version = "1.88"
 homepage = "https://github.com/stevepryde/thirtyfour"
 repository = "https://github.com/stevepryde/thirtyfour"
 keywords = [

--- a/thirtyfour-macros/Cargo.toml
+++ b/thirtyfour-macros/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/thirtyfour_macros"
 readme = "README.md"
 authors.workspace = true
 license.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 keywords.workspace = true

--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/thirtyfour"
 readme = "README.md"
 authors.workspace = true
 license.workspace = true
+rust-version.workspace = true
 homepage.workspace = true
 repository.workspace = true
 keywords.workspace = true

--- a/thirtyfour/README.md
+++ b/thirtyfour/README.md
@@ -73,7 +73,7 @@ async fn main() -> WebDriverResult<()> {
 
 ## Minimum Supported Rust Version
 
-The MSRV for `thirtyfour` is currently latest, and so its guaranteed to run the latest stable release.
+Rust 1.88.
 
 ## LICENSE
 


### PR DESCRIPTION
## Summary

- Pin MSRV to **Rust 1.88** (released 2025-06-26). The README previously claimed "currently latest", which isn't a real commitment.
- Add `rust-version = "1.88"` to `[workspace.package]` so both crates inherit it. This also enables cargo's MSRV-aware resolver to pick MSRV-compatible dep versions.
- Add a `msrv` GitHub Actions workflow that runs `cargo check --workspace --all-features --all-targets` on 1.88 for every PR and push to main, so a future dependency bump can't silently raise the floor.
- Trim the README MSRV section to just the version.

## Why 1.88 specifically

The realistic floor — anything lower won't actually compile:

- `resolver = "3"` requires 1.84
- `edition = "2024"` requires 1.85
- `zip = "8"` (8.6.0, pulled in by the `manager` feature) requires 1.88

Tested locally on 1.85 and 1.87 — both fail on `zip`. 1.88 builds clean.

## Test plan

- [x] `cargo +1.88.0 check --workspace --all-features --all-targets`
- [x] `cargo +1.88.0 test -p thirtyfour --lib --all-features`
- [x] `cargo +1.88.0 test -p thirtyfour --doc --all-features`
- [x] `cargo +1.88.0 build --workspace --all-features --tests --examples`
- [x] `cargo +1.88.0 clippy --all-features --all-targets`
- [x] Pre-push checklist on stable: `cargo fmt --check`, `cargo clippy --all-features --all-targets`, `cargo doc --no-deps --all-features`
- [ ] New `msrv` workflow runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)