### PR TITLE
Issue triage: with_class fix, drop-on-panic tests, By docs

### DIFF
--- a/thirtyfour/src/common/command.rs
+++ b/thirtyfour/src/common/command.rs
@@ -70,6 +70,39 @@ pub enum BySelector {
 }
 
 /// Element Selector struct providing a convenient way to specify selectors.
+///
+/// # Scope when querying from a [`WebElement`]
+///
+/// When you call `find` / `find_all` / `query` on a [`WebElement`] (rather
+/// than on a [`WebDriver`]), thirtyfour issues `Find Element From Element`
+/// and the search is **scoped to the element's subtree** — except for
+/// [`By::XPath`], see below.
+///
+/// All other variants (`Id`, `Name`, `Tag`, `ClassName`, `Css`, `Testid`,
+/// `LinkText`, `PartialLinkText`) are forwarded as CSS selectors, which the
+/// WebDriver spec runs against the element's descendants only.
+///
+/// # XPath gotcha
+///
+/// XPath `//foo` is **document-rooted**, even when called from a
+/// [`WebElement`]. To search relative to the element you queried from, use
+/// `.//foo`:
+///
+/// ```rust,no_run
+/// # use thirtyfour::prelude::*;
+/// # async fn _scope(parent: WebElement) -> WebDriverResult<()> {
+/// // Wrong — searches the whole document, may match elements outside `parent`.
+/// let _ = parent.find(By::XPath("//div[@class='child']")).await?;
+/// // Right — searches only inside `parent`.
+/// let _ = parent.find(By::XPath(".//div[@class='child']")).await?;
+/// # Ok(()) }
+/// ```
+///
+/// This is W3C WebDriver behaviour, not a thirtyfour quirk — it matches
+/// every other Selenium-family client.
+///
+/// [`WebDriver`]: crate::WebDriver
+/// [`WebElement`]: crate::WebElement
 #[derive(Debug, Clone)]
 pub struct By {
     selector: BySelector,
@@ -106,6 +139,13 @@ impl By {
     }
 
     /// Select element by XPath.
+    ///
+    /// When called from a [`WebElement`], remember to prefix paths with
+    /// `.//` to scope the search to the element's subtree — `//foo` is
+    /// document-rooted regardless of which element you query from. See the
+    /// [`By`] type-level docs for the full explanation.
+    ///
+    /// [`WebElement`]: crate::WebElement
     pub fn XPath(x: impl IntoArcStr) -> Self {
         Self {
             selector: BySelector::XPath(x.into()),

--- a/thirtyfour/src/extensions/query/conditions.rs
+++ b/thirtyfour/src/extensions/query/conditions.rs
@@ -59,9 +59,18 @@ pub fn element_is_not_clickable(ignore_errors: bool) -> impl ElementPredicate {
     move |elem: WebElement| async move { negate(elem.is_clickable().await, ignore_errors) }
 }
 
-/// Predicate that returns true for elements that have the specified class name.
-/// See the `Needle` documentation for more details on text matching rules.
-/// In particular, it is recommended to use StringMatch or Regex to perform a whole-word search.
+/// True if `needle` matches any whitespace-separated token in `class_attr`.
+/// The HTML `class` attribute is a token list, so matching the full attribute
+/// string would mean `needle == "foo"` could never match `class="a foo b"` —
+/// see issue #259.
+fn class_attr_matches_token<N: Needle>(needle: &N, class_attr: &str) -> bool {
+    class_attr.split_whitespace().any(|tok| needle.is_match(tok))
+}
+
+/// Predicate that returns true for elements where any token in the `class`
+/// attribute matches `class_name`. See the `Needle` documentation for more
+/// details on text matching rules — the needle is run against each
+/// whitespace-separated class token, not the full attribute string.
 pub fn element_has_class<N>(class_name: N, ignore_errors: bool) -> impl ElementPredicate
 where
     N: Needle + Clone + Send + Sync + 'static,
@@ -70,7 +79,7 @@ where
         let class_name = class_name.clone();
         async move {
             match elem.class_name().await {
-                Ok(Some(x)) => Ok(class_name.is_match(&x)),
+                Ok(Some(x)) => Ok(class_attr_matches_token(&class_name, &x)),
                 Ok(None) => Ok(false),
                 Err(e) => handle_errors(Err(e), ignore_errors),
             }
@@ -78,9 +87,10 @@ where
     }
 }
 
-/// Predicate that returns true for elements that do not contain the specified class name.
-/// See the `Needle` documentation for more details on text matching rules.
-/// In particular, it is recommended to use StringMatch or Regex to perform a whole-word search.
+/// Predicate that returns true for elements where no token in the `class`
+/// attribute matches `class_name`. See the `Needle` documentation for more
+/// details on text matching rules — the needle is run against each
+/// whitespace-separated class token, not the full attribute string.
 pub fn element_lacks_class<N>(class_name: N, ignore_errors: bool) -> impl ElementPredicate
 where
     N: Needle + Clone + Send + Sync + 'static,
@@ -89,7 +99,7 @@ where
         let class_name = class_name.clone();
         async move {
             match elem.class_name().await {
-                Ok(Some(x)) => Ok(!class_name.is_match(&x)),
+                Ok(Some(x)) => Ok(!class_attr_matches_token(&class_name, &x)),
                 Ok(None) => Ok(true),
                 Err(e) => handle_errors(Err(e), ignore_errors),
             }

--- a/thirtyfour/tests/managed.rs
+++ b/thirtyfour/tests/managed.rs
@@ -169,3 +169,92 @@ async fn managed_chrome_options_and_dedup() -> WebDriverResult<()> {
     })
     .await
 }
+
+/// True if a TCP connect to the driver's `host:port` succeeds, i.e. the
+/// chromedriver subprocess is still listening.
+async fn driver_is_listening(server_url: &url::Url) -> bool {
+    let host = server_url.host_str().unwrap_or("127.0.0.1");
+    let port = server_url.port_or_known_default().unwrap_or(0);
+    tokio::time::timeout(Duration::from_secs(1), tokio::net::TcpStream::connect((host, port)))
+        .await
+        .map(|r| r.is_ok())
+        .unwrap_or(false)
+}
+
+/// Issue #281: dropping a `WebDriver` without calling `quit()` should still
+/// close the session and (for managed drivers) kill the chromedriver
+/// subprocess. `SessionHandle::Drop` runs `quit()` synchronously via
+/// `spawn_blocked_future`, and `ManagedDriverProcess::Drop` SIGKILLs the
+/// subprocess.
+#[tokio::test(flavor = "multi_thread")]
+async fn dropping_managed_driver_kills_subprocess() -> WebDriverResult<()> {
+    with_timeout(async {
+        let server_url = {
+            let driver = WebDriver::managed(chrome_caps()).await?;
+            let url = driver.server_url().clone();
+            assert!(driver_is_listening(&url).await, "driver should be listening while alive");
+            if !skip_navigation() {
+                driver.goto("about:blank").await?;
+            }
+            url
+            // No explicit `driver.quit().await` — drop fires here, which must
+            // run quit() and then SIGKILL the subprocess.
+        };
+
+        // Give SIGKILL a moment to actually reap the process.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        assert!(
+            !driver_is_listening(&server_url).await,
+            "chromedriver at {server_url} should be gone after WebDriver was dropped without quit"
+        );
+        Ok(())
+    })
+    .await
+}
+
+/// Issue #281 specifically: panic unwind drops the in-scope `WebDriver`,
+/// which must run the same `quit + kill subprocess` path as a clean drop.
+/// Users should never need a custom `Drop` guard with `block_on` — that's
+/// what `SessionHandle::Drop` already does internally.
+#[tokio::test(flavor = "multi_thread")]
+async fn panic_unwind_kills_managed_driver_subprocess() -> WebDriverResult<()> {
+    use std::sync::{Arc, Mutex};
+
+    with_timeout(async {
+        let captured: Arc<Mutex<Option<url::Url>>> = Arc::new(Mutex::new(None));
+        let captured_clone = Arc::clone(&captured);
+
+        // Run the panicking code on a dedicated thread so the unwind happens
+        // there and we can `join()` to observe it. The `WebDriver` is held
+        // when `panic!` fires; the unwind must drop it cleanly.
+        let join = std::thread::spawn(move || {
+            thirtyfour::support::block_on(async move {
+                let driver = WebDriver::managed(chrome_caps()).await.expect("managed launch");
+                *captured_clone.lock().unwrap() = Some(driver.server_url().clone());
+                if !skip_navigation() {
+                    driver.goto("about:blank").await.expect("goto");
+                }
+                panic!("simulated user panic with WebDriver still in scope");
+            });
+        })
+        .join();
+
+        assert!(join.is_err(), "thread should have panicked");
+
+        let url = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("server URL should have been captured before panic");
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        assert!(
+            !driver_is_listening(&url).await,
+            "chromedriver at {url} should be gone after panic unwind dropped the WebDriver"
+        );
+        Ok(())
+    })
+    .await
+}

--- a/thirtyfour/tests/query_filters.rs
+++ b/thirtyfour/tests/query_filters.rs
@@ -1,0 +1,140 @@
+//! Integration tests for `ElementQuery` filter predicates against a real
+//! browser via `WebDriver::managed`.
+//!
+//! Gated behind `manager-tests` like the other manager-driven E2E tests:
+//!
+//! ```text
+//! cargo test -p thirtyfour --features manager-tests --test query_filters -- --test-threads=1
+//! ```
+
+#![cfg(feature = "manager-tests")]
+
+use std::time::Duration;
+
+use thirtyfour::ChromeCapabilities;
+use thirtyfour::prelude::*;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(180);
+
+fn chrome_caps() -> ChromeCapabilities {
+    let mut caps = DesiredCapabilities::chrome();
+    caps.set_headless().unwrap();
+    caps.set_no_sandbox().unwrap();
+    caps.set_disable_gpu().unwrap();
+    caps.set_disable_dev_shm_usage().unwrap();
+    caps.add_arg("--no-sandbox").unwrap();
+    caps
+}
+
+/// Reproduces issue #259: `with_class("foo")` against an element whose `class`
+/// attribute is `"a b foo c"` should match. The user expects CSS-class
+/// semantics — match a single token within the space-separated class list.
+#[tokio::test(flavor = "multi_thread")]
+async fn with_class_matches_one_class_in_multi_class_attribute() -> WebDriverResult<()> {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let driver = WebDriver::managed(chrome_caps()).await?;
+
+        // Two `<li>`s share a generic class list; only the second carries the
+        // class we filter on. Mirrors the markup from the original bug report.
+        driver
+            .goto(
+                "data:text/html,<html><body><ul>\
+                 <li class='MuiListItem-root MuiListItem-gutters practice-type-list-item css-120b5pf' data-testid='type-1'>type</li>\
+                 <li class='MuiListItem-root MuiListItem-gutters practice-exercises-list-item css-j4r5fq' data-testid='exercises-1'>e1</li>\
+                 <li class='MuiListItem-root MuiListItem-gutters practice-exercises-list-item css-j4r5fq' data-testid='exercises-2'>e2</li>\
+                 </ul></body></html>",
+            )
+            .await?;
+
+        let elems = driver
+            .query(By::Tag("li"))
+            .with_class("practice-exercises-list-item")
+            .nowait()
+            .any()
+            .await?;
+
+        assert_eq!(
+            elems.len(),
+            2,
+            "with_class should match elements where the class attribute contains the class as a token"
+        );
+
+        driver.quit().await?;
+        Ok(())
+    })
+    .await
+    .unwrap_or_else(|_| {
+        Err(WebDriverError::FatalError(format!(
+            "test exceeded {}s budget",
+            TEST_TIMEOUT.as_secs()
+        )))
+    })
+}
+
+/// `with_class("foo")` must NOT match an element whose class is `"foobar"` —
+/// CSS class semantics are whole-token, not substring.
+#[tokio::test(flavor = "multi_thread")]
+async fn with_class_does_not_match_class_substring() -> WebDriverResult<()> {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let driver = WebDriver::managed(chrome_caps()).await?;
+
+        driver
+            .goto(
+                "data:text/html,<html><body>\
+                 <div class='foobar' data-testid='foobar'>x</div>\
+                 <div class='foo' data-testid='foo'>y</div>\
+                 </body></html>",
+            )
+            .await?;
+
+        let elems = driver.query(By::Tag("div")).with_class("foo").nowait().any().await?;
+
+        assert_eq!(elems.len(), 1, "with_class('foo') should not match class='foobar'");
+        assert_eq!(elems[0].attr("data-testid").await?.as_deref(), Some("foo"));
+
+        driver.quit().await?;
+        Ok(())
+    })
+    .await
+    .unwrap_or_else(|_| {
+        Err(WebDriverError::FatalError(format!("test exceeded {}s budget", TEST_TIMEOUT.as_secs())))
+    })
+}
+
+/// `without_class("foo")` is the inverse: the element with class `"foo"`
+/// must be excluded; `"foobar"` and `"bar"` must be included.
+#[tokio::test(flavor = "multi_thread")]
+async fn without_class_excludes_only_whole_token_match() -> WebDriverResult<()> {
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        let driver = WebDriver::managed(chrome_caps()).await?;
+
+        driver
+            .goto(
+                "data:text/html,<html><body>\
+                 <div class='foobar' data-testid='foobar'>a</div>\
+                 <div class='foo bar' data-testid='foo-bar'>b</div>\
+                 <div class='bar' data-testid='bar'>c</div>\
+                 </body></html>",
+            )
+            .await?;
+
+        let elems = driver.query(By::Tag("div")).without_class("foo").nowait().any().await?;
+
+        let mut testids: Vec<String> = Vec::new();
+        for e in &elems {
+            if let Some(id) = e.attr("data-testid").await? {
+                testids.push(id);
+            }
+        }
+        testids.sort();
+
+        assert_eq!(testids, vec!["bar".to_string(), "foobar".to_string()]);
+
+        driver.quit().await?;
+        Ok(())
+    })
+    .await
+    .unwrap_or_else(|_| {
+        Err(WebDriverError::FatalError(format!("test exceeded {}s budget", TEST_TIMEOUT.as_secs())))
+    })
+}


### PR DESCRIPTION
## Summary

- **Fix `with_class` / `without_class`** to use CSS-class-token semantics instead of comparing the full `class` attribute string ([#259](https://github.com/stevepryde/thirtyfour/issues/259)). The previous behaviour silently failed for any element with more than one class.
- **Add regression tests for drop-on-panic** ([#281](https://github.com/stevepryde/thirtyfour/issues/281)). No code change — `SessionHandle::Drop` and `ManagedDriverProcess::Drop` already do the right thing; the tests just lock that in.
- **Document scope rules on `By`** ([#155](https://github.com/stevepryde/thirtyfour/issues/155)) — element-scoped vs document-rooted, with the XPath `//` vs `.//` gotcha called out.

## Behaviour change

`with_class("foo")` and `without_class("foo")` previously matched (or excluded) elements where the `class` attribute string *exactly* equalled `"foo"`. They now match where any whitespace-separated token in the attribute equals `"foo"` — which is what every reasonable user expects from a method called `with_class`.

For users passing `Regex` or `StringMatch` needles: those previously matched against the full attribute; they're now run per token. For typical "match one class name" use cases this is what you want; if you genuinely need to match the full attribute, use `with_attribute("class", needle)`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets`
- [x] `cargo doc --no-deps --all-features`
- [x] `cargo test -p thirtyfour --lib` — 82 passed
- [x] `cargo test --doc -p thirtyfour` — 121 passed
- [x] `cargo test -p thirtyfour --features manager-tests --test query_filters -- --test-threads=1` — 3 passed
- [x] `cargo test -p thirtyfour --features manager-tests --test managed -- --test-threads=1 dropping_managed_driver_kills_subprocess panic_unwind_kills_managed_driver_subprocess` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)