### PR TITLE
Add WebDriver BiDi (W3C bidirectional protocol) support

### DIFF
--- a/.github/workflows/bidi-test.yml
+++ b/.github/workflows/bidi-test.yml
@@ -1,0 +1,59 @@
+on:
+  push:
+    branches: [main]
+    # BiDi tests download a real driver and exercise the typed + event WS
+    # layers. Trigger on changes to anything that could affect them.
+    paths:
+      - 'thirtyfour/src/bidi/**'
+      - 'thirtyfour/tests/bidi_typed.rs'
+      - 'thirtyfour/tests/bidi_events.rs'
+      - 'thirtyfour/tests/common.rs'
+      - 'thirtyfour/src/web_driver.rs'
+      - 'thirtyfour/src/web_element.rs'
+      - 'thirtyfour/src/session/**'
+      - 'thirtyfour/src/manager/**'
+      - 'thirtyfour/src/common/capabilities/**'
+      - 'thirtyfour/Cargo.toml'
+      - '.github/workflows/bidi-test.yml'
+  pull_request:
+    paths:
+      - 'thirtyfour/src/bidi/**'
+      - 'thirtyfour/tests/bidi_typed.rs'
+      - 'thirtyfour/tests/bidi_events.rs'
+      - 'thirtyfour/tests/common.rs'
+      - 'thirtyfour/src/web_driver.rs'
+      - 'thirtyfour/src/web_element.rs'
+      - 'thirtyfour/src/session/**'
+      - 'thirtyfour/src/manager/**'
+      - 'thirtyfour/src/common/capabilities/**'
+      - 'thirtyfour/Cargo.toml'
+      - '.github/workflows/bidi-test.yml'
+name: cargo test (bidi)
+jobs:
+  # WebDriver BiDi is a W3C cross-browser protocol — run the suite against
+  # both chromedriver and geckodriver to keep the typed bindings honest.
+  # Ubuntu only: the WS connect path is OS-agnostic so per-OS coverage
+  # would just add CI time; the existing `cdp-test.yml` already covers
+  # OS-specific shape on the Chromium side.
+  bidi:
+    runs-on: ubuntu-latest
+    name: bidi ${{ matrix.suite }} / ${{ matrix.browser }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, firefox]
+        suite: [typed, events]
+    env:
+      THIRTYFOUR_BROWSER: ${{ matrix.browser }}
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: actions/checkout@v2
+      - name: cargo test (bidi_${{ matrix.suite }})
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p thirtyfour --features manager-tests,bidi --test bidi_${{ matrix.suite }} -- --test-threads=1

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,53 @@
 # Migration guide
 
+## New: WebDriver BiDi support
+
+The `bidi` feature flag adds a typed WebDriver BiDi (W3C bidirectional
+protocol) layer alongside the classic HTTP API and CDP. It targets
+chromedriver ≥ 115 and geckodriver ≥ 0.31.
+
+```toml
+# Cargo.toml
+thirtyfour = { version = "0.37", features = ["bidi"] }
+```
+
+```rust
+use thirtyfour::prelude::*;
+
+let mut caps = DesiredCapabilities::chrome();
+caps.enable_bidi()?;                                  // sets `webSocketUrl: true`
+let driver = WebDriver::new("http://localhost:4444", caps).await?;
+
+let bidi = driver.bidi().await?;                      // lazy-connect the WS
+let status = bidi.session().status().await?;
+let tree   = bidi.browsing_context().get_tree(None).await?;
+let ctx    = tree.contexts[0].context.clone();
+
+bidi.browsing_context()
+    .navigate(ctx.clone(), "https://example.com", None)
+    .await?;
+
+let result = bidi.script().evaluate(ctx, "document.title", false).await?;
+println!("title: {:?}", result.ok_value());
+```
+
+Curated typed bindings for **session, browser, browsingContext, script,
+network, storage, log, input, permissions** are under
+`thirtyfour::bidi::modules::*`. Events use the same broadcast pattern as
+the existing CDP events:
+
+```rust
+use thirtyfour::bidi::modules::browsing_context::events::Load;
+use futures_util::StreamExt;
+
+bidi.session().subscribe("browsingContext.load").await?;
+let mut load_events = bidi.subscribe::<Load>();
+// ... navigate, then load_events.next().await ...
+```
+
+The handle is cached on the session, so `driver.bidi().await` is cheap on
+subsequent calls. Coexists with the classic HTTP API and `driver.cdp()`.
+
 ## 0.36 → 0.37
 
 The 0.37 release has two main themes: a full rewrite of the CDP layer,

--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -32,6 +32,10 @@ cdp = []
 # `Cdp::connect()` and `CdpSession`. Off by default; pulls in
 # `tokio-tungstenite`.
 cdp-events = ["cdp", "dep:tokio-tungstenite", "tokio/macros", "tokio/rt"]
+# WebDriver BiDi (W3C) — typed commands and event subscription over a
+# WebSocket negotiated via the `webSocketUrl: true` capability. Off by
+# default. Pulls in `tokio-tungstenite`. See `WebDriver::bidi`.
+bidi = ["dep:tokio-tungstenite", "tokio/macros", "tokio/rt"]
 # Auto-download and lifetime-manage local chromedriver / geckodriver processes.
 # Pulls in archive-extraction and cache-dir deps. See `thirtyfour::manager`.
 manager = [
@@ -138,6 +142,18 @@ required-features = ["manager"]
 [[example]]
 name = "chrome_devtools"
 required-features = ["manager", "cdp"]
+
+[[example]]
+name = "bidi_basic"
+required-features = ["manager", "bidi"]
+
+[[example]]
+name = "bidi_network_intercept"
+required-features = ["manager", "bidi"]
+
+[[example]]
+name = "bidi_log_events"
+required-features = ["manager", "bidi"]
 
 [[example]]
 name = "chrome_options"

--- a/thirtyfour/README.md
+++ b/thirtyfour/README.md
@@ -23,6 +23,7 @@ Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI 
 - Alert support
 - Capture / Save screenshot of browser or individual element as PNG
 - Chrome DevTools Protocol (CDP) — typed commands plus optional WebSocket-based event subscription via the `cdp-events` feature
+- WebDriver BiDi (W3C bidirectional protocol) — typed commands and event subscription cross-browser, opt-in via the `bidi` feature
 - Powerful query interface (the recommended way to find elements) with explicit waits and various predicates
 - Component Wrappers (similar to `Page Object Model`)
 
@@ -31,6 +32,11 @@ Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI 
 - `rustls-tls`: (Default) Use rustls to provide TLS support (via reqwest).
 - `native-tls`: Use native TLS (via reqwest).
 - `component`: (Default) Enable the `Component` derive macro (via thirtyfour_macros).
+- `cdp`: (Default) Typed Chrome DevTools Protocol commands.
+- `cdp-events`: WebSocket-backed CDP event subscription.
+- `bidi`: WebDriver BiDi (W3C) — typed commands and event subscription
+  via `WebDriver::bidi()`. Opt in by calling `caps.enable_bidi()` before
+  starting the session.
 
 ### Example (async):
 

--- a/thirtyfour/examples/bidi_basic.rs
+++ b/thirtyfour/examples/bidi_basic.rs
@@ -1,0 +1,50 @@
+//! WebDriver BiDi quick start.
+//!
+//! Run with: `cargo run --example bidi_basic --features manager,bidi`
+//!
+//! Auto-downloads chromedriver, launches a headless Chrome, opts in to BiDi
+//! via the `webSocketUrl: true` capability, and exercises a few common
+//! commands and one event subscription.
+
+use futures_util::StreamExt;
+use thirtyfour::bidi::modules::browsing_context::events::Load;
+use thirtyfour::prelude::*;
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> WebDriverResult<()> {
+    let mut caps = DesiredCapabilities::chrome();
+    caps.set_headless()?;
+    caps.set_no_sandbox()?;
+    caps.set_disable_gpu()?;
+    caps.enable_bidi()?;
+
+    let driver = WebDriver::managed(caps).await?;
+    let bidi = driver.bidi().await?;
+
+    // Status round-trip — verifies the WS is connected and ready.
+    let status = bidi.session().status().await?;
+    println!("driver ready: {} ({})", status.ready, status.message);
+
+    // Pick the active browsing context.
+    let tree = bidi.browsing_context().get_tree(None).await?;
+    let context = tree.contexts[0].context.clone();
+
+    // Subscribe to load events, then navigate.
+    bidi.session().subscribe("browsingContext.load").await?;
+    let mut load_events = bidi.subscribe::<Load>();
+
+    let url = "data:text/html,<html><title>BiDi%20demo</title></html>";
+    bidi.browsing_context().navigate(context.clone(), url, None).await?;
+
+    if let Some(load) = load_events.next().await {
+        println!("loaded: {} (context={})", load.url, load.context);
+    }
+
+    // Read the title via script.evaluate.
+    let result = bidi.script().evaluate(context.clone(), "document.title", false).await?;
+    if let Some(value) = result.ok_value() {
+        println!("title: {}", value);
+    }
+
+    driver.quit().await
+}

--- a/thirtyfour/examples/bidi_log_events.rs
+++ b/thirtyfour/examples/bidi_log_events.rs
@@ -1,0 +1,63 @@
+//! WebDriver BiDi `log.entryAdded` event subscription.
+//!
+//! Run with: `cargo run --example bidi_log_events --features manager,bidi`
+//!
+//! Subscribes to `log.entryAdded`, navigates to a page that calls
+//! `console.log` / `console.warn` / `console.error`, and prints each
+//! entry with its severity, source realm, and text.
+
+use futures_util::StreamExt;
+use thirtyfour::bidi::modules::log::LogLevel;
+use thirtyfour::bidi::modules::log::events::EntryAdded;
+use thirtyfour::prelude::*;
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> WebDriverResult<()> {
+    let mut caps = DesiredCapabilities::chrome();
+    caps.set_headless()?;
+    caps.set_no_sandbox()?;
+    caps.set_disable_gpu()?;
+    caps.enable_bidi()?;
+
+    let driver = WebDriver::managed(caps).await?;
+    let bidi = driver.bidi().await?;
+
+    bidi.session().subscribe("log.entryAdded").await?;
+    let mut events = bidi.subscribe::<EntryAdded>();
+
+    let tree = bidi.browsing_context().get_tree(None).await?;
+    let context = tree.contexts[0].context.clone();
+
+    let page = "data:text/html,<html><body><script>\
+        console.log('hello from log');\
+        console.warn('a warning');\
+        console.error('an error');\
+        </script></body></html>";
+    bidi.browsing_context()
+        .navigate(
+            context,
+            page,
+            Some(thirtyfour::bidi::modules::browsing_context::ReadinessState::Complete),
+        )
+        .await?;
+
+    // Drain three log entries — one per console call above.
+    let mut seen = 0;
+    while let Some(event) = events.next().await {
+        let level = match event.level {
+            LogLevel::Debug => "DEBUG",
+            LogLevel::Info => "INFO",
+            LogLevel::Warn => "WARN",
+            LogLevel::Error => "ERROR",
+            LogLevel::Unknown(ref s) => s.as_str(),
+        };
+        let text = event.text.as_deref().unwrap_or("(no text)");
+        println!("[{level}] {} :: {text}", event.entry_type);
+        seen += 1;
+        if seen >= 3 {
+            break;
+        }
+    }
+
+    driver.quit().await
+}

--- a/thirtyfour/examples/bidi_network_intercept.rs
+++ b/thirtyfour/examples/bidi_network_intercept.rs
@@ -1,0 +1,72 @@
+//! WebDriver BiDi network interception.
+//!
+//! Run with: `cargo run --example bidi_network_intercept --features manager,bidi`
+//!
+//! Demonstrates the request-interception loop:
+//!
+//! 1. Subscribe to `network.beforeRequestSent`.
+//! 2. Register an intercept for the request phase.
+//! 3. Navigate; the request is paused on the wire.
+//! 4. Continue (or fail / synthesize) the paused request.
+//!
+//! The pattern is the same for response-phase interception — swap the
+//! phase enum and continue with `network.continueResponse`.
+
+use futures_util::StreamExt;
+use thirtyfour::bidi::modules::browsing_context::ReadinessState;
+use thirtyfour::bidi::modules::network;
+use thirtyfour::bidi::modules::network::events::BeforeRequestSent;
+use thirtyfour::prelude::*;
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> WebDriverResult<()> {
+    let mut caps = DesiredCapabilities::chrome();
+    caps.set_headless()?;
+    caps.set_no_sandbox()?;
+    caps.set_disable_gpu()?;
+    caps.enable_bidi()?;
+
+    let driver = WebDriver::managed(caps).await?;
+    let bidi = driver.bidi().await?;
+
+    // Subscribe BEFORE adding the intercept so we don't miss the event.
+    bidi.session().subscribe("network.beforeRequestSent").await?;
+    let mut events = bidi.subscribe::<BeforeRequestSent>();
+
+    let intercept = bidi
+        .network()
+        .add_intercept(vec![network::InterceptPhase::BeforeRequestSent], None)
+        .await?;
+    println!("intercept registered: {}", intercept.intercept);
+
+    let tree = bidi.browsing_context().get_tree(None).await?;
+    let context = tree.contexts[0].context.clone();
+
+    // Kick off the navigation in the background — it won't return until
+    // we continue the paused request.
+    let nav = {
+        let bidi = bidi.clone();
+        let context = context.clone();
+        tokio::spawn(async move {
+            bidi.browsing_context()
+                .navigate(context, "https://example.com/", Some(ReadinessState::Complete))
+                .await
+        })
+    };
+
+    // Wait for the paused request and let it through unmodified.
+    while let Some(event) = events.next().await {
+        if event.is_blocked && event.request.url.starts_with("https://example.com/") {
+            println!("continuing paused {} {}", event.request.method, event.request.url);
+            bidi.network().continue_request(event.request.request).await?;
+            break;
+        }
+    }
+
+    nav.await.map_err(|e| WebDriverError::FatalError(format!("nav join: {e}")))??;
+
+    bidi.network().remove_intercept(intercept.intercept).await?;
+    println!("page loaded; intercept removed");
+
+    driver.quit().await
+}

--- a/thirtyfour/src/bidi/capabilities.rs
+++ b/thirtyfour/src/bidi/capabilities.rs
@@ -1,0 +1,30 @@
+//! Discovery of the BiDi WebSocket URL for a WebDriver session.
+//!
+//! BiDi is negotiated via the W3C `webSocketUrl: true` capability on
+//! `New Session`. The driver responds with the actual `ws://...` URL on
+//! the session capabilities, which is what we read here.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::error::{WebDriverError, WebDriverErrorInner, WebDriverResult};
+use crate::session::handle::SessionHandle;
+
+/// Resolve the BiDi WebSocket URL for the given session.
+pub(crate) fn resolve_bidi_websocket_url(handle: &Arc<SessionHandle>) -> WebDriverResult<String> {
+    let caps = handle.capabilities();
+
+    if let Some(Value::String(url)) = caps.get("webSocketUrl") {
+        return Ok(url.clone());
+    }
+
+    Err(WebDriverError::from_inner(WebDriverErrorInner::NotFound(
+        "BiDi WebSocket URL".to_string(),
+        "session capabilities did not include a `webSocketUrl` string — \
+         did you call `caps.enable_bidi()` (or set `webSocketUrl: true` \
+         manually) before opening the session, and is the driver \
+         BiDi-capable (chromedriver ≥ 115, geckodriver ≥ 0.31)?"
+            .to_string(),
+    )))
+}

--- a/thirtyfour/src/bidi/command.rs
+++ b/thirtyfour/src/bidi/command.rs
@@ -1,0 +1,69 @@
+//! Core traits that pair a BiDi command's request type with its response
+//! type, and an event type with its method name.
+//!
+//! Implement [`BidiCommand`] for any command not in the curated set under
+//! [`crate::bidi::modules`]; the same `BiDi::send` / `EventStream`
+//! infrastructure will pick it up. [`BidiEvent`] is the same idea for events
+//! delivered to an active subscription.
+
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+/// A typed BiDi command.
+///
+/// `Self` is the request `params` type (must be [`Serialize`]); [`Returns`]
+/// is the typed `result` returned by [`crate::bidi::BiDi::send`]. `METHOD`
+/// is the wire name, e.g. `"browsingContext.navigate"`.
+///
+/// [`Returns`]: BidiCommand::Returns
+///
+/// # Example
+/// ```
+/// use serde::{Deserialize, Serialize};
+/// use thirtyfour::bidi::BidiCommand;
+///
+/// #[derive(Serialize)]
+/// struct NavigateParams {
+///     context: String,
+///     url: String,
+/// }
+///
+/// #[derive(Deserialize)]
+/// struct NavigateResult {
+///     navigation: Option<String>,
+///     url: String,
+/// }
+///
+/// impl BidiCommand for NavigateParams {
+///     const METHOD: &'static str = "browsingContext.navigate";
+///     type Returns = NavigateResult;
+/// }
+/// ```
+pub trait BidiCommand: Serialize {
+    /// Wire name of the command (e.g. `"browsingContext.navigate"`).
+    const METHOD: &'static str;
+    /// Response `result` type. Use [`Empty`] for commands that return `{}`.
+    type Returns: DeserializeOwned;
+}
+
+/// A typed BiDi event delivered through [`crate::bidi::BiDi::subscribe`].
+pub trait BidiEvent: DeserializeOwned + Clone + Send + Sync + 'static {
+    /// Wire name of the event (e.g. `"browsingContext.load"`).
+    const METHOD: &'static str;
+}
+
+/// Marker type for BiDi commands whose response `result` body is `{}`.
+///
+/// Many commands (`session.subscribe`, `browsingContext.close`,
+/// `script.removePreloadScript`, …) return an empty object on success.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Empty {}
+
+/// A raw event delivered by [`crate::bidi::BiDi::subscribe_raw`].
+#[derive(Debug, Clone)]
+pub struct RawEvent {
+    /// Wire name of the event (e.g. `"network.beforeRequestSent"`).
+    pub method: String,
+    /// Event params as raw JSON.
+    pub params: serde_json::Value,
+}

--- a/thirtyfour/src/bidi/error.rs
+++ b/thirtyfour/src/bidi/error.rs
@@ -1,0 +1,80 @@
+//! BiDi-specific error type.
+//!
+//! Failed BiDi commands return a JSON envelope of the form
+//! `{"type":"error","id":N,"error":"<code>","message":"...","stacktrace":"..."}`.
+//! [`BidiError`] is the typed view of that envelope.
+
+use serde::Deserialize;
+use std::fmt;
+
+/// A BiDi command error.
+///
+/// The `error` field is one of the W3C BiDi-defined error codes (e.g.
+/// `"unknown command"`, `"no such frame"`, `"invalid argument"`); kept as a
+/// `String` because the spec adds new codes over time.
+#[derive(Debug, Clone, thiserror::Error)]
+pub struct BidiError {
+    /// The BiDi method that failed (e.g. `"browsingContext.navigate"`).
+    pub command: String,
+    /// W3C BiDi error code (`"invalid argument"`, `"no such frame"`, …).
+    pub error: String,
+    /// Human-readable message from the driver.
+    pub message: String,
+    /// Optional stack trace from the driver.
+    pub stacktrace: Option<String>,
+}
+
+impl BidiError {
+    /// True if this error indicates the BiDi session ended (e.g. browser
+    /// closed). Detected by the W3C error code.
+    pub fn is_session_ended(&self) -> bool {
+        matches!(
+            self.error.as_str(),
+            "invalid session id" | "session not created" | "unable to close browser"
+        )
+    }
+
+    /// True if this error indicates the target referenced by the command
+    /// (browsing context, frame, element node, request, …) does not exist.
+    pub fn is_no_such(&self) -> bool {
+        self.error.starts_with("no such")
+    }
+}
+
+impl fmt::Display for BidiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BiDi command {} failed: {} — {}", self.command, self.error, self.message)
+    }
+}
+
+impl From<BidiError> for crate::error::WebDriverError {
+    fn from(e: BidiError) -> Self {
+        // BiDi errors carry richer information than the W3C HTTP error
+        // shape, so we render them as `FatalError` strings rather than
+        // pretending to be a typed W3C error code (would require synthetic
+        // `WebDriverErrorInfo`s). Users who want the typed BiDi shape
+        // should call `BiDi::send` directly and get back `BidiError`.
+        crate::error::WebDriverError::FatalError(e.to_string())
+    }
+}
+
+/// Wire shape of an error envelope as it appears on the WebSocket. Used by
+/// the transport when parsing responses.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct BidiErrorEnvelope {
+    pub error: String,
+    pub message: String,
+    #[serde(default)]
+    pub stacktrace: Option<String>,
+}
+
+impl BidiErrorEnvelope {
+    pub(crate) fn into_error(self, command: impl Into<String>) -> BidiError {
+        BidiError {
+            command: command.into(),
+            error: self.error,
+            message: self.message,
+            stacktrace: self.stacktrace,
+        }
+    }
+}

--- a/thirtyfour/src/bidi/events.rs
+++ b/thirtyfour/src/bidi/events.rs
@@ -1,0 +1,136 @@
+//! Event subscription primitives for [`crate::bidi::BiDi`].
+//!
+//! A subscription is a `Stream<Item = E>` filtered to one event method
+//! name. Backed by a `tokio::sync::broadcast` channel that fans out from
+//! the WebSocket reader task to every active subscriber.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_util::Stream;
+use tokio::sync::broadcast::error::TryRecvError;
+use tokio::sync::broadcast::{Receiver, error::RecvError};
+
+use super::BidiEvent;
+use super::command::RawEvent;
+
+/// A typed BiDi event stream.
+///
+/// Constructed via [`crate::bidi::BiDi::subscribe`]. Internally a wrapper
+/// over a `tokio::sync::broadcast::Receiver` that filters by event method
+/// name, then deserialises params into `T`.
+///
+/// Items where the wire shape can't be deserialised as `T` are silently
+/// skipped — they shouldn't happen unless a vendor-specific event method
+/// name collides, in which case the user should switch to
+/// [`crate::bidi::BiDi::subscribe_raw`] and parse manually.
+#[derive(Debug)]
+pub struct EventStream<T> {
+    rx: Receiver<RawEvent>,
+    method: &'static str,
+    _marker: std::marker::PhantomData<fn() -> T>,
+}
+
+impl<T> EventStream<T> {
+    pub(crate) fn new(rx: Receiver<RawEvent>, method: &'static str) -> Self {
+        Self {
+            rx,
+            method,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    fn matches(&self, raw: &RawEvent) -> bool {
+        raw.method == self.method
+    }
+}
+
+impl<T: BidiEvent> Stream for EventStream<T> {
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            match this.rx.try_recv() {
+                Ok(raw) => {
+                    if this.matches(&raw)
+                        && let Ok(parsed) = serde_json::from_value::<T>(raw.params)
+                    {
+                        return Poll::Ready(Some(parsed));
+                    }
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Lagged(_)) => continue,
+                Err(TryRecvError::Closed) => return Poll::Ready(None),
+            }
+        }
+
+        let polled = {
+            let recv = this.rx.recv();
+            tokio::pin!(recv);
+            recv.poll(cx)
+        };
+        match polled {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(raw)) => {
+                if this.matches(&raw)
+                    && let Ok(parsed) = serde_json::from_value::<T>(raw.params)
+                {
+                    return Poll::Ready(Some(parsed));
+                }
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Poll::Ready(Err(RecvError::Lagged(_))) => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Poll::Ready(Err(RecvError::Closed)) => Poll::Ready(None),
+        }
+    }
+}
+
+/// All-events stream returned by [`crate::bidi::BiDi::subscribe_raw`].
+/// Yields raw `RawEvent`s without method or shape filtering.
+#[derive(Debug)]
+pub struct RawEventStream {
+    rx: Receiver<RawEvent>,
+}
+
+impl RawEventStream {
+    pub(crate) fn new(rx: Receiver<RawEvent>) -> Self {
+        Self {
+            rx,
+        }
+    }
+}
+
+impl Stream for RawEventStream {
+    type Item = RawEvent;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            match this.rx.try_recv() {
+                Ok(raw) => return Poll::Ready(Some(raw)),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Lagged(_)) => continue,
+                Err(TryRecvError::Closed) => return Poll::Ready(None),
+            }
+        }
+        let polled = {
+            let recv = this.rx.recv();
+            tokio::pin!(recv);
+            recv.poll(cx)
+        };
+        match polled {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(raw)) => Poll::Ready(Some(raw)),
+            Poll::Ready(Err(RecvError::Lagged(_))) => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Poll::Ready(Err(RecvError::Closed)) => Poll::Ready(None),
+        }
+    }
+}

--- a/thirtyfour/src/bidi/handle.rs
+++ b/thirtyfour/src/bidi/handle.rs
@@ -1,0 +1,147 @@
+//! The [`BiDi`] handle — the entry point for WebDriver BiDi.
+//!
+//! Returned by [`crate::WebDriver::bidi`]. Cheap to clone (wraps an
+//! `Arc`-shared transport).
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use super::BidiEvent;
+use super::capabilities::resolve_bidi_websocket_url;
+use super::command::BidiCommand;
+use super::error::BidiError;
+use super::events::{EventStream, RawEventStream};
+use super::modules;
+use super::transport::ws::BidiTransport;
+use crate::error::WebDriverResult;
+use crate::session::handle::SessionHandle;
+
+/// WebDriver BiDi handle.
+///
+/// Cheap to clone; wraps an internal `Arc`. Open one with
+/// [`crate::WebDriver::bidi`]; the WebSocket is connected lazily on first
+/// call and reused thereafter.
+///
+/// # Example
+/// ```no_run
+/// # use thirtyfour::prelude::*;
+/// # async fn run() -> WebDriverResult<()> {
+/// let mut caps = DesiredCapabilities::chrome();
+/// caps.enable_bidi()?;
+/// let driver = WebDriver::new("http://localhost:4444", caps).await?;
+///
+/// let bidi = driver.bidi().await?;
+/// let status = bidi.session().status().await?;
+/// println!("ready: {}", status.ready);
+/// # driver.quit().await }
+/// ```
+#[derive(Debug, Clone)]
+pub struct BiDi {
+    transport: BidiTransport,
+}
+
+impl BiDi {
+    /// Connect to the BiDi WebSocket discovered from the session's
+    /// capabilities.
+    pub(crate) async fn connect(handle: Arc<SessionHandle>) -> WebDriverResult<Self> {
+        let url = resolve_bidi_websocket_url(&handle)?;
+        let transport = BidiTransport::connect(&url).await?;
+        Ok(Self {
+            transport,
+        })
+    }
+
+    /// Send a typed BiDi command and decode its `result`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use thirtyfour::prelude::*;
+    /// # async fn run(driver: WebDriver) -> WebDriverResult<()> {
+    /// use thirtyfour::bidi::modules::session::Status;
+    /// let info = driver.bidi().await?.send(Status).await?;
+    /// println!("{}", info.message);
+    /// # Ok(()) }
+    /// ```
+    pub async fn send<C: BidiCommand>(&self, params: C) -> Result<C::Returns, BidiError> {
+        let raw = self
+            .transport
+            .send_raw(C::METHOD, serde_json::to_value(params).map_err(serde_err)?)
+            .await?;
+        serde_json::from_value(raw).map_err(serde_err)
+    }
+
+    /// Send a BiDi command by name with raw JSON params, returning the raw
+    /// `result` value. Useful for one-off commands that aren't in the
+    /// curated set under [`crate::bidi::modules`].
+    pub async fn send_raw(&self, method: &str, params: Value) -> Result<Value, BidiError> {
+        self.transport.send_raw(method, params).await
+    }
+
+    /// Subscribe to a typed event. The driver only delivers events the
+    /// client has explicitly subscribed to via `session.subscribe`; this
+    /// method is just the local stream end. Use [`Self::session`] to send
+    /// the subscription command.
+    pub fn subscribe<E: BidiEvent>(&self) -> EventStream<E> {
+        EventStream::new(self.transport.subscribe_events(), E::METHOD)
+    }
+
+    /// Subscribe to all events on the BiDi connection as raw `(method, params)`.
+    pub fn subscribe_raw(&self) -> RawEventStream {
+        RawEventStream::new(self.transport.subscribe_events())
+    }
+
+    /// `session.*` module facade (status, subscribe, end, …).
+    pub fn session(&self) -> modules::session::SessionModule<'_> {
+        modules::session::SessionModule::new(self)
+    }
+
+    /// `browser.*` module facade (close, user contexts).
+    pub fn browser(&self) -> modules::browser::BrowserModule<'_> {
+        modules::browser::BrowserModule::new(self)
+    }
+
+    /// `browsingContext.*` module facade (navigation, screenshots, tree …).
+    pub fn browsing_context(&self) -> modules::browsing_context::BrowsingContextModule<'_> {
+        modules::browsing_context::BrowsingContextModule::new(self)
+    }
+
+    /// `script.*` module facade (`evaluate`, `callFunction`, preload scripts).
+    pub fn script(&self) -> modules::script::ScriptModule<'_> {
+        modules::script::ScriptModule::new(self)
+    }
+
+    /// `network.*` module facade (interception, modify req/resp).
+    pub fn network(&self) -> modules::network::NetworkModule<'_> {
+        modules::network::NetworkModule::new(self)
+    }
+
+    /// `storage.*` module facade (cookies, partitions).
+    pub fn storage(&self) -> modules::storage::StorageModule<'_> {
+        modules::storage::StorageModule::new(self)
+    }
+
+    /// `log.*` module facade (event-only — no commands).
+    pub fn log(&self) -> modules::log::LogModule<'_> {
+        modules::log::LogModule::new(self)
+    }
+
+    /// `input.*` module facade (`performActions`, `releaseActions`, `setFiles`).
+    pub fn input(&self) -> modules::input::InputModule<'_> {
+        modules::input::InputModule::new(self)
+    }
+
+    /// `permissions.*` module facade (`setPermission`).
+    pub fn permissions(&self) -> modules::permissions::PermissionsModule<'_> {
+        modules::permissions::PermissionsModule::new(self)
+    }
+}
+
+fn serde_err(e: serde_json::Error) -> BidiError {
+    BidiError {
+        command: "<serde>".to_string(),
+        error: "unknown error".to_string(),
+        message: e.to_string(),
+        stacktrace: None,
+    }
+}

--- a/thirtyfour/src/bidi/ids.rs
+++ b/thirtyfour/src/bidi/ids.rs
@@ -1,0 +1,101 @@
+//! Newtypes for opaque BiDi identifiers.
+//!
+//! The spec uses a handful of distinct string-shaped ids that are easy to
+//! mix up. These newtypes preserve the wire format (`#[serde(transparent)]`)
+//! while keeping them distinct in Rust.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+macro_rules! string_id {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(pub String);
+
+        impl $name {
+            /// Construct from any string-like value.
+            pub fn new(s: impl Into<String>) -> Self {
+                Self(s.into())
+            }
+
+            /// Borrow the inner string.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(s: String) -> Self {
+                Self(s)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(s: &str) -> Self {
+                Self(s.to_string())
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+    };
+}
+
+string_id! {
+    /// Identifier for a browsing context (`browsingContext.BrowsingContext`).
+    /// On most drivers this is the same string used as a WebDriver classic
+    /// window handle.
+    BrowsingContextId
+}
+
+string_id! {
+    /// Identifier for a navigation initiated through BiDi
+    /// (`browsingContext.Navigation`).
+    NavigationId
+}
+
+string_id! {
+    /// Identifier for a script realm (`script.Realm`). Stable while the
+    /// realm exists; reused across `script.evaluate` / `script.callFunction`.
+    RealmId
+}
+
+string_id! {
+    /// Identifier for a preload script registered via
+    /// `script.addPreloadScript`.
+    PreloadScriptId
+}
+
+string_id! {
+    /// Identifier for a network request (`network.Request`).
+    RequestId
+}
+
+string_id! {
+    /// Identifier for a network request interception
+    /// (`network.Intercept`).
+    InterceptId
+}
+
+string_id! {
+    /// Identifier for a user context — BiDi's "incognito-like" isolation
+    /// container (`browser.UserContext`).
+    UserContextId
+}
+
+string_id! {
+    /// Opaque identifier for a script-shared DOM node
+    /// (`script.SharedReference.sharedId`). Stable across navigations
+    /// within the same browsing context.
+    NodeId
+}
+
+string_id! {
+    /// Channel identifier for `script.message` events.
+    ChannelId
+}

--- a/thirtyfour/src/bidi/macros.rs
+++ b/thirtyfour/src/bidi/macros.rs
@@ -1,0 +1,76 @@
+//! Internal macros for the BiDi layer.
+
+/// Define a closed-set BiDi string enum with a forward-compat
+/// `Unknown(String)` escape hatch.
+///
+/// Identical to [`crate::cdp::macros`] but kept private to the BiDi module
+/// so the two protocols can evolve independently. Wire values are spelled
+/// per variant so the macro works for both camelCase BiDi values
+/// (`granted`, `phaseLoad`) and dotted ones (`network.beforeRequestSent`).
+///
+/// Deserialising a value not in the enum yields `Unknown(<that string>)`,
+/// preserving forwards-compatibility when newer drivers add values.
+macro_rules! string_enum {
+    (
+        $(#[$meta:meta])*
+        $vis:vis enum $name:ident {
+            $(
+                $(#[$variant_meta:meta])*
+                $variant:ident = $wire:literal
+            ),+ $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+        $vis enum $name {
+            $(
+                $(#[$variant_meta])*
+                $variant,
+            )+
+            /// A wire value not yet known to this version of thirtyfour.
+            /// Round-trips through serde so newer driver values still
+            /// deserialise and re-serialise unchanged.
+            Unknown(String),
+        }
+
+        impl $name {
+            /// Wire-format string for this value.
+            pub fn as_str(&self) -> &str {
+                match self {
+                    $(Self::$variant => $wire,)+
+                    Self::Unknown(s) => s.as_str(),
+                }
+            }
+        }
+
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+
+        impl ::serde::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
+            where
+                S: ::serde::Serializer,
+            {
+                serializer.serialize_str(self.as_str())
+            }
+        }
+
+        impl<'de> ::serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+            where
+                D: ::serde::Deserializer<'de>,
+            {
+                let s = String::deserialize(deserializer)?;
+                ::std::result::Result::Ok(match s.as_str() {
+                    $($wire => Self::$variant,)+
+                    _ => Self::Unknown(s),
+                })
+            }
+        }
+    };
+}
+
+pub(crate) use string_enum;

--- a/thirtyfour/src/bidi/mod.rs
+++ b/thirtyfour/src/bidi/mod.rs
@@ -1,0 +1,69 @@
+//! WebDriver BiDi (W3C bidirectional protocol) support.
+//!
+//! WebDriver BiDi is the W3C-standard cross-browser successor to parts of
+//! Chrome DevTools Protocol. It runs over a WebSocket negotiated by the
+//! `webSocketUrl: true` capability on `New Session`; the driver responds
+//! with the actual `ws://...` URL on the session's capabilities.
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! # use thirtyfour::prelude::*;
+//! # async fn run() -> WebDriverResult<()> {
+//! let mut caps = DesiredCapabilities::chrome();
+//! caps.enable_bidi()?;
+//! let driver = WebDriver::new("http://localhost:4444", caps).await?;
+//!
+//! // Lazy-connect the BiDi WebSocket on first use; cached afterwards.
+//! let bidi = driver.bidi().await?;
+//! let status = bidi.session().status().await?;
+//! assert!(status.ready || !status.message.is_empty());
+//! # driver.quit().await }
+//! ```
+//!
+//! # Modules
+//!
+//! Curated typed bindings live under [`modules`](crate::bidi::modules):
+//!
+//! - [`session`](crate::bidi::modules::session) — protocol handshake,
+//!   subscription control, status.
+//! - [`browser`](crate::bidi::modules::browser) — top-level browser (close,
+//!   user contexts).
+//! - [`browsing_context`](crate::bidi::modules::browsing_context) — tabs,
+//!   frames, navigation, screenshots.
+//! - [`script`](crate::bidi::modules::script) — `evaluate`, `callFunction`,
+//!   preload scripts, realms.
+//! - [`network`](crate::bidi::modules::network) — interception,
+//!   modify-request/response, auth.
+//! - [`storage`](crate::bidi::modules::storage) — cookies and partition
+//!   lookup.
+//! - [`log`](crate::bidi::modules::log) — log entry events.
+//! - [`input`](crate::bidi::modules::input) — `performActions`,
+//!   `releaseActions`, `setFiles`.
+//! - [`permissions`](crate::bidi::modules::permissions) — `setPermission`.
+//!
+//! # Untyped escape hatch
+//!
+//! Anything outside the curated set goes through
+//! [`BiDi::send_raw`](crate::bidi::BiDi::send_raw) /
+//! [`BiDi::subscribe_raw`](crate::bidi::BiDi::subscribe_raw).
+
+pub mod modules;
+
+mod capabilities;
+mod command;
+mod error;
+mod events;
+mod handle;
+mod ids;
+mod macros;
+mod transport;
+
+pub use command::{BidiCommand, BidiEvent, Empty, RawEvent};
+pub use error::BidiError;
+pub use events::{EventStream, RawEventStream};
+pub use handle::BiDi;
+pub use ids::{
+    BrowsingContextId, ChannelId, InterceptId, NavigationId, NodeId, PreloadScriptId, RealmId,
+    RequestId, UserContextId,
+};

--- a/thirtyfour/src/bidi/modules/browser.rs
+++ b/thirtyfour/src/bidi/modules/browser.rs
@@ -1,0 +1,98 @@
+//! `browser.*` BiDi module — top-level browser control and user contexts.
+
+use serde::{Deserialize, Serialize};
+
+use crate::bidi::BiDi;
+use crate::bidi::command::{BidiCommand, Empty};
+use crate::bidi::error::BidiError;
+use crate::bidi::ids::UserContextId;
+
+/// `browser.close`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct Close;
+
+impl BidiCommand for Close {
+    const METHOD: &'static str = "browser.close";
+    type Returns = Empty;
+}
+
+/// `browser.createUserContext`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct CreateUserContext;
+
+impl BidiCommand for CreateUserContext {
+    const METHOD: &'static str = "browser.createUserContext";
+    type Returns = UserContextInfo;
+}
+
+/// One user context (incognito-like partition).
+#[derive(Debug, Clone, Deserialize)]
+pub struct UserContextInfo {
+    /// User context id.
+    #[serde(rename = "userContext")]
+    pub user_context: UserContextId,
+}
+
+/// `browser.getUserContexts`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GetUserContexts;
+
+impl BidiCommand for GetUserContexts {
+    const METHOD: &'static str = "browser.getUserContexts";
+    type Returns = GetUserContextsResult;
+}
+
+/// Response for [`GetUserContexts`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetUserContextsResult {
+    /// All known user contexts (always includes `"default"`).
+    #[serde(rename = "userContexts")]
+    pub user_contexts: Vec<UserContextInfo>,
+}
+
+/// `browser.removeUserContext`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveUserContext {
+    /// User context to remove. The default user context cannot be removed.
+    pub user_context: UserContextId,
+}
+
+impl BidiCommand for RemoveUserContext {
+    const METHOD: &'static str = "browser.removeUserContext";
+    type Returns = Empty;
+}
+
+/// Module facade returned by [`BiDi::browser`].
+#[derive(Debug)]
+pub struct BrowserModule<'a> {
+    bidi: &'a BiDi,
+}
+
+impl<'a> BrowserModule<'a> {
+    pub(crate) fn new(bidi: &'a BiDi) -> Self {
+        Self {
+            bidi,
+        }
+    }
+
+    /// `browser.createUserContext` — opens an incognito-like partition.
+    pub async fn create_user_context(&self) -> Result<UserContextInfo, BidiError> {
+        self.bidi.send(CreateUserContext).await
+    }
+
+    /// `browser.getUserContexts` — list all current user contexts.
+    pub async fn get_user_contexts(&self) -> Result<GetUserContextsResult, BidiError> {
+        self.bidi.send(GetUserContexts).await
+    }
+
+    /// `browser.removeUserContext` — close every context inside the partition.
+    pub async fn remove_user_context(&self, user_context: UserContextId) -> Result<(), BidiError> {
+        self.bidi
+            .send(RemoveUserContext {
+                user_context,
+            })
+            .await?;
+        Ok(())
+    }
+}

--- a/thirtyfour/src/bidi/modules/browsing_context.rs
+++ b/thirtyfour/src/bidi/modules/browsing_context.rs
@@ -1,0 +1,623 @@
+//! `browsingContext.*` BiDi module — tabs, frames, navigation, screenshots.
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::bidi::BiDi;
+use crate::bidi::command::{BidiCommand, BidiEvent, Empty};
+use crate::bidi::error::BidiError;
+use crate::bidi::ids::{BrowsingContextId, NavigationId, UserContextId};
+use crate::bidi::macros::string_enum;
+
+string_enum! {
+    /// Wait condition for [`Navigate`] (`browsingContext.navigate`).
+    pub enum ReadinessState {
+        /// Resolve as soon as the navigation has been initiated.
+        None = "none",
+        /// Resolve when the document has been parsed.
+        Interactive = "interactive",
+        /// Resolve when the load event has fired.
+        Complete = "complete",
+    }
+}
+
+string_enum! {
+    /// Lifecycle phase for [`events::DomContentLoaded`]-style events.
+    pub enum LifecyclePhase {
+        /// Document has loaded.
+        Load = "load",
+        /// `DOMContentLoaded` fired.
+        DomContentLoaded = "DOMContentLoaded",
+    }
+}
+
+string_enum! {
+    /// New-context creation type.
+    pub enum CreateType {
+        /// Open as a new tab in the existing window.
+        Tab = "tab",
+        /// Open as a new top-level window.
+        Window = "window",
+    }
+}
+
+string_enum! {
+    /// Image format for [`CaptureScreenshot`].
+    pub enum ImageFormatType {
+        /// PNG.
+        Png = "png",
+        /// JPEG (optionally lossy).
+        Jpeg = "jpeg",
+    }
+}
+
+string_enum! {
+    /// History traversal direction in [`TraverseHistory`].
+    pub enum TraversalDirection {
+        /// Equivalent to clicking the browser back button.
+        Back = "back",
+        /// Equivalent to clicking the browser forward button.
+        Forward = "forward",
+    }
+}
+
+/// `browsingContext.getTree`.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetTree {
+    /// Limit traversal depth. `Some(0)` returns just the matched roots.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_depth: Option<u32>,
+    /// Restrict the tree to descendants of this context. `None` returns all
+    /// top-level contexts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root: Option<BrowsingContextId>,
+}
+
+impl BidiCommand for GetTree {
+    const METHOD: &'static str = "browsingContext.getTree";
+    type Returns = GetTreeResult;
+}
+
+/// Response for [`GetTree`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetTreeResult {
+    /// One node per top-level context (or one node if [`GetTree::root`] was
+    /// set). Children populate [`BrowsingContextInfo::children`].
+    pub contexts: Vec<BrowsingContextInfo>,
+}
+
+/// A node in the browsing-context tree.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowsingContextInfo {
+    /// Identifier for this context.
+    pub context: BrowsingContextId,
+    /// Top-level context id this node belongs to.
+    pub parent: Option<BrowsingContextId>,
+    /// User context (incognito-like partition) the context lives in.
+    #[serde(default)]
+    pub user_context: Option<UserContextId>,
+    /// Descendants when traversal depth allows. Absent or `null` on the
+    /// wire — chromedriver sends `children: null` for the
+    /// `contextCreated` event when there are no descendants yet.
+    #[serde(default, deserialize_with = "null_to_default")]
+    pub children: Vec<BrowsingContextInfo>,
+    /// Current document URL.
+    pub url: String,
+    /// Whether this context is the active OS-level window.
+    #[serde(default)]
+    pub original_opener: Option<BrowsingContextId>,
+    /// Reflects `client_window` on newer drivers.
+    #[serde(default, rename = "clientWindow")]
+    pub client_window: Option<String>,
+}
+
+/// Deserializer that accepts both an absent field and a literal `null` and
+/// produces `T::default()`.
+fn null_to_default<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Default + Deserialize<'de>,
+{
+    Ok(Option::<T>::deserialize(d)?.unwrap_or_default())
+}
+
+/// `browsingContext.navigate`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Navigate {
+    /// Browsing context to navigate.
+    pub context: BrowsingContextId,
+    /// URL to load.
+    pub url: String,
+    /// Wait condition. Defaults to `Complete`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wait: Option<ReadinessState>,
+}
+
+impl BidiCommand for Navigate {
+    const METHOD: &'static str = "browsingContext.navigate";
+    type Returns = NavigateResult;
+}
+
+/// Response for [`Navigate`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct NavigateResult {
+    /// Server-assigned navigation id (`None` if `wait: None`).
+    pub navigation: Option<NavigationId>,
+    /// Final URL after redirects.
+    pub url: String,
+}
+
+/// `browsingContext.reload`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Reload {
+    /// Browsing context to reload.
+    pub context: BrowsingContextId,
+    /// If true, bypass HTTP caches.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore_cache: Option<bool>,
+    /// Wait condition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wait: Option<ReadinessState>,
+}
+
+impl BidiCommand for Reload {
+    const METHOD: &'static str = "browsingContext.reload";
+    type Returns = NavigateResult;
+}
+
+/// `browsingContext.create`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Create {
+    /// Whether to create a tab or window.
+    pub r#type: CreateType,
+    /// Optional reference context (used as opener / parent).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_context: Option<BrowsingContextId>,
+    /// Whether to bring the new context to the foreground.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background: Option<bool>,
+    /// User context to put it in.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_context: Option<UserContextId>,
+}
+
+impl BidiCommand for Create {
+    const METHOD: &'static str = "browsingContext.create";
+    type Returns = CreateResult;
+}
+
+/// Response for [`Create`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateResult {
+    /// Identifier for the newly created context.
+    pub context: BrowsingContextId,
+}
+
+/// `browsingContext.close`.
+#[derive(Debug, Clone, Serialize)]
+pub struct Close {
+    /// Browsing context to close.
+    pub context: BrowsingContextId,
+    /// If true, bypass any `beforeunload` prompt.
+    #[serde(rename = "promptUnload", skip_serializing_if = "Option::is_none")]
+    pub prompt_unload: Option<bool>,
+}
+
+impl BidiCommand for Close {
+    const METHOD: &'static str = "browsingContext.close";
+    type Returns = Empty;
+}
+
+/// `browsingContext.activate`.
+#[derive(Debug, Clone, Serialize)]
+pub struct Activate {
+    /// Browsing context to activate (focus the OS-level window).
+    pub context: BrowsingContextId,
+}
+
+impl BidiCommand for Activate {
+    const METHOD: &'static str = "browsingContext.activate";
+    type Returns = Empty;
+}
+
+/// `browsingContext.captureScreenshot`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptureScreenshot {
+    /// Browsing context to capture.
+    pub context: BrowsingContextId,
+    /// `viewport` (default) or `document` for a full-document screenshot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<ScreenshotOrigin>,
+    /// Output format.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<ImageFormat>,
+}
+
+string_enum! {
+    /// Origin coordinate system for [`CaptureScreenshot::origin`].
+    pub enum ScreenshotOrigin {
+        /// Capture only the visible viewport.
+        Viewport = "viewport",
+        /// Capture the entire scrolled document.
+        Document = "document",
+    }
+}
+
+/// Image format options for [`CaptureScreenshot::format`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImageFormat {
+    /// Image type — PNG or JPEG.
+    pub r#type: ImageFormatType,
+    /// JPEG quality, 0.0..=1.0. Ignored for PNG.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quality: Option<f64>,
+}
+
+impl BidiCommand for CaptureScreenshot {
+    const METHOD: &'static str = "browsingContext.captureScreenshot";
+    type Returns = CaptureScreenshotResult;
+}
+
+/// Response for [`CaptureScreenshot`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct CaptureScreenshotResult {
+    /// Base64-encoded image bytes.
+    pub data: String,
+}
+
+/// `browsingContext.setViewport`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetViewport {
+    /// Browsing context to resize.
+    pub context: BrowsingContextId,
+    /// Pixel viewport. `None` resets to driver default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub viewport: Option<Viewport>,
+    /// Device pixel ratio. `None` keeps current.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_pixel_ratio: Option<f64>,
+}
+
+/// Viewport shape used by [`SetViewport`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Viewport {
+    /// Pixel width.
+    pub width: u32,
+    /// Pixel height.
+    pub height: u32,
+}
+
+impl BidiCommand for SetViewport {
+    const METHOD: &'static str = "browsingContext.setViewport";
+    type Returns = Empty;
+}
+
+/// `browsingContext.traverseHistory`.
+#[derive(Debug, Clone, Serialize)]
+pub struct TraverseHistory {
+    /// Browsing context to traverse.
+    pub context: BrowsingContextId,
+    /// Number of steps. Negative goes back; positive goes forward.
+    pub delta: i32,
+}
+
+impl BidiCommand for TraverseHistory {
+    const METHOD: &'static str = "browsingContext.traverseHistory";
+    type Returns = Empty;
+}
+
+/// `browsingContext.handleUserPrompt`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HandleUserPrompt {
+    /// Browsing context whose dialog should be handled.
+    pub context: BrowsingContextId,
+    /// Accept the dialog (`true`) or dismiss (`false`). `None` lets the
+    /// driver pick the default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accept: Option<bool>,
+    /// Text to type for `prompt()` dialogs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_text: Option<String>,
+}
+
+impl BidiCommand for HandleUserPrompt {
+    const METHOD: &'static str = "browsingContext.handleUserPrompt";
+    type Returns = Empty;
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/// Events surfaced by the `browsingContext.*` module.
+pub mod events {
+    use super::*;
+
+    /// `browsingContext.contextCreated`.
+    #[derive(Debug, Clone, Deserialize)]
+    pub struct ContextCreated(pub BrowsingContextInfo);
+
+    impl BidiEvent for ContextCreated {
+        const METHOD: &'static str = "browsingContext.contextCreated";
+    }
+
+    /// `browsingContext.contextDestroyed`.
+    #[derive(Debug, Clone, Deserialize)]
+    pub struct ContextDestroyed(pub BrowsingContextInfo);
+
+    impl BidiEvent for ContextDestroyed {
+        const METHOD: &'static str = "browsingContext.contextDestroyed";
+    }
+
+    /// `browsingContext.navigationStarted`.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NavigationStarted {
+        /// Context the navigation belongs to.
+        pub context: BrowsingContextId,
+        /// Navigation id (matches [`NavigateResult::navigation`]).
+        pub navigation: Option<NavigationId>,
+        /// Target URL.
+        pub url: String,
+        /// Driver-assigned timestamp (ms since unix epoch).
+        pub timestamp: u64,
+    }
+
+    impl BidiEvent for NavigationStarted {
+        const METHOD: &'static str = "browsingContext.navigationStarted";
+    }
+
+    /// `browsingContext.load` — page load event.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Load {
+        /// Context that finished loading.
+        pub context: BrowsingContextId,
+        /// Navigation id.
+        pub navigation: Option<NavigationId>,
+        /// Final URL.
+        pub url: String,
+        /// Timestamp (ms since unix epoch).
+        pub timestamp: u64,
+    }
+
+    impl BidiEvent for Load {
+        const METHOD: &'static str = "browsingContext.load";
+    }
+
+    /// `browsingContext.domContentLoaded`.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DomContentLoaded {
+        /// Context the event belongs to.
+        pub context: BrowsingContextId,
+        /// Navigation id.
+        pub navigation: Option<NavigationId>,
+        /// Final URL.
+        pub url: String,
+        /// Timestamp (ms since unix epoch).
+        pub timestamp: u64,
+    }
+
+    impl BidiEvent for DomContentLoaded {
+        const METHOD: &'static str = "browsingContext.domContentLoaded";
+    }
+
+    /// `browsingContext.fragmentNavigated`.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct FragmentNavigated {
+        /// Context.
+        pub context: BrowsingContextId,
+        /// Navigation id.
+        pub navigation: Option<NavigationId>,
+        /// New URL.
+        pub url: String,
+        /// Timestamp.
+        pub timestamp: u64,
+    }
+
+    impl BidiEvent for FragmentNavigated {
+        const METHOD: &'static str = "browsingContext.fragmentNavigated";
+    }
+
+    /// `browsingContext.userPromptOpened`.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct UserPromptOpened {
+        /// Context that opened the prompt.
+        pub context: BrowsingContextId,
+        /// Dialog kind (`alert`, `confirm`, `prompt`, `beforeunload`).
+        #[serde(rename = "type")]
+        pub prompt_type: String,
+        /// Prompt message.
+        pub message: String,
+        /// Default value for `prompt()` dialogs.
+        #[serde(default)]
+        pub default_value: Option<String>,
+    }
+
+    impl BidiEvent for UserPromptOpened {
+        const METHOD: &'static str = "browsingContext.userPromptOpened";
+    }
+
+    /// `browsingContext.userPromptClosed`.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct UserPromptClosed {
+        /// Context the prompt was attached to.
+        pub context: BrowsingContextId,
+        /// Whether the prompt was accepted.
+        pub accepted: bool,
+        /// Text the user typed (for prompt dialogs).
+        #[serde(default)]
+        pub user_text: Option<String>,
+    }
+
+    impl BidiEvent for UserPromptClosed {
+        const METHOD: &'static str = "browsingContext.userPromptClosed";
+    }
+}
+
+/// Module facade returned by [`BiDi::browsing_context`].
+#[derive(Debug)]
+pub struct BrowsingContextModule<'a> {
+    bidi: &'a BiDi,
+}
+
+impl<'a> BrowsingContextModule<'a> {
+    pub(crate) fn new(bidi: &'a BiDi) -> Self {
+        Self {
+            bidi,
+        }
+    }
+
+    /// `browsingContext.getTree` — full tree of all top-level contexts.
+    pub async fn get_tree(
+        &self,
+        root: Option<BrowsingContextId>,
+    ) -> Result<GetTreeResult, BidiError> {
+        self.bidi
+            .send(GetTree {
+                max_depth: None,
+                root,
+            })
+            .await
+    }
+
+    /// `browsingContext.navigate`.
+    pub async fn navigate(
+        &self,
+        context: BrowsingContextId,
+        url: impl Into<String>,
+        wait: Option<ReadinessState>,
+    ) -> Result<NavigateResult, BidiError> {
+        self.bidi
+            .send(Navigate {
+                context,
+                url: url.into(),
+                wait,
+            })
+            .await
+    }
+
+    /// `browsingContext.reload`.
+    pub async fn reload(
+        &self,
+        context: BrowsingContextId,
+        ignore_cache: bool,
+        wait: Option<ReadinessState>,
+    ) -> Result<NavigateResult, BidiError> {
+        self.bidi
+            .send(Reload {
+                context,
+                ignore_cache: Some(ignore_cache),
+                wait,
+            })
+            .await
+    }
+
+    /// `browsingContext.create` — open a new tab or window.
+    pub async fn create(&self, kind: CreateType) -> Result<CreateResult, BidiError> {
+        self.bidi
+            .send(Create {
+                r#type: kind,
+                reference_context: None,
+                background: None,
+                user_context: None,
+            })
+            .await
+    }
+
+    /// `browsingContext.close`.
+    pub async fn close(&self, context: BrowsingContextId) -> Result<(), BidiError> {
+        self.bidi
+            .send(Close {
+                context,
+                prompt_unload: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `browsingContext.activate`.
+    pub async fn activate(&self, context: BrowsingContextId) -> Result<(), BidiError> {
+        self.bidi
+            .send(Activate {
+                context,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `browsingContext.captureScreenshot` — viewport, PNG. Returns
+    /// base64-encoded PNG bytes.
+    pub async fn capture_screenshot(
+        &self,
+        context: BrowsingContextId,
+    ) -> Result<CaptureScreenshotResult, BidiError> {
+        self.bidi
+            .send(CaptureScreenshot {
+                context,
+                origin: Some(ScreenshotOrigin::Viewport),
+                format: None,
+            })
+            .await
+    }
+
+    /// `browsingContext.setViewport`.
+    pub async fn set_viewport(
+        &self,
+        context: BrowsingContextId,
+        viewport: Option<Viewport>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetViewport {
+                context,
+                viewport,
+                device_pixel_ratio: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `browsingContext.traverseHistory`.
+    pub async fn traverse_history(
+        &self,
+        context: BrowsingContextId,
+        delta: i32,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(TraverseHistory {
+                context,
+                delta,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `browsingContext.handleUserPrompt`.
+    pub async fn handle_user_prompt(
+        &self,
+        context: BrowsingContextId,
+        accept: Option<bool>,
+        user_text: Option<String>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(HandleUserPrompt {
+                context,
+                accept,
+                user_text,
+            })
+            .await?;
+        Ok(())
+    }
+}

--- a/thirtyfour/src/bidi/modules/input.rs
+++ b/thirtyfour/src/bidi/modules/input.rs
@@ -1,0 +1,119 @@
+//! `input.*` BiDi module — `performActions`, `releaseActions`, `setFiles`.
+//!
+//! Action sources (key, pointer, wheel, none) follow the same JSON shape
+//! as W3C WebDriver classic actions. Action source objects are passed
+//! through as `serde_json::Value` so callers can construct them with the
+//! `json!` macro or build their own typed wrappers.
+
+use serde::Serialize;
+
+use crate::bidi::BiDi;
+use crate::bidi::command::{BidiCommand, Empty};
+use crate::bidi::error::BidiError;
+use crate::bidi::ids::{BrowsingContextId, NodeId};
+
+/// `input.performActions`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PerformActions {
+    /// Browsing context the actions apply to.
+    pub context: BrowsingContextId,
+    /// One entry per input source. Each is a JSON object with `id`, `type`,
+    /// optional `parameters`, and an `actions` array.
+    pub actions: Vec<serde_json::Value>,
+}
+
+impl BidiCommand for PerformActions {
+    const METHOD: &'static str = "input.performActions";
+    type Returns = Empty;
+}
+
+/// `input.releaseActions`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReleaseActions {
+    /// Browsing context.
+    pub context: BrowsingContextId,
+}
+
+impl BidiCommand for ReleaseActions {
+    const METHOD: &'static str = "input.releaseActions";
+    type Returns = Empty;
+}
+
+/// `input.setFiles`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SetFiles {
+    /// Browsing context.
+    pub context: BrowsingContextId,
+    /// Element to set files on, as a BiDi `script.SharedReference`. Use
+    /// [`shared_reference`] to construct.
+    pub element: serde_json::Value,
+    /// File paths.
+    pub files: Vec<String>,
+}
+
+/// Wrap a [`NodeId`] in the `script.SharedReference` JSON shape that
+/// `input.setFiles` expects (`{"sharedId":"…"}`).
+pub fn shared_reference(node: &NodeId) -> serde_json::Value {
+    serde_json::json!({"sharedId": node.as_str()})
+}
+
+impl BidiCommand for SetFiles {
+    const METHOD: &'static str = "input.setFiles";
+    type Returns = Empty;
+}
+
+/// Module facade returned by [`BiDi::input`].
+#[derive(Debug)]
+pub struct InputModule<'a> {
+    bidi: &'a BiDi,
+}
+
+impl<'a> InputModule<'a> {
+    pub(crate) fn new(bidi: &'a BiDi) -> Self {
+        Self {
+            bidi,
+        }
+    }
+
+    /// `input.performActions`.
+    pub async fn perform_actions(
+        &self,
+        context: BrowsingContextId,
+        actions: Vec<serde_json::Value>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(PerformActions {
+                context,
+                actions,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `input.releaseActions`.
+    pub async fn release_actions(&self, context: BrowsingContextId) -> Result<(), BidiError> {
+        self.bidi
+            .send(ReleaseActions {
+                context,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `input.setFiles`.
+    pub async fn set_files(
+        &self,
+        context: BrowsingContextId,
+        element: &NodeId,
+        files: Vec<String>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetFiles {
+                context,
+                element: shared_reference(element),
+                files,
+            })
+            .await?;
+        Ok(())
+    }
+}

--- a/thirtyfour/src/bidi/modules/log.rs
+++ b/thirtyfour/src/bidi/modules/log.rs
@@ -1,0 +1,79 @@
+//! `log.*` BiDi module — event-only.
+
+use serde::Deserialize;
+
+use crate::bidi::BiDi;
+use crate::bidi::command::BidiEvent;
+use crate::bidi::ids::RealmId;
+use crate::bidi::macros::string_enum;
+
+string_enum! {
+    /// Severity for [`events::EntryAdded`].
+    pub enum LogLevel {
+        /// `console.debug` and friends.
+        Debug = "debug",
+        /// `console.info` / `console.log`.
+        Info = "info",
+        /// `console.warn`.
+        Warn = "warn",
+        /// `console.error` and uncaught exceptions.
+        Error = "error",
+    }
+}
+
+/// Events surfaced by the `log.*` module.
+pub mod events {
+    use super::*;
+
+    /// `log.entryAdded`. Modeled as a JSON-flexible struct since the spec
+    /// distinguishes `console`, `javascript`, and other entry types via the
+    /// `type` field with different schemas. Common fields are typed; the
+    /// rest land in [`EntryAdded::extra`].
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct EntryAdded {
+        /// Entry kind (`"console"`, `"javascript"`, …).
+        #[serde(rename = "type")]
+        pub entry_type: String,
+        /// Severity.
+        pub level: LogLevel,
+        /// Source realm.
+        #[serde(default)]
+        pub source: serde_json::Value,
+        /// Coalesced text.
+        #[serde(default)]
+        pub text: Option<String>,
+        /// Driver timestamp (ms since epoch).
+        pub timestamp: u64,
+        /// Stack trace (if any).
+        #[serde(default)]
+        pub stack_trace: serde_json::Value,
+        /// JS realm id (where applicable).
+        #[serde(default)]
+        pub realm: Option<RealmId>,
+        /// Extra type-specific fields (e.g. `method` and `args` for console).
+        #[serde(flatten)]
+        pub extra: serde_json::Map<String, serde_json::Value>,
+    }
+
+    impl BidiEvent for EntryAdded {
+        const METHOD: &'static str = "log.entryAdded";
+    }
+}
+
+/// Module facade returned by [`BiDi::log`]. The `log` module is event-only
+/// in the spec — there are no commands. The facade exists for symmetry with
+/// the other modules.
+#[derive(Debug)]
+pub struct LogModule<'a> {
+    #[allow(dead_code)]
+    bidi: &'a BiDi,
+}
+
+impl<'a> LogModule<'a> {
+    pub(crate) fn new(bidi: &'a BiDi) -> Self {
+        Self {
+            bidi,
+        }
+    }
+}

--- a/thirtyfour/src/bidi/modules/mod.rs
+++ b/thirtyfour/src/bidi/modules/mod.rs
@@ -1,0 +1,26 @@
+//! Curated typed bindings for WebDriver BiDi modules.
+//!
+//! Each submodule mirrors a [W3C BiDi spec module]. Commands implement
+//! [`crate::bidi::BidiCommand`] and events implement
+//! [`crate::bidi::BidiEvent`]; both flow through [`crate::bidi::BiDi`].
+//!
+//! [W3C BiDi spec module]: https://w3c.github.io/webdriver-bidi/
+
+/// `browser.*` — top-level browser control and user contexts.
+pub mod browser;
+/// `browsingContext.*` — tabs, frames, navigation, screenshots.
+pub mod browsing_context;
+/// `input.*` — `performActions`, `releaseActions`, `setFiles`.
+pub mod input;
+/// `log.*` — log entry events.
+pub mod log;
+/// `network.*` — interception and request/response control.
+pub mod network;
+/// `permissions.*` — `setPermission`.
+pub mod permissions;
+/// `script.*` — `evaluate`, `callFunction`, preload scripts, realms.
+pub mod script;
+/// `session.*` — protocol handshake, subscription, status.
+pub mod session;
+/// `storage.*` — cookies and partitions.
+pub mod storage;

--- a/thirtyfour/src/bidi/modules/network.rs
+++ b/thirtyfour/src/bidi/modules/network.rs
@@ -1,0 +1,495 @@
+//! `network.*` BiDi module — request observation, interception, and modify
+//! request/response.
+
+use serde::{Deserialize, Serialize};
+
+use crate::bidi::BiDi;
+use crate::bidi::command::{BidiCommand, BidiEvent, Empty};
+use crate::bidi::error::BidiError;
+use crate::bidi::ids::{BrowsingContextId, InterceptId, RequestId, UserContextId};
+use crate::bidi::macros::string_enum;
+
+string_enum! {
+    /// Phase a [`AddIntercept`] should fire on.
+    pub enum InterceptPhase {
+        /// Before the request leaves the network stack.
+        BeforeRequestSent = "beforeRequestSent",
+        /// When the response arrives, before delivery.
+        ResponseStarted = "responseStarted",
+        /// On HTTP 401 / proxy auth.
+        AuthRequired = "authRequired",
+    }
+}
+
+string_enum! {
+    /// HTTP cache mode for [`SetCacheBehavior`].
+    pub enum CacheBehavior {
+        /// Default — honour cache headers.
+        Default = "default",
+        /// Bypass cache entirely.
+        Bypass = "bypass",
+    }
+}
+
+/// `network.addIntercept`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddIntercept {
+    /// Phase(s) to intercept.
+    pub phases: Vec<InterceptPhase>,
+    /// Restrict to specific browsing contexts. Empty = global.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub contexts: Vec<BrowsingContextId>,
+    /// URL match patterns. Each is a string-or-object per BiDi
+    /// `network.UrlPattern`. Pass-through as JSON.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url_patterns: Option<Vec<serde_json::Value>>,
+}
+
+impl BidiCommand for AddIntercept {
+    const METHOD: &'static str = "network.addIntercept";
+    type Returns = AddInterceptResult;
+}
+
+/// Response for [`AddIntercept`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct AddInterceptResult {
+    /// Server-assigned intercept id.
+    pub intercept: InterceptId,
+}
+
+/// `network.removeIntercept`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoveIntercept {
+    /// Intercept id returned by [`AddIntercept`].
+    pub intercept: InterceptId,
+}
+
+impl BidiCommand for RemoveIntercept {
+    const METHOD: &'static str = "network.removeIntercept";
+    type Returns = Empty;
+}
+
+/// `network.continueRequest` — let an intercepted request proceed,
+/// optionally with modifications.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContinueRequest {
+    /// Request to continue.
+    pub request: RequestId,
+    /// Override request body (BiDi `network.BytesValue`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<serde_json::Value>,
+    /// Override cookies (BiDi `network.CookieHeader[]`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cookies: Option<Vec<serde_json::Value>>,
+    /// Override headers (BiDi `network.Header[]`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<Vec<serde_json::Value>>,
+    /// Override HTTP method.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    /// Override URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+impl BidiCommand for ContinueRequest {
+    const METHOD: &'static str = "network.continueRequest";
+    type Returns = Empty;
+}
+
+/// `network.continueResponse` — let an intercepted response proceed,
+/// optionally with modifications.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContinueResponse {
+    /// Request whose response is being continued.
+    pub request: RequestId,
+    /// Override cookies.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cookies: Option<Vec<serde_json::Value>>,
+    /// Override credentials (basic-auth).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<serde_json::Value>,
+    /// Override headers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<Vec<serde_json::Value>>,
+    /// Override status reason phrase.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason_phrase: Option<String>,
+    /// Override status code.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_code: Option<u16>,
+}
+
+impl BidiCommand for ContinueResponse {
+    const METHOD: &'static str = "network.continueResponse";
+    type Returns = Empty;
+}
+
+/// `network.continueWithAuth` — answer an `authRequired` intercept.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContinueWithAuth {
+    /// Request to continue.
+    pub request: RequestId,
+    /// Action and credentials. Use [`AuthAction`] helpers below.
+    #[serde(flatten)]
+    pub action: AuthAction,
+}
+
+/// Action passed to [`ContinueWithAuth`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "action", rename_all = "lowercase")]
+pub enum AuthAction {
+    /// Provide credentials.
+    ProvideCredentials {
+        /// Credentials object.
+        credentials: AuthCredentials,
+    },
+    /// Cancel the auth request.
+    Cancel,
+    /// Default — let the browser handle it.
+    Default,
+}
+
+/// Basic-auth credentials.
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthCredentials {
+    /// Auth scheme (`"basic"`).
+    pub r#type: String,
+    /// Username.
+    pub username: String,
+    /// Password.
+    pub password: String,
+}
+
+impl AuthCredentials {
+    /// Construct a basic-auth credentials object.
+    pub fn basic(username: impl Into<String>, password: impl Into<String>) -> Self {
+        Self {
+            r#type: "basic".to_string(),
+            username: username.into(),
+            password: password.into(),
+        }
+    }
+}
+
+impl BidiCommand for ContinueWithAuth {
+    const METHOD: &'static str = "network.continueWithAuth";
+    type Returns = Empty;
+}
+
+/// `network.failRequest` — fail an intercepted request.
+#[derive(Debug, Clone, Serialize)]
+pub struct FailRequest {
+    /// Request to fail.
+    pub request: RequestId,
+}
+
+impl BidiCommand for FailRequest {
+    const METHOD: &'static str = "network.failRequest";
+    type Returns = Empty;
+}
+
+/// `network.provideResponse` — synthesize a response for an intercepted
+/// request (instead of letting it reach the network).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProvideResponse {
+    /// Request to respond to.
+    pub request: RequestId,
+    /// Response body (`network.BytesValue`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<serde_json::Value>,
+    /// Cookies.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cookies: Option<Vec<serde_json::Value>>,
+    /// Headers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<Vec<serde_json::Value>>,
+    /// Reason phrase.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason_phrase: Option<String>,
+    /// Status code.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_code: Option<u16>,
+}
+
+impl BidiCommand for ProvideResponse {
+    const METHOD: &'static str = "network.provideResponse";
+    type Returns = Empty;
+}
+
+/// `network.setCacheBehavior`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetCacheBehavior {
+    /// Cache mode.
+    pub cache_behavior: CacheBehavior,
+    /// Restrict to specific browsing contexts. Empty = global.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub contexts: Vec<BrowsingContextId>,
+    /// Restrict to specific user contexts. Empty = global.
+    #[serde(rename = "userContexts", skip_serializing_if = "Vec::is_empty")]
+    pub user_contexts: Vec<UserContextId>,
+}
+
+impl BidiCommand for SetCacheBehavior {
+    const METHOD: &'static str = "network.setCacheBehavior";
+    type Returns = Empty;
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/// Events surfaced by the `network.*` module.
+pub mod events {
+    use super::*;
+
+    /// `network.beforeRequestSent`.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct BeforeRequestSent {
+        /// Browsing context the request belongs to (top-level for nav).
+        pub context: Option<BrowsingContextId>,
+        /// Underlying request data (BiDi `network.RequestData`).
+        pub request: RequestData,
+        /// Driver timestamp (ms since epoch).
+        pub timestamp: u64,
+        /// Optional initiator info.
+        #[serde(default)]
+        pub initiator: Option<serde_json::Value>,
+        /// Whether the request is currently blocked by an intercept.
+        #[serde(default)]
+        pub is_blocked: bool,
+        /// Intercept ids that match this request.
+        #[serde(default)]
+        pub intercepts: Vec<InterceptId>,
+    }
+
+    impl BidiEvent for BeforeRequestSent {
+        const METHOD: &'static str = "network.beforeRequestSent";
+    }
+
+    /// `network.responseStarted`.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ResponseStarted {
+        /// Browsing context.
+        pub context: Option<BrowsingContextId>,
+        /// Request data.
+        pub request: RequestData,
+        /// Response data.
+        pub response: ResponseData,
+        /// Driver timestamp.
+        pub timestamp: u64,
+        /// Whether currently blocked by an intercept.
+        #[serde(default)]
+        pub is_blocked: bool,
+        /// Intercept ids that match this response.
+        #[serde(default)]
+        pub intercepts: Vec<InterceptId>,
+    }
+
+    impl BidiEvent for ResponseStarted {
+        const METHOD: &'static str = "network.responseStarted";
+    }
+
+    /// `network.responseCompleted`.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ResponseCompleted {
+        /// Browsing context.
+        pub context: Option<BrowsingContextId>,
+        /// Request data.
+        pub request: RequestData,
+        /// Response data.
+        pub response: ResponseData,
+        /// Driver timestamp.
+        pub timestamp: u64,
+    }
+
+    impl BidiEvent for ResponseCompleted {
+        const METHOD: &'static str = "network.responseCompleted";
+    }
+
+    /// `network.fetchError`.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct FetchError {
+        /// Browsing context.
+        pub context: Option<BrowsingContextId>,
+        /// Request data.
+        pub request: RequestData,
+        /// Driver timestamp.
+        pub timestamp: u64,
+        /// Error string (browser-defined).
+        pub error_text: String,
+    }
+
+    impl BidiEvent for FetchError {
+        const METHOD: &'static str = "network.fetchError";
+    }
+
+    /// `network.authRequired`.
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct AuthRequired {
+        /// Browsing context.
+        pub context: Option<BrowsingContextId>,
+        /// Request data.
+        pub request: RequestData,
+        /// Response data (status will be 401 / 407).
+        pub response: ResponseData,
+        /// Driver timestamp.
+        pub timestamp: u64,
+        /// Whether currently blocked by an intercept.
+        #[serde(default)]
+        pub is_blocked: bool,
+    }
+
+    impl BidiEvent for AuthRequired {
+        const METHOD: &'static str = "network.authRequired";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire-shape types reused by events.
+// ---------------------------------------------------------------------------
+
+/// Subset of BiDi's `network.RequestData` we model strongly. Vendor or
+/// rarely-used fields fall through to [`RequestData::extra`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestData {
+    /// Request id.
+    pub request: RequestId,
+    /// HTTP method.
+    pub method: String,
+    /// Full URL.
+    pub url: String,
+    /// Headers (`network.Header[]`).
+    #[serde(default)]
+    pub headers: Vec<serde_json::Value>,
+    /// Cookies sent on the request.
+    #[serde(default)]
+    pub cookies: Vec<serde_json::Value>,
+    /// Other fields (timing, body size, …).
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Subset of BiDi's `network.ResponseData` we model strongly.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResponseData {
+    /// Final URL after redirects.
+    pub url: String,
+    /// HTTP protocol (`"http/1.1"`, `"h2"`, …).
+    #[serde(default)]
+    pub protocol: Option<String>,
+    /// HTTP status code.
+    pub status: u16,
+    /// Status reason phrase.
+    pub status_text: String,
+    /// Headers.
+    #[serde(default)]
+    pub headers: Vec<serde_json::Value>,
+    /// Other fields (mime type, encoding, …).
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Module facade returned by [`BiDi::network`].
+#[derive(Debug)]
+pub struct NetworkModule<'a> {
+    bidi: &'a BiDi,
+}
+
+impl<'a> NetworkModule<'a> {
+    pub(crate) fn new(bidi: &'a BiDi) -> Self {
+        Self {
+            bidi,
+        }
+    }
+
+    /// `network.addIntercept`.
+    pub async fn add_intercept(
+        &self,
+        phases: Vec<InterceptPhase>,
+        url_patterns: Option<Vec<serde_json::Value>>,
+    ) -> Result<AddInterceptResult, BidiError> {
+        self.bidi
+            .send(AddIntercept {
+                phases,
+                contexts: vec![],
+                url_patterns,
+            })
+            .await
+    }
+
+    /// `network.removeIntercept`.
+    pub async fn remove_intercept(&self, intercept: InterceptId) -> Result<(), BidiError> {
+        self.bidi
+            .send(RemoveIntercept {
+                intercept,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `network.continueRequest` (no modifications).
+    pub async fn continue_request(&self, request: RequestId) -> Result<(), BidiError> {
+        self.bidi
+            .send(ContinueRequest {
+                request,
+                body: None,
+                cookies: None,
+                headers: None,
+                method: None,
+                url: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `network.continueResponse` (no modifications).
+    pub async fn continue_response(&self, request: RequestId) -> Result<(), BidiError> {
+        self.bidi
+            .send(ContinueResponse {
+                request,
+                cookies: None,
+                credentials: None,
+                headers: None,
+                reason_phrase: None,
+                status_code: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `network.failRequest`.
+    pub async fn fail_request(&self, request: RequestId) -> Result<(), BidiError> {
+        self.bidi
+            .send(FailRequest {
+                request,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `network.setCacheBehavior` — global.
+    pub async fn set_cache_behavior(&self, mode: CacheBehavior) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetCacheBehavior {
+                cache_behavior: mode,
+                contexts: vec![],
+                user_contexts: vec![],
+            })
+            .await?;
+        Ok(())
+    }
+}

--- a/thirtyfour/src/bidi/modules/permissions.rs
+++ b/thirtyfour/src/bidi/modules/permissions.rs
@@ -1,0 +1,76 @@
+//! `permissions.*` BiDi module — `setPermission`.
+
+use serde::Serialize;
+
+use crate::bidi::BiDi;
+use crate::bidi::command::{BidiCommand, Empty};
+use crate::bidi::error::BidiError;
+use crate::bidi::ids::UserContextId;
+use crate::bidi::macros::string_enum;
+
+string_enum! {
+    /// Permission state for [`SetPermission`].
+    pub enum PermissionState {
+        /// Allow.
+        Granted = "granted",
+        /// Deny.
+        Denied = "denied",
+        /// Reset to default ("ask").
+        Prompt = "prompt",
+    }
+}
+
+/// `permissions.setPermission`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetPermission {
+    /// Permission descriptor (`{"name":"geolocation"}`, etc.) — see
+    /// [Permissions API].
+    ///
+    /// [Permissions API]: https://www.w3.org/TR/permissions/#permission-descriptor
+    pub descriptor: serde_json::Value,
+    /// New state.
+    pub state: PermissionState,
+    /// Origin string (e.g. `"https://example.com"`).
+    pub origin: String,
+    /// Restrict to a user context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_context: Option<UserContextId>,
+}
+
+impl BidiCommand for SetPermission {
+    const METHOD: &'static str = "permissions.setPermission";
+    type Returns = Empty;
+}
+
+/// Module facade returned by [`BiDi::permissions`].
+#[derive(Debug)]
+pub struct PermissionsModule<'a> {
+    bidi: &'a BiDi,
+}
+
+impl<'a> PermissionsModule<'a> {
+    pub(crate) fn new(bidi: &'a BiDi) -> Self {
+        Self {
+            bidi,
+        }
+    }
+
+    /// `permissions.setPermission`.
+    pub async fn set_permission(
+        &self,
+        descriptor: serde_json::Value,
+        state: PermissionState,
+        origin: impl Into<String>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetPermission {
+                descriptor,
+                state,
+                origin: origin.into(),
+                user_context: None,
+            })
+            .await?;
+        Ok(())
+    }
+}

--- a/thirtyfour/src/bidi/modules/script.rs
+++ b/thirtyfour/src/bidi/modules/script.rs
@@ -1,0 +1,382 @@
+//! `script.*` BiDi module — `evaluate`, `callFunction`, preload scripts, realms.
+//!
+//! Remote-object trees in BiDi (`RemoteValue`) are deeply recursive and
+//! mostly used as opaque round-trip data: this module exposes them as
+//! [`serde_json::Value`] so users don't pay an upfront serde cost, and can
+//! deserialize themselves if/when they want to.
+
+use serde::{Deserialize, Serialize};
+
+use crate::bidi::BiDi;
+use crate::bidi::command::{BidiCommand, BidiEvent, Empty};
+use crate::bidi::error::BidiError;
+use crate::bidi::ids::{BrowsingContextId, ChannelId, PreloadScriptId, RealmId};
+use crate::bidi::macros::string_enum;
+
+string_enum! {
+    /// Mode controlling how `evaluate` / `callFunction` resolve return-value
+    /// references.
+    pub enum ResultOwnership {
+        /// Return references owned by the calling realm; release explicitly
+        /// via `script.disown`.
+        Root = "root",
+        /// Drop references as soon as the response is delivered.
+        None = "none",
+    }
+}
+
+/// `script.Target` — addressing a script realm.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum Target {
+    /// Address by realm id (most precise; survives navigations).
+    Realm {
+        /// Realm to evaluate in.
+        realm: RealmId,
+    },
+    /// Address by browsing-context id; the driver picks the active realm.
+    Context {
+        /// Browsing context to evaluate in.
+        context: BrowsingContextId,
+        /// Optional sandbox name. Each `(context, sandbox)` is its own realm.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sandbox: Option<String>,
+    },
+}
+
+/// `script.evaluate`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Evaluate {
+    /// Source code to evaluate. May contain `await` if `awaitPromise: true`.
+    pub expression: String,
+    /// Realm or context to evaluate in.
+    pub target: Target,
+    /// If true, await any returned promise before resolving.
+    pub await_promise: bool,
+    /// Whether the result reference should be retained.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_ownership: Option<ResultOwnership>,
+    /// If true, treat the call as a user activation (allows
+    /// `Document.requestStorageAccess()`, etc.).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_activation: Option<bool>,
+}
+
+impl BidiCommand for Evaluate {
+    const METHOD: &'static str = "script.evaluate";
+    type Returns = EvaluateResult;
+}
+
+/// Response for [`Evaluate`] / [`CallFunction`].
+///
+/// The driver returns one of two shapes — success (with `result`) or
+/// exception (with `exceptionDetails`). Modeled here as a tagged enum on
+/// `type`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum EvaluateResult {
+    /// Successful evaluation.
+    Success {
+        /// Realm the value lives in.
+        realm: RealmId,
+        /// Returned value (BiDi `RemoteValue`).
+        result: serde_json::Value,
+    },
+    /// Threw an exception.
+    Exception {
+        /// Realm the throw happened in.
+        realm: RealmId,
+        /// Exception details (BiDi `ExceptionDetails`).
+        #[serde(rename = "exceptionDetails")]
+        exception_details: serde_json::Value,
+    },
+}
+
+impl EvaluateResult {
+    /// Borrow the `result` value if this is a success, else `None`.
+    pub fn ok_value(&self) -> Option<&serde_json::Value> {
+        match self {
+            EvaluateResult::Success {
+                result,
+                ..
+            } => Some(result),
+            _ => None,
+        }
+    }
+
+    /// True if the call returned an exception.
+    pub fn is_exception(&self) -> bool {
+        matches!(self, EvaluateResult::Exception { .. })
+    }
+}
+
+/// `script.callFunction`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CallFunction {
+    /// Function-source string. Receives `this` and arguments per BiDi semantics.
+    pub function_declaration: String,
+    /// If true, await any returned promise before resolving.
+    pub await_promise: bool,
+    /// Realm or context to call in.
+    pub target: Target,
+    /// Arguments passed to the function (BiDi `LocalValue` JSON).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub arguments: Vec<serde_json::Value>,
+    /// Optional `this` reference (BiDi `LocalValue` JSON).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub this: Option<serde_json::Value>,
+    /// Whether the result reference should be retained.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_ownership: Option<ResultOwnership>,
+    /// If true, treat the call as a user activation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_activation: Option<bool>,
+}
+
+impl BidiCommand for CallFunction {
+    const METHOD: &'static str = "script.callFunction";
+    type Returns = EvaluateResult;
+}
+
+/// `script.addPreloadScript`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddPreloadScript {
+    /// Function source — runs at document-start of every navigation.
+    pub function_declaration: String,
+    /// Optional list of `LocalValue` arguments to pass.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub arguments: Vec<serde_json::Value>,
+    /// Optional sandbox name (creates an isolated realm).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<String>,
+    /// Restrict to specific contexts. Empty / omitted = global.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub contexts: Vec<BrowsingContextId>,
+}
+
+impl BidiCommand for AddPreloadScript {
+    const METHOD: &'static str = "script.addPreloadScript";
+    type Returns = AddPreloadScriptResult;
+}
+
+/// Response for [`AddPreloadScript`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct AddPreloadScriptResult {
+    /// Server-assigned id used by [`RemovePreloadScript`].
+    pub script: PreloadScriptId,
+}
+
+/// `script.removePreloadScript`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RemovePreloadScript {
+    /// Id returned by [`AddPreloadScript`].
+    pub script: PreloadScriptId,
+}
+
+impl BidiCommand for RemovePreloadScript {
+    const METHOD: &'static str = "script.removePreloadScript";
+    type Returns = Empty;
+}
+
+/// `script.getRealms`.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetRealms {
+    /// Restrict to a single browsing context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<BrowsingContextId>,
+    /// Restrict to a realm type. See spec for valid strings (`window`,
+    /// `dedicated-worker`, `shared-worker`, `service-worker`, `worker`,
+    /// `paint-worklet`, `audio-worklet`, `worklet`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<String>,
+}
+
+impl BidiCommand for GetRealms {
+    const METHOD: &'static str = "script.getRealms";
+    type Returns = GetRealmsResult;
+}
+
+/// Response for [`GetRealms`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetRealmsResult {
+    /// Discovered realms.
+    pub realms: Vec<RealmInfo>,
+}
+
+/// Info for a single realm. Modeled as the spec's discriminated union over
+/// `type`; the rest of the fields vary by type, so non-essential fields are
+/// captured into [`RealmInfo::extra`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RealmInfo {
+    /// Realm id.
+    pub realm: RealmId,
+    /// Origin string.
+    pub origin: String,
+    /// Realm type (`"window"`, `"worker"`, …).
+    #[serde(rename = "type")]
+    pub realm_type: String,
+    /// Browsing context for window-type realms.
+    #[serde(default)]
+    pub context: Option<BrowsingContextId>,
+    /// Other fields (e.g. `sandbox`, `owners`) flattened into a JSON map.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// `script.disown` — drop references to remote objects.
+#[derive(Debug, Clone, Serialize)]
+pub struct Disown {
+    /// Object handles to disown.
+    pub handles: Vec<String>,
+    /// Realm or context to disown in.
+    pub target: Target,
+}
+
+impl BidiCommand for Disown {
+    const METHOD: &'static str = "script.disown";
+    type Returns = Empty;
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/// Events surfaced by the `script.*` module.
+pub mod events {
+    use super::*;
+
+    /// `script.realmCreated`.
+    #[derive(Debug, Clone, Deserialize)]
+    pub struct RealmCreated(pub RealmInfo);
+
+    impl BidiEvent for RealmCreated {
+        const METHOD: &'static str = "script.realmCreated";
+    }
+
+    /// `script.realmDestroyed`.
+    #[derive(Debug, Clone, Deserialize)]
+    pub struct RealmDestroyed {
+        /// Realm that was destroyed.
+        pub realm: RealmId,
+    }
+
+    impl BidiEvent for RealmDestroyed {
+        const METHOD: &'static str = "script.realmDestroyed";
+    }
+
+    /// `script.message`. Posted from preload-script-installed channels via
+    /// the function `channel(...)` argument.
+    #[derive(Debug, Clone, Deserialize)]
+    pub struct Message {
+        /// Channel id the message was sent on.
+        pub channel: ChannelId,
+        /// Payload (`RemoteValue`).
+        pub data: serde_json::Value,
+        /// Source realm.
+        pub source: serde_json::Value,
+    }
+
+    impl BidiEvent for Message {
+        const METHOD: &'static str = "script.message";
+    }
+}
+
+/// Module facade returned by [`BiDi::script`].
+#[derive(Debug)]
+pub struct ScriptModule<'a> {
+    bidi: &'a BiDi,
+}
+
+impl<'a> ScriptModule<'a> {
+    pub(crate) fn new(bidi: &'a BiDi) -> Self {
+        Self {
+            bidi,
+        }
+    }
+
+    /// `script.evaluate` — convenience: synchronous expression in the active
+    /// realm of `context`.
+    pub async fn evaluate(
+        &self,
+        context: BrowsingContextId,
+        expression: impl Into<String>,
+        await_promise: bool,
+    ) -> Result<EvaluateResult, BidiError> {
+        self.bidi
+            .send(Evaluate {
+                expression: expression.into(),
+                target: Target::Context {
+                    context,
+                    sandbox: None,
+                },
+                await_promise,
+                result_ownership: None,
+                user_activation: None,
+            })
+            .await
+    }
+
+    /// `script.callFunction` — convenience: call a function declaration in
+    /// `context` with no arguments.
+    pub async fn call_function(
+        &self,
+        context: BrowsingContextId,
+        function_declaration: impl Into<String>,
+        await_promise: bool,
+    ) -> Result<EvaluateResult, BidiError> {
+        self.bidi
+            .send(CallFunction {
+                function_declaration: function_declaration.into(),
+                await_promise,
+                target: Target::Context {
+                    context,
+                    sandbox: None,
+                },
+                arguments: vec![],
+                this: None,
+                result_ownership: None,
+                user_activation: None,
+            })
+            .await
+    }
+
+    /// `script.addPreloadScript`.
+    pub async fn add_preload_script(
+        &self,
+        function_declaration: impl Into<String>,
+    ) -> Result<AddPreloadScriptResult, BidiError> {
+        self.bidi
+            .send(AddPreloadScript {
+                function_declaration: function_declaration.into(),
+                arguments: vec![],
+                sandbox: None,
+                contexts: vec![],
+            })
+            .await
+    }
+
+    /// `script.removePreloadScript`.
+    pub async fn remove_preload_script(&self, script: PreloadScriptId) -> Result<(), BidiError> {
+        self.bidi
+            .send(RemovePreloadScript {
+                script,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `script.getRealms` — all realms.
+    pub async fn get_realms(&self) -> Result<GetRealmsResult, BidiError> {
+        self.bidi
+            .send(GetRealms {
+                context: None,
+                r#type: None,
+            })
+            .await
+    }
+}

--- a/thirtyfour/src/bidi/modules/session.rs
+++ b/thirtyfour/src/bidi/modules/session.rs
@@ -1,0 +1,150 @@
+//! `session.*` BiDi module — protocol handshake, subscription, status.
+
+use serde::{Deserialize, Serialize};
+
+use crate::bidi::BiDi;
+use crate::bidi::command::{BidiCommand, Empty};
+use crate::bidi::error::BidiError;
+use crate::bidi::ids::{BrowsingContextId, UserContextId};
+
+/// `session.status`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct Status;
+
+/// Response for [`Status`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct StatusResult {
+    /// True when the driver is ready to accept a new session.
+    pub ready: bool,
+    /// Human-readable readiness message.
+    pub message: String,
+}
+
+impl BidiCommand for Status {
+    const METHOD: &'static str = "session.status";
+    type Returns = StatusResult;
+}
+
+/// `session.subscribe` — register interest in one or more event names.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct Subscribe {
+    /// Event names like `"browsingContext.load"` or whole modules like
+    /// `"browsingContext"` (subscribes to every event in the module).
+    pub events: Vec<String>,
+    /// Optional list of browsing-context ids to scope the subscription.
+    /// Empty / omitted = global.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub contexts: Vec<BrowsingContextId>,
+    /// Optional list of user-context ids to scope the subscription.
+    #[serde(rename = "userContexts", skip_serializing_if = "Vec::is_empty")]
+    pub user_contexts: Vec<UserContextId>,
+}
+
+impl BidiCommand for Subscribe {
+    const METHOD: &'static str = "session.subscribe";
+    type Returns = SubscribeResult;
+}
+
+/// Response for [`Subscribe`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct SubscribeResult {
+    /// Server-assigned id that can be passed to [`Unsubscribe`] to remove
+    /// just this subscription. Optional — older drivers may not send it.
+    #[serde(default)]
+    pub subscription: Option<String>,
+}
+
+/// `session.unsubscribe` — remove a previous subscription. Either by event
+/// names or by subscription id.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct Unsubscribe {
+    /// Event names previously passed to [`Subscribe`].
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<String>,
+    /// Subscription ids previously returned by [`Subscribe`].
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub subscriptions: Vec<String>,
+    /// Optional list of browsing-context ids that scoped the original
+    /// subscription.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub contexts: Vec<BrowsingContextId>,
+}
+
+impl BidiCommand for Unsubscribe {
+    const METHOD: &'static str = "session.unsubscribe";
+    type Returns = Empty;
+}
+
+/// `session.end` — terminates the BiDi session.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct End;
+
+impl BidiCommand for End {
+    const METHOD: &'static str = "session.end";
+    type Returns = Empty;
+}
+
+/// Module facade returned by [`BiDi::session`].
+#[derive(Debug)]
+pub struct SessionModule<'a> {
+    bidi: &'a BiDi,
+}
+
+impl<'a> SessionModule<'a> {
+    pub(crate) fn new(bidi: &'a BiDi) -> Self {
+        Self {
+            bidi,
+        }
+    }
+
+    /// `session.status`.
+    pub async fn status(&self) -> Result<StatusResult, BidiError> {
+        self.bidi.send(Status).await
+    }
+
+    /// `session.subscribe` — convenience over a single event name.
+    pub async fn subscribe(&self, event: impl Into<String>) -> Result<SubscribeResult, BidiError> {
+        self.bidi
+            .send(Subscribe {
+                events: vec![event.into()],
+                contexts: vec![],
+                user_contexts: vec![],
+            })
+            .await
+    }
+
+    /// `session.subscribe` — multi-event variant.
+    pub async fn subscribe_many(
+        &self,
+        events: impl IntoIterator<Item = String>,
+    ) -> Result<SubscribeResult, BidiError> {
+        self.bidi
+            .send(Subscribe {
+                events: events.into_iter().collect(),
+                contexts: vec![],
+                user_contexts: vec![],
+            })
+            .await
+    }
+
+    /// `session.unsubscribe` by event name(s).
+    pub async fn unsubscribe(
+        &self,
+        events: impl IntoIterator<Item = String>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(Unsubscribe {
+                events: events.into_iter().collect(),
+                subscriptions: vec![],
+                contexts: vec![],
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `session.end`.
+    pub async fn end(&self) -> Result<(), BidiError> {
+        self.bidi.send(End).await?;
+        Ok(())
+    }
+}

--- a/thirtyfour/src/bidi/modules/storage.rs
+++ b/thirtyfour/src/bidi/modules/storage.rs
@@ -1,0 +1,272 @@
+//! `storage.*` BiDi module — cookies and storage partitions.
+
+use serde::{Deserialize, Serialize};
+
+use crate::bidi::BiDi;
+use crate::bidi::command::BidiCommand;
+use crate::bidi::error::BidiError;
+use crate::bidi::macros::string_enum;
+
+string_enum! {
+    /// Same-site policy for [`Cookie::same_site`] / [`PartialCookie::same_site`].
+    pub enum SameSite {
+        /// Strict — only same-site requests carry the cookie.
+        Strict = "strict",
+        /// Lax — top-level navigations also carry the cookie.
+        Lax = "lax",
+        /// None — must be `secure: true`.
+        None = "none",
+        /// Default — driver-defined.
+        Default = "default",
+    }
+}
+
+/// `storage.Cookie` returned by [`GetCookies`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Cookie {
+    /// Cookie name.
+    pub name: String,
+    /// Cookie value (BiDi `network.BytesValue`).
+    pub value: serde_json::Value,
+    /// Cookie domain.
+    pub domain: String,
+    /// Cookie path.
+    pub path: String,
+    /// HTTP-only flag.
+    pub http_only: bool,
+    /// Secure flag.
+    pub secure: bool,
+    /// Same-site policy.
+    pub same_site: SameSite,
+    /// Cookie size on the wire.
+    #[serde(default)]
+    pub size: Option<u32>,
+    /// Expiry as epoch milliseconds; absent for session cookies.
+    #[serde(default)]
+    pub expiry: Option<i64>,
+}
+
+/// `storage.PartialCookie` used by [`SetCookie`] / [`DeleteCookies`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PartialCookie {
+    /// Cookie name.
+    pub name: String,
+    /// Cookie value as a `network.BytesValue`. Use [`bytes_string`] to wrap a
+    /// plain string.
+    pub value: serde_json::Value,
+    /// Cookie domain.
+    pub domain: String,
+    /// Cookie path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// HTTP-only flag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_only: Option<bool>,
+    /// Secure flag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secure: Option<bool>,
+    /// Same-site policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub same_site: Option<SameSite>,
+    /// Expiry as epoch milliseconds; omit for session cookies.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiry: Option<i64>,
+}
+
+/// Wrap a plain string into a BiDi `network.BytesValue` JSON object
+/// (`{"type":"string","value":"…"}`).
+pub fn bytes_string(value: impl Into<String>) -> serde_json::Value {
+    serde_json::json!({"type": "string", "value": value.into()})
+}
+
+/// `storage.CookieFilter` used by [`GetCookies`] / [`DeleteCookies`].
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CookieFilter {
+    /// Match by exact name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Match by value (`network.BytesValue`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>,
+    /// Match by domain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    /// Match by path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Match by http-only flag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_only: Option<bool>,
+    /// Match by secure flag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secure: Option<bool>,
+    /// Match by same-site.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub same_site: Option<SameSite>,
+    /// Match by size.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<u32>,
+    /// Match by expiry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiry: Option<i64>,
+}
+
+/// `storage.PartitionDescriptor` — opaque addressing for a storage partition.
+/// Use `serde_json::json!` to construct, e.g.
+/// `json!({"type":"context","context": id})` or
+/// `json!({"type":"storageKey","userContext":"default","sourceOrigin":"https://x"})`.
+pub type PartitionDescriptor = serde_json::Value;
+
+/// `storage.getCookies`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GetCookies {
+    /// Optional filter — only matching cookies are returned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<CookieFilter>,
+    /// Optional partition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partition: Option<PartitionDescriptor>,
+}
+
+impl BidiCommand for GetCookies {
+    const METHOD: &'static str = "storage.getCookies";
+    type Returns = GetCookiesResult;
+}
+
+/// Response for [`GetCookies`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetCookiesResult {
+    /// Matching cookies.
+    pub cookies: Vec<Cookie>,
+    /// Resolved partition key (driver-defined shape).
+    #[serde(default)]
+    pub partition_key: serde_json::Value,
+}
+
+/// `storage.setCookie`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SetCookie {
+    /// Cookie to set.
+    pub cookie: PartialCookie,
+    /// Optional partition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partition: Option<PartitionDescriptor>,
+}
+
+impl BidiCommand for SetCookie {
+    const METHOD: &'static str = "storage.setCookie";
+    type Returns = SetCookieResult;
+}
+
+/// Response for [`SetCookie`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetCookieResult {
+    /// Resolved partition key.
+    #[serde(default)]
+    pub partition_key: serde_json::Value,
+}
+
+/// `storage.deleteCookies`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct DeleteCookies {
+    /// Filter — every matching cookie is removed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<CookieFilter>,
+    /// Optional partition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partition: Option<PartitionDescriptor>,
+}
+
+impl BidiCommand for DeleteCookies {
+    const METHOD: &'static str = "storage.deleteCookies";
+    type Returns = DeleteCookiesResult;
+}
+
+/// Response for [`DeleteCookies`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteCookiesResult {
+    /// Resolved partition key.
+    #[serde(default)]
+    pub partition_key: serde_json::Value,
+}
+
+/// Module facade returned by [`BiDi::storage`].
+#[derive(Debug)]
+pub struct StorageModule<'a> {
+    bidi: &'a BiDi,
+}
+
+impl<'a> StorageModule<'a> {
+    pub(crate) fn new(bidi: &'a BiDi) -> Self {
+        Self {
+            bidi,
+        }
+    }
+
+    /// `storage.getCookies` — all cookies in the default partition.
+    pub async fn get_cookies(&self) -> Result<GetCookiesResult, BidiError> {
+        self.bidi
+            .send(GetCookies {
+                filter: None,
+                partition: None,
+            })
+            .await
+    }
+
+    /// `storage.getCookies` filtered by name.
+    pub async fn get_cookies_by_name(
+        &self,
+        name: impl Into<String>,
+    ) -> Result<GetCookiesResult, BidiError> {
+        self.bidi
+            .send(GetCookies {
+                filter: Some(CookieFilter {
+                    name: Some(name.into()),
+                    ..CookieFilter::default()
+                }),
+                partition: None,
+            })
+            .await
+    }
+
+    /// `storage.setCookie`.
+    pub async fn set_cookie(&self, cookie: PartialCookie) -> Result<SetCookieResult, BidiError> {
+        self.bidi
+            .send(SetCookie {
+                cookie,
+                partition: None,
+            })
+            .await
+    }
+
+    /// `storage.deleteCookies` — by exact name.
+    pub async fn delete_cookies_by_name(&self, name: impl Into<String>) -> Result<(), BidiError> {
+        self.bidi
+            .send(DeleteCookies {
+                filter: Some(CookieFilter {
+                    name: Some(name.into()),
+                    ..CookieFilter::default()
+                }),
+                partition: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// `storage.deleteCookies` — every cookie in the default partition.
+    pub async fn delete_all_cookies(&self) -> Result<(), BidiError> {
+        self.bidi
+            .send(DeleteCookies {
+                filter: None,
+                partition: None,
+            })
+            .await?;
+        Ok(())
+    }
+}

--- a/thirtyfour/src/bidi/transport/mod.rs
+++ b/thirtyfour/src/bidi/transport/mod.rs
@@ -1,0 +1,6 @@
+//! WebSocket transport for BiDi.
+//!
+//! Single implementation under [`ws`]; broken out so the BiDi handle can
+//! depend on a single concrete type while keeping connection state private.
+
+pub(crate) mod ws;

--- a/thirtyfour/src/bidi/transport/ws.rs
+++ b/thirtyfour/src/bidi/transport/ws.rs
@@ -1,0 +1,213 @@
+//! WebSocket transport for WebDriver BiDi.
+//!
+//! One WebSocket per WebDriver session (BiDi has no per-message session
+//! multiplexing — that's handled by `New Session` over HTTP). Outbound
+//! frames are written by a writer task; inbound frames are demuxed by a
+//! reader task into:
+//!
+//! - oneshot channels for command responses, keyed by `id`.
+//! - a `tokio::sync::broadcast` channel for events.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use futures_util::sink::SinkExt;
+use futures_util::stream::StreamExt;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::{Mutex, broadcast, mpsc, oneshot};
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::bidi::command::RawEvent;
+use crate::bidi::error::{BidiError, BidiErrorEnvelope};
+use crate::error::{WebDriverError, WebDriverResult};
+
+/// Channel buffer for the broadcast event stream. If a subscriber falls
+/// further behind than this, it'll see `RecvError::Lagged` and miss frames.
+const EVENT_BUFFER: usize = 1024;
+
+#[derive(Debug, Clone)]
+pub(crate) struct BidiTransport {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    out: mpsc::UnboundedSender<String>,
+    pending: Mutex<HashMap<u64, oneshot::Sender<Result<Value, BidiError>>>>,
+    events: broadcast::Sender<RawEvent>,
+    next_id: AtomicU64,
+}
+
+impl BidiTransport {
+    /// Connect to the BiDi WebSocket URL.
+    pub(crate) async fn connect(url: &str) -> WebDriverResult<Self> {
+        let (ws, _resp) = tokio_tungstenite::connect_async(url)
+            .await
+            .map_err(|e| WebDriverError::HttpError(format!("BiDi WebSocket connect: {e}")))?;
+
+        let (mut sink, mut stream) = ws.split();
+
+        let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();
+        let (events_tx, _events_rx0) = broadcast::channel::<RawEvent>(EVENT_BUFFER);
+
+        let inner = Arc::new(Inner {
+            out: out_tx,
+            pending: Mutex::new(HashMap::new()),
+            events: events_tx,
+            next_id: AtomicU64::new(1),
+        });
+
+        // Writer task.
+        tokio::spawn(async move {
+            while let Some(text) = out_rx.recv().await {
+                if sink.send(Message::Text(text)).await.is_err() {
+                    break;
+                }
+            }
+            let _ = sink.close().await;
+        });
+
+        // Reader task — consumes inbound frames and dispatches them.
+        let inner_for_reader = Arc::clone(&inner);
+        tokio::spawn(async move {
+            while let Some(message) = stream.next().await {
+                let frame = match message {
+                    Ok(Message::Text(t)) => t,
+                    Ok(Message::Binary(b)) => match String::from_utf8(b) {
+                        Ok(s) => s,
+                        Err(_) => continue,
+                    },
+                    Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_)) => continue,
+                    Ok(Message::Close(_)) | Err(_) => break,
+                };
+                inner_for_reader.dispatch(&frame).await;
+            }
+            inner_for_reader.fail_all_pending("BiDi WebSocket closed").await;
+        });
+
+        Ok(Self {
+            inner,
+        })
+    }
+
+    /// Send a BiDi command by `method` with raw `params` and await the
+    /// response `result`.
+    pub(crate) async fn send_raw(&self, method: &str, params: Value) -> Result<Value, BidiError> {
+        // BiDi tolerates `"params": null` for some commands but the spec
+        // requires an object. Coerce null → {} for safety.
+        let params = if params.is_null() {
+            serde_json::json!({})
+        } else {
+            params
+        };
+        let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.inner.pending.lock().await.insert(id, resp_tx);
+
+        let frame = OutgoingCommand {
+            id,
+            method,
+            params: &params,
+        };
+        let serialized = serde_json::to_string(&frame).map_err(|e| BidiError {
+            command: method.to_string(),
+            error: "unknown error".to_string(),
+            message: format!("serialise command: {e}"),
+            stacktrace: None,
+        })?;
+        if self.inner.out.send(serialized).is_err() {
+            return Err(BidiError {
+                command: method.to_string(),
+                error: "unknown error".to_string(),
+                message: "BiDi WebSocket connection closed".to_string(),
+                stacktrace: None,
+            });
+        }
+
+        match resp_rx.await {
+            Ok(result) => result,
+            Err(_) => Err(BidiError {
+                command: method.to_string(),
+                error: "unknown error".to_string(),
+                message: "BiDi response channel dropped".to_string(),
+                stacktrace: None,
+            }),
+        }
+    }
+
+    /// Subscribe to every event on this transport.
+    pub(crate) fn subscribe_events(&self) -> broadcast::Receiver<RawEvent> {
+        self.inner.events.subscribe()
+    }
+}
+
+impl Inner {
+    async fn dispatch(self: &Arc<Self>, frame: &str) {
+        let value: Value = match serde_json::from_str(frame) {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+
+        match value.get("type").and_then(Value::as_str) {
+            Some("success") => {
+                let Some(id) = value.get("id").and_then(Value::as_u64) else {
+                    return;
+                };
+                if let Some(tx) = self.pending.lock().await.remove(&id) {
+                    let result = value.get("result").cloned().unwrap_or(Value::Null);
+                    let _ = tx.send(Ok(result));
+                }
+            }
+            Some("error") => {
+                let env: BidiErrorEnvelope = match serde_json::from_value(value.clone()) {
+                    Ok(e) => e,
+                    Err(_) => BidiErrorEnvelope {
+                        error: "unknown error".to_string(),
+                        message: "malformed BiDi error envelope".to_string(),
+                        stacktrace: None,
+                    },
+                };
+                if let Some(id) = value.get("id").and_then(Value::as_u64)
+                    && let Some(tx) = self.pending.lock().await.remove(&id)
+                {
+                    let _ = tx.send(Err(env.into_error("<response>")));
+                }
+                // Errors with `id: null` are protocol-level (e.g. malformed
+                // command). The spec only specifies that they may appear; we
+                // don't have a pending request to wake.
+            }
+            Some("event") => {
+                if let Some(method) = value.get("method").and_then(Value::as_str) {
+                    let params = value.get("params").cloned().unwrap_or(Value::Null);
+                    let _ = self.events.send(RawEvent {
+                        method: method.to_string(),
+                        params,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    async fn fail_all_pending(&self, message: &str) {
+        let mut pending = self.pending.lock().await;
+        for (_, tx) in pending.drain() {
+            let _ = tx.send(Err(BidiError {
+                command: "<connection>".to_string(),
+                error: "unknown error".to_string(),
+                message: message.to_string(),
+                stacktrace: None,
+            }));
+        }
+    }
+}
+
+/// Wire shape of an outbound BiDi command frame.
+#[derive(Serialize)]
+struct OutgoingCommand<'a> {
+    id: u64,
+    method: &'a str,
+    params: &'a Value,
+}

--- a/thirtyfour/src/common/capabilities/desiredcapabilities.rs
+++ b/thirtyfour/src/common/capabilities/desiredcapabilities.rs
@@ -109,6 +109,9 @@ const W3C_CAPABILITY_NAMES: &[&str] = &[
     "timeouts",
     "unhandledPromptBehavior",
     "strictFileInteractability",
+    // W3C WebDriver BiDi — set to `true` to opt in; the response capabilities
+    // come back with the actual `ws://...` URL string.
+    "webSocketUrl",
 ];
 
 const OSS_W3C_CONVERSION: &[(&str, &str)] = &[
@@ -309,6 +312,14 @@ pub trait CapabilitiesHelper: AsRef<Capabilities> + AsMut<Capabilities> {
     /// Set the page load strategy to use.
     fn set_page_load_strategy(&mut self, strategy: PageLoadStrategy) -> WebDriverResult<()> {
         self.set("pageLoadStrategy", strategy)
+    }
+
+    /// Opt the session in to WebDriver BiDi by setting the W3C
+    /// `webSocketUrl: true` capability. The driver responds with the actual
+    /// `ws://...` URL on the session capabilities; reach the BiDi handle via
+    /// [`crate::WebDriver::bidi`] (feature `bidi`).
+    fn enable_bidi(&mut self) -> WebDriverResult<()> {
+        self.set("webSocketUrl", true)
     }
 }
 

--- a/thirtyfour/src/lib.rs
+++ b/thirtyfour/src/lib.rs
@@ -40,6 +40,9 @@
 //!   [`WebElement::cdp_backend_node_id`].
 //! * `cdp-events`: WebSocket-backed CDP event subscription. Enables
 //!   [`cdp::CdpSession`] and pulls in `tokio-tungstenite`. Off by default.
+//! * `bidi`: WebDriver BiDi (W3C bidirectional protocol) — typed commands
+//!   and event subscription via [`WebDriver::bidi`]. Pulls in
+//!   `tokio-tungstenite`. Off by default.
 //!
 //! ## Example
 //!
@@ -199,6 +202,11 @@ pub mod prelude {
 pub mod action_chain;
 /// Alert handling.
 pub mod alert;
+/// WebDriver BiDi (W3C bidirectional protocol) support — typed commands and
+/// event subscription over a WebSocket. Negotiated via the `webSocketUrl`
+/// capability. See [`bidi`] for the API.
+#[cfg(feature = "bidi")]
+pub mod bidi;
 /// Chrome DevTools Protocol (CDP) support — typed commands, optional event
 /// subscription via WebSocket. See [`cdp`] for the API.
 #[cfg(feature = "cdp")]

--- a/thirtyfour/src/manager/process.rs
+++ b/thirtyfour/src/manager/process.rs
@@ -182,6 +182,18 @@ async fn spawn_at_port(
         cmd.arg(format!("--allowed-ips={}", cfg.host));
     }
 
+    // geckodriver's WebDriver-BiDi WebSocket binds Firefox's RemoteAgent
+    // server to a fixed default port (9222). When the manager runs many
+    // Firefox sessions back-to-back the new Firefox can't bind 9222 if the
+    // previous Firefox hasn't fully released it yet — and the resulting
+    // `webSocketUrl` capability still reports 9222, so connecting fails
+    // with HTTP 404. Pass `--websocket-port=0` to ask geckodriver to pick a
+    // free port; it propagates through to RemoteAgent and the returned
+    // `webSocketUrl` reflects the actual bound port.
+    if matches!(browser, BrowserKind::Firefox) {
+        cmd.arg("--websocket-port=0");
+    }
+
     let mut child = cmd
         .spawn()
         .map_err(|e| ManagerError::Spawn(format!("spawn {}: {}", binary.display(), e)))?;

--- a/thirtyfour/src/session/handle.rs
+++ b/thirtyfour/src/session/handle.rs
@@ -36,12 +36,17 @@ pub struct SessionHandle {
     session_id: SessionId,
     /// Session capabilities returned by `New Session` (vendor-prefixed
     /// fields like `goog:chromeOptions.debuggerAddress` and `se:cdp`
-    /// are read from here for CDP WebSocket discovery).
+    /// are read from here for CDP WebSocket discovery; W3C `webSocketUrl`
+    /// for BiDi).
     capabilities: Arc<Capabilities>,
     /// The config used by this instance.
     config: WebDriverConfig,
     /// quit session flag
     quit: Arc<OnceCell<()>>,
+    /// Lazily-connected WebDriver BiDi handle, shared by every clone of the
+    /// `SessionHandle`. Initialised on first call to [`crate::WebDriver::bidi`].
+    #[cfg(feature = "bidi")]
+    bidi: Arc<OnceCell<crate::bidi::BiDi>>,
     /// Optional opaque guard that keeps an external resource (e.g. a managed
     /// `chromedriver` subprocess) alive for as long as this session exists.
     /// Declared **last** so it drops after `quit` has run in the `Drop` impl.
@@ -79,6 +84,8 @@ impl SessionHandle {
             capabilities: Arc::new(capabilities),
             config,
             quit: Arc::new(OnceCell::new()),
+            #[cfg(feature = "bidi")]
+            bidi: Arc::new(OnceCell::new()),
             driver_guard,
         })
     }
@@ -93,9 +100,18 @@ impl SessionHandle {
             session_id: self.session_id.clone(),
             capabilities: Arc::clone(&self.capabilities),
             quit: Arc::clone(&self.quit),
+            #[cfg(feature = "bidi")]
+            bidi: Arc::clone(&self.bidi),
             config,
             driver_guard: self.driver_guard.clone(),
         }
+    }
+
+    /// Cached BiDi handle. Used by [`crate::WebDriver::bidi`] to lazy-init
+    /// once and reuse on subsequent calls.
+    #[cfg(feature = "bidi")]
+    pub(crate) fn bidi_cell(&self) -> &Arc<OnceCell<crate::bidi::BiDi>> {
+        &self.bidi
     }
 
     /// The session id for this webdriver session.
@@ -1233,6 +1249,8 @@ impl Drop for SessionHandle {
             session_id: self.session_id.clone(),
             capabilities: Arc::clone(&self.capabilities),
             config: self.config.clone(),
+            #[cfg(feature = "bidi")]
+            bidi: Arc::clone(&self.bidi),
             // The guard stays on the *original* SessionHandle so it drops after
             // this DropGuard's quit() future has run. The reconstructed handle
             // here is just the bits needed to issue the DELETE /session HTTP call.

--- a/thirtyfour/src/web_driver.rs
+++ b/thirtyfour/src/web_driver.rs
@@ -175,6 +175,41 @@ impl WebDriver {
         builder
     }
 
+    /// Open (or return the already-cached) WebDriver BiDi handle for this
+    /// session.
+    ///
+    /// Requires `webSocketUrl: true` to have been set on the capabilities
+    /// before [`WebDriver::new`] (use
+    /// [`CapabilitiesHelper::enable_bidi`](crate::CapabilitiesHelper::enable_bidi))
+    /// so the driver returns a `webSocketUrl` string the BiDi handle can
+    /// dial.
+    ///
+    /// Lazy: the WebSocket isn't connected until the first call. Subsequent
+    /// calls return the same cached handle (cloning is cheap).
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use thirtyfour::prelude::*;
+    /// # async fn run() -> WebDriverResult<()> {
+    /// let mut caps = DesiredCapabilities::chrome();
+    /// caps.enable_bidi()?;
+    /// let driver = WebDriver::new("http://localhost:4444", caps).await?;
+    ///
+    /// let bidi = driver.bidi().await?;
+    /// let status = bidi.session().status().await?;
+    /// println!("BiDi ready: {}", status.ready);
+    /// # driver.quit().await }
+    /// ```
+    #[cfg(feature = "bidi")]
+    pub async fn bidi(&self) -> WebDriverResult<crate::bidi::BiDi> {
+        let handle = self.handle.clone();
+        let cell = self.handle.bidi_cell().clone();
+        let bidi = cell
+            .get_or_try_init(|| async move { crate::bidi::BiDi::connect(handle).await })
+            .await?;
+        Ok(bidi.clone())
+    }
+
     /// Get a Chrome DevTools Protocol handle for this session.
     ///
     /// Cheap to call (just clones the underlying `Arc<SessionHandle>`).

--- a/thirtyfour/tests/bidi_events.rs
+++ b/thirtyfour/tests/bidi_events.rs
@@ -1,0 +1,401 @@
+//! End-to-end tests for BiDi event subscription.
+//!
+//! Cross-browser via `THIRTYFOUR_BROWSER` (default `chrome`):
+//!
+//! ```text
+//! cargo test -p thirtyfour --features manager-tests,bidi --test bidi_events -- --test-threads=1
+//! THIRTYFOUR_BROWSER=firefox cargo test -p thirtyfour --features manager-tests,bidi --test bidi_events -- --test-threads=1
+//! ```
+//!
+//! Every typed event in [`thirtyfour::bidi::modules`] should have an
+//! integration test here that proves the real driver emits it with the
+//! shape we expect.
+
+#![cfg(all(feature = "manager-tests", feature = "bidi"))]
+
+use std::future::Future;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use thirtyfour::bidi::modules::{browsing_context, log, network, script};
+use thirtyfour::prelude::*;
+
+use crate::common::launch_managed_bidi;
+
+mod common;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(180);
+const EVENT_TIMEOUT: Duration = Duration::from_secs(15);
+
+async fn with_timeout<F, T>(f: F) -> WebDriverResult<T>
+where
+    F: Future<Output = WebDriverResult<T>>,
+{
+    tokio::time::timeout(TEST_TIMEOUT, f).await.unwrap_or_else(|_| {
+        Err(WebDriverError::FatalError(format!("test exceeded {}s budget", TEST_TIMEOUT.as_secs())))
+    })
+}
+
+fn bidi_to_wd(e: thirtyfour::bidi::BidiError) -> WebDriverError {
+    WebDriverError::FatalError(e.to_string())
+}
+
+/// Wait for the next event of type `E` matching `predicate`, with the
+/// `EVENT_TIMEOUT` budget. Returns the matched event.
+async fn wait_for<E, F>(stream: &mut thirtyfour::bidi::EventStream<E>, mut predicate: F) -> E
+where
+    E: thirtyfour::bidi::BidiEvent,
+    F: FnMut(&E) -> bool,
+{
+    let deadline = tokio::time::Instant::now() + EVENT_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        match tokio::time::timeout(remaining, stream.next()).await {
+            Ok(Some(evt)) if predicate(&evt) => return evt,
+            Ok(Some(_)) => continue,
+            _ => panic!(
+                "no matching {} event within {}s",
+                std::any::type_name::<E>(),
+                EVENT_TIMEOUT.as_secs()
+            ),
+        }
+    }
+}
+
+async fn spawn_local_http(body: &'static str) -> WebDriverResult<String> {
+    let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .map_err(|e| WebDriverError::FatalError(format!("bind localhost: {e}")))?;
+    let addr = listener
+        .local_addr()
+        .map_err(|e| WebDriverError::FatalError(format!("local_addr: {e}")))?;
+    let app = axum::Router::new().route("/", axum::routing::get(move || async move { body }));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    Ok(format!("http://127.0.0.1:{}/", addr.port()))
+}
+
+// ---------------------------------------------------------------------------
+// browsingContext events
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_load_event_after_navigate() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("browsingContext.load").await.map_err(bidi_to_wd)?;
+        let mut events = bidi.subscribe::<browsing_context::events::Load>();
+
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        let url = "data:text/html,<html><body>load</body></html>";
+        bidi.browsing_context().navigate(ctx.clone(), url, None).await.map_err(bidi_to_wd)?;
+        let evt = wait_for(&mut events, |e| e.context == ctx).await;
+        assert!(evt.url.starts_with("data:text/html"));
+        assert!(evt.timestamp > 0);
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_dom_content_loaded_event_after_navigate() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("browsingContext.domContentLoaded").await.map_err(bidi_to_wd)?;
+        let mut events = bidi.subscribe::<browsing_context::events::DomContentLoaded>();
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        let url = "data:text/html,<html><body>dcl</body></html>";
+        bidi.browsing_context().navigate(ctx.clone(), url, None).await.map_err(bidi_to_wd)?;
+        let evt = wait_for(&mut events, |e| e.context == ctx).await;
+        assert!(evt.url.starts_with("data:text/html"));
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_navigation_started_event_after_navigate() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("browsingContext.navigationStarted").await.map_err(bidi_to_wd)?;
+        let mut events = bidi.subscribe::<browsing_context::events::NavigationStarted>();
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        let url = "data:text/html,<html><body>nav</body></html>";
+        bidi.browsing_context().navigate(ctx.clone(), url, None).await.map_err(bidi_to_wd)?;
+        let evt = wait_for(&mut events, |e| e.context == ctx).await;
+        assert!(evt.url.starts_with("data:text/html"));
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_context_created_event_for_iframe() -> WebDriverResult<()> {
+    // The spec-guaranteed trigger for `contextCreated` is navigating a
+    // top-level context to a page with an iframe — the iframe is a child
+    // browsing context whose creation must be announced. (Top-level tabs
+    // created via `browsingContext.create` get their announcement folded
+    // into the response and don't always fire the event in chromedriver.)
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("browsingContext.contextCreated").await.map_err(bidi_to_wd)?;
+        let mut events = bidi.subscribe::<browsing_context::events::ContextCreated>();
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let parent = tree.contexts[0].context.clone();
+        let url =
+            "data:text/html,<html><body><iframe src='data:text/html,child'></iframe></body></html>";
+        bidi.browsing_context()
+            .navigate(parent.clone(), url, Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        let evt = wait_for(&mut events, |e| e.0.parent.as_ref() == Some(&parent)).await;
+        assert_eq!(evt.0.parent.as_ref(), Some(&parent));
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_context_destroyed_event_after_close() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("browsingContext.contextDestroyed").await.map_err(bidi_to_wd)?;
+        let mut events = bidi.subscribe::<browsing_context::events::ContextDestroyed>();
+        let created = bidi
+            .browsing_context()
+            .create(browsing_context::CreateType::Tab)
+            .await
+            .map_err(bidi_to_wd)?;
+        let target = created.context.clone();
+        bidi.browsing_context().close(created.context).await.map_err(bidi_to_wd)?;
+        let evt = wait_for(&mut events, |e| e.0.context == target).await;
+        assert_eq!(evt.0.context, target);
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// log events
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn log_entry_added_for_console_log() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("log.entryAdded").await.map_err(bidi_to_wd)?;
+        let mut events = bidi.subscribe::<log::events::EntryAdded>();
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(
+                ctx.clone(),
+                "data:text/html,<html></html>",
+                Some(browsing_context::ReadinessState::Complete),
+            )
+            .await
+            .map_err(bidi_to_wd)?;
+        bidi.script()
+            .evaluate(ctx, "console.log('thirtyfour-bidi-marker')", false)
+            .await
+            .map_err(bidi_to_wd)?;
+        let evt = wait_for(&mut events, |e| {
+            e.entry_type == "console"
+                && e.text.as_deref().is_some_and(|t| t.contains("thirtyfour-bidi-marker"))
+        })
+        .await;
+        assert_eq!(evt.entry_type, "console");
+        assert_eq!(evt.level, log::LogLevel::Info);
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// script events
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn script_realm_created_after_navigate() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("script.realmCreated").await.map_err(bidi_to_wd)?;
+        let mut events = bidi.subscribe::<script::events::RealmCreated>();
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(
+                ctx,
+                "data:text/html,<html><body>r</body></html>",
+                Some(browsing_context::ReadinessState::Complete),
+            )
+            .await
+            .map_err(bidi_to_wd)?;
+        // Any window realm event is enough to prove the typed shape.
+        let evt = wait_for(&mut events, |e| e.0.realm_type == "window").await;
+        assert_eq!(evt.0.realm_type, "window");
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// network events
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn network_before_request_sent_event_during_navigate() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("network.beforeRequestSent").await.map_err(bidi_to_wd)?;
+        let mut events = bidi.subscribe::<network::events::BeforeRequestSent>();
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        let server = spawn_local_http("ok").await?;
+        bidi.browsing_context()
+            .navigate(ctx.clone(), server.clone(), Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        let evt = wait_for(&mut events, |e| e.request.url.starts_with(&server)).await;
+        assert_eq!(evt.request.method.to_uppercase(), "GET");
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn network_response_completed_event_during_navigate() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("network.responseCompleted").await.map_err(bidi_to_wd)?;
+        let mut events = bidi.subscribe::<network::events::ResponseCompleted>();
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        let server = spawn_local_http("hello world").await?;
+        bidi.browsing_context()
+            .navigate(ctx.clone(), server.clone(), Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        let evt = wait_for(&mut events, |e| e.request.url.starts_with(&server)).await;
+        assert_eq!(evt.response.status, 200);
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn network_response_started_event_during_navigate() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("network.responseStarted").await.map_err(bidi_to_wd)?;
+        let mut events = bidi.subscribe::<network::events::ResponseStarted>();
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        let server = spawn_local_http("started").await?;
+        bidi.browsing_context()
+            .navigate(ctx.clone(), server.clone(), Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        let evt = wait_for(&mut events, |e| e.request.url.starts_with(&server)).await;
+        assert_eq!(evt.response.status, 200);
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn network_intercept_continue_request_unmodified() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let server = spawn_local_http("intercepted").await?;
+
+        // 1. Subscribe to events first so we don't miss them.
+        bidi.session().subscribe("network.beforeRequestSent").await.map_err(bidi_to_wd)?;
+        let mut events = bidi.subscribe::<network::events::BeforeRequestSent>();
+
+        // 2. Add a global intercept on the request phase.
+        let added = bidi
+            .network()
+            .add_intercept(vec![network::InterceptPhase::BeforeRequestSent], None)
+            .await
+            .map_err(bidi_to_wd)?;
+
+        // 3. Navigate; the request will be paused.
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        // Start the navigation in the background — the call only resolves
+        // once the load completes, which won't happen until we continue
+        // the intercepted request.
+        let nav_bidi = bidi.clone();
+        let nav_server = server.clone();
+        let nav_ctx = ctx.clone();
+        let nav_handle = tokio::spawn(async move {
+            nav_bidi
+                .browsing_context()
+                .navigate(nav_ctx, nav_server, Some(browsing_context::ReadinessState::Complete))
+                .await
+        });
+
+        // 4. Find the matching event, then continue the request.
+        let evt =
+            wait_for(&mut events, |e| e.request.url.starts_with(&server) && e.is_blocked).await;
+        bidi.network().continue_request(evt.request.request.clone()).await.map_err(bidi_to_wd)?;
+
+        nav_handle
+            .await
+            .map_err(|e| WebDriverError::FatalError(format!("nav join: {e}")))?
+            .map_err(bidi_to_wd)?;
+
+        // 5. Cleanup.
+        bidi.network().remove_intercept(added.intercept).await.map_err(bidi_to_wd)?;
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// raw event subscription
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn subscribe_raw_yields_typed_method_names() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("browsingContext.load").await.map_err(bidi_to_wd)?;
+        let mut raw = bidi.subscribe_raw();
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(ctx, "data:text/html,<html></html>", None)
+            .await
+            .map_err(bidi_to_wd)?;
+        let deadline = tokio::time::Instant::now() + EVENT_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            match tokio::time::timeout(remaining, raw.next()).await {
+                Ok(Some(ev)) if ev.method == "browsingContext.load" => break,
+                Ok(Some(_)) => continue,
+                _ => panic!("no browsingContext.load via raw stream"),
+            }
+        }
+        driver.quit().await
+    })
+    .await
+}

--- a/thirtyfour/tests/bidi_typed.rs
+++ b/thirtyfour/tests/bidi_typed.rs
@@ -1,0 +1,696 @@
+//! End-to-end tests for the typed WebDriver BiDi API.
+//!
+//! BiDi is a W3C cross-browser protocol; this suite runs against either
+//! chromedriver or geckodriver, selected by `THIRTYFOUR_BROWSER`
+//! (default `chrome`). The driver is downloaded by the manager, so these
+//! tests gate behind the `manager-tests` feature.
+//!
+//! ```text
+//! cargo test -p thirtyfour --features manager-tests,bidi --test bidi_typed -- --test-threads=1
+//! THIRTYFOUR_BROWSER=firefox cargo test -p thirtyfour --features manager-tests,bidi --test bidi_typed -- --test-threads=1
+//! ```
+//!
+//! Every typed command in [`thirtyfour::bidi::modules`] should have at
+//! least one test here. The point is to verify the wire format against a
+//! real BiDi-capable driver — unit tests of the JSON shape are
+//! guess-against-guess and don't tell you anything the driver doesn't.
+
+#![cfg(all(feature = "manager-tests", feature = "bidi"))]
+
+use std::future::Future;
+use std::time::Duration;
+
+use thirtyfour::bidi::modules::{browser, browsing_context, network, script, storage};
+use thirtyfour::prelude::*;
+
+use crate::common::launch_managed_bidi;
+
+mod common;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(180);
+
+async fn with_timeout<F, T>(f: F) -> WebDriverResult<T>
+where
+    F: Future<Output = WebDriverResult<T>>,
+{
+    tokio::time::timeout(TEST_TIMEOUT, f).await.unwrap_or_else(|_| {
+        Err(WebDriverError::FatalError(format!("test exceeded {}s budget", TEST_TIMEOUT.as_secs())))
+    })
+}
+
+const BLANK_HTML: &str = "data:text/html,<html><head><title>BiDi%20test</title></head>\
+<body><h1>x</h1><input id=t /></body></html>";
+
+/// Convert a `BidiError` (returned by `BiDi::send`) into a `WebDriverError`
+/// so tests can use `?` from inside `with_timeout`.
+fn bidi_to_wd(e: thirtyfour::bidi::BidiError) -> WebDriverError {
+    WebDriverError::FatalError(e.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// session
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_status_round_trip() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let status = bidi.session().status().await.map_err(bidi_to_wd)?;
+        // Once we already have an active session the driver reports
+        // `ready: false`, but `message` is always present.
+        assert!(!status.message.is_empty());
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_subscribe_unsubscribe_round_trip() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.session().subscribe("browsingContext.load").await.map_err(bidi_to_wd)?;
+        bidi.session()
+            .unsubscribe(["browsingContext.load".to_string()])
+            .await
+            .map_err(bidi_to_wd)?;
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// browsingContext
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_get_tree() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        assert!(!tree.contexts.is_empty(), "expected at least one top-level context");
+        let root = &tree.contexts[0];
+        // `parent` is null for top-level contexts. Top-level URL is
+        // `about:blank` immediately after a fresh session.
+        assert!(root.parent.is_none());
+        assert!(!root.context.as_str().is_empty());
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_navigate_complete() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let context = tree.contexts[0].context.clone();
+        let nav = bidi
+            .browsing_context()
+            .navigate(context.clone(), BLANK_HTML, Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        assert!(nav.url.starts_with("data:text/html"));
+        // `wait: complete` always assigns a navigation id.
+        assert!(nav.navigation.is_some());
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_create_and_close() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let created = bidi
+            .browsing_context()
+            .create(browsing_context::CreateType::Tab)
+            .await
+            .map_err(bidi_to_wd)?;
+        assert!(!created.context.as_str().is_empty());
+        // Confirm it shows up in the tree.
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        assert!(tree.contexts.iter().any(|c| c.context == created.context));
+        bidi.browsing_context().close(created.context.clone()).await.map_err(bidi_to_wd)?;
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_capture_screenshot_returns_png_b64() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(ctx.clone(), BLANK_HTML, Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        let shot = bidi.browsing_context().capture_screenshot(ctx).await.map_err(bidi_to_wd)?;
+        assert!(!shot.data.is_empty());
+        // PNG base64 always starts with `iVBOR…`.
+        assert!(
+            shot.data.starts_with("iVBOR"),
+            "unexpected screenshot prefix: {}",
+            &shot.data[..16]
+        );
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_set_viewport_then_capture() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(ctx.clone(), BLANK_HTML, Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        bidi.browsing_context()
+            .set_viewport(
+                ctx.clone(),
+                Some(browsing_context::Viewport {
+                    width: 320,
+                    height: 240,
+                }),
+            )
+            .await
+            .map_err(bidi_to_wd)?;
+        // Verify the viewport actually changed via window.innerWidth.
+        let result =
+            bidi.script().evaluate(ctx, "window.innerWidth", false).await.map_err(bidi_to_wd)?;
+        let v = result.ok_value().expect("expected success result");
+        assert_eq!(v["value"].as_i64(), Some(320));
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_activate() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        // Smoke test — activate doesn't error on a single visible tab.
+        bidi.browsing_context().activate(ctx).await.map_err(bidi_to_wd)?;
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_traverse_history() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(
+                ctx.clone(),
+                "data:text/html,<html><body>a</body></html>",
+                Some(browsing_context::ReadinessState::Complete),
+            )
+            .await
+            .map_err(bidi_to_wd)?;
+        bidi.browsing_context()
+            .navigate(
+                ctx.clone(),
+                "data:text/html,<html><body>b</body></html>",
+                Some(browsing_context::ReadinessState::Complete),
+            )
+            .await
+            .map_err(bidi_to_wd)?;
+        // Step back. Driver returns Empty on success.
+        bidi.browsing_context().traverse_history(ctx, -1).await.map_err(bidi_to_wd)?;
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_reload() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(ctx.clone(), BLANK_HTML, Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        // geckodriver 0.36 doesn't yet implement the `ignoreCache` param
+        // ("unsupported operation"). Send the bare reload — wait condition
+        // only — so the test exercises the command shape on both browsers.
+        bidi.send(browsing_context::Reload {
+            context: ctx,
+            ignore_cache: None,
+            wait: Some(browsing_context::ReadinessState::Complete),
+        })
+        .await
+        .map_err(bidi_to_wd)?;
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_handle_user_prompt_dismiss() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(
+                ctx.clone(),
+                "data:text/html,<html><body><script>setTimeout(() => alert('hi'), 0);</script></body></html>",
+                Some(browsing_context::ReadinessState::Interactive),
+            )
+            .await
+            .map_err(bidi_to_wd)?;
+        // The alert may or may not fire before this call depending on
+        // timing. Try once; if there's no prompt the driver returns
+        // "no such alert" — accept either outcome to keep the test
+        // non-flaky.
+        let outcome = bidi
+            .browsing_context()
+            .handle_user_prompt(ctx, Some(false), None)
+            .await;
+        match outcome {
+            Ok(_) => {}
+            Err(e) if e.error == "no such alert" => {}
+            Err(e) => return Err(bidi_to_wd(e)),
+        }
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// script
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn script_evaluate_simple_expression() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        let r = bidi.script().evaluate(ctx, "1 + 2", false).await.map_err(bidi_to_wd)?;
+        let v = r.ok_value().expect("success");
+        assert_eq!(v["type"], "number");
+        assert_eq!(v["value"].as_i64(), Some(3));
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn script_evaluate_await_promise() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        let r = bidi
+            .script()
+            .evaluate(
+                ctx,
+                "new Promise(res => setTimeout(() => res(42), 1))",
+                /* await_promise */ true,
+            )
+            .await
+            .map_err(bidi_to_wd)?;
+        let v = r.ok_value().expect("success");
+        assert_eq!(v["value"].as_i64(), Some(42));
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn script_evaluate_returns_exception_on_throw() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        let r = bidi
+            .script()
+            .evaluate(ctx, "throw new Error('boom')", false)
+            .await
+            .map_err(bidi_to_wd)?;
+        assert!(r.is_exception());
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn script_call_function_returns_value() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        let r = bidi
+            .script()
+            .call_function(ctx, "() => 'thirtyfour'", false)
+            .await
+            .map_err(bidi_to_wd)?;
+        let v = r.ok_value().expect("success");
+        assert_eq!(v["value"].as_str(), Some("thirtyfour"));
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn script_get_realms_lists_window_realm() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let r = bidi.script().get_realms().await.map_err(bidi_to_wd)?;
+        // At least the top-level window realm.
+        assert!(r.realms.iter().any(|info| info.realm_type == "window"));
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn script_add_remove_preload_script() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let added = bidi
+            .script()
+            .add_preload_script("() => { window.__thirtyfour_preload = 1; }")
+            .await
+            .map_err(bidi_to_wd)?;
+        assert!(!added.script.as_str().is_empty());
+        // Navigate so the preload runs.
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(ctx.clone(), BLANK_HTML, Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        let r = bidi
+            .script()
+            .evaluate(ctx, "window.__thirtyfour_preload", false)
+            .await
+            .map_err(bidi_to_wd)?;
+        let v = r.ok_value().expect("success");
+        assert_eq!(v["value"].as_i64(), Some(1));
+        bidi.script().remove_preload_script(added.script).await.map_err(bidi_to_wd)?;
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn script_evaluate_in_realm_target() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let realms = bidi.script().get_realms().await.map_err(bidi_to_wd)?;
+        let realm =
+            realms.realms.into_iter().find(|r| r.realm_type == "window").expect("window realm");
+        let r = bidi
+            .send(script::Evaluate {
+                expression: "navigator.userAgent".to_string(),
+                target: script::Target::Realm {
+                    realm: realm.realm,
+                },
+                await_promise: false,
+                result_ownership: None,
+                user_activation: None,
+            })
+            .await
+            .map_err(bidi_to_wd)?;
+        let v = r.ok_value().expect("success");
+        let ua = v["value"].as_str().unwrap_or("");
+        // Just assert the realm-targeted call returned a non-empty
+        // user-agent string — the exact contents are browser-specific.
+        assert!(!ua.is_empty(), "expected a non-empty user agent string");
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// network — non-event commands.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn network_add_remove_intercept() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let added = bidi
+            .network()
+            .add_intercept(vec![network::InterceptPhase::BeforeRequestSent], None)
+            .await
+            .map_err(bidi_to_wd)?;
+        assert!(!added.intercept.as_str().is_empty());
+        bidi.network().remove_intercept(added.intercept).await.map_err(bidi_to_wd)?;
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn network_set_cache_behavior_global() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        bidi.network()
+            .set_cache_behavior(network::CacheBehavior::Bypass)
+            .await
+            .map_err(bidi_to_wd)?;
+        bidi.network()
+            .set_cache_behavior(network::CacheBehavior::Default)
+            .await
+            .map_err(bidi_to_wd)?;
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// storage
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn storage_set_get_delete_cookie_round_trip() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        // Cookies need a real (non-data:) origin. Navigate to about:blank
+        // is rejected by some drivers so use a tiny localhost server.
+        let server = spawn_local_http("ok").await?;
+        bidi.browsing_context()
+            .navigate(ctx, server.clone(), Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+
+        let host = url::Url::parse(&server)
+            .ok()
+            .and_then(|u| u.host_str().map(String::from))
+            .expect("host");
+        bidi.storage()
+            .set_cookie(storage::PartialCookie {
+                name: "thirtyfour".to_string(),
+                value: storage::bytes_string("hello"),
+                domain: host.clone(),
+                path: Some("/".to_string()),
+                http_only: Some(false),
+                secure: Some(false),
+                same_site: Some(storage::SameSite::Lax),
+                expiry: None,
+            })
+            .await
+            .map_err(bidi_to_wd)?;
+        let got = bidi.storage().get_cookies_by_name("thirtyfour").await.map_err(bidi_to_wd)?;
+        assert_eq!(got.cookies.len(), 1);
+        assert_eq!(got.cookies[0].name, "thirtyfour");
+        bidi.storage().delete_cookies_by_name("thirtyfour").await.map_err(bidi_to_wd)?;
+        let after = bidi.storage().get_cookies_by_name("thirtyfour").await.map_err(bidi_to_wd)?;
+        assert!(after.cookies.is_empty());
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// input
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn input_perform_actions_keystrokes_into_input() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(ctx.clone(), BLANK_HTML, Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        // Focus the input element first via JS.
+        bidi.script()
+            .evaluate(ctx.clone(), "document.getElementById('t').focus()", false)
+            .await
+            .map_err(bidi_to_wd)?;
+        // Send "hi" through input.performActions.
+        let actions = vec![serde_json::json!({
+            "id": "kbd",
+            "type": "key",
+            "actions": [
+                {"type": "keyDown", "value": "h"},
+                {"type": "keyUp",   "value": "h"},
+                {"type": "keyDown", "value": "i"},
+                {"type": "keyUp",   "value": "i"},
+            ]
+        })];
+        bidi.input().perform_actions(ctx.clone(), actions).await.map_err(bidi_to_wd)?;
+        let r = bidi
+            .script()
+            .evaluate(ctx, "document.getElementById('t').value", false)
+            .await
+            .map_err(bidi_to_wd)?;
+        let v = r.ok_value().expect("success");
+        assert_eq!(v["value"].as_str(), Some("hi"));
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn input_release_actions_no_op_after_perform() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.input().release_actions(ctx).await.map_err(bidi_to_wd)?;
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// browser
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browser_user_context_create_list_remove() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let created = bidi.browser().create_user_context().await.map_err(bidi_to_wd)?;
+        let list = bidi.browser().get_user_contexts().await.map_err(bidi_to_wd)?;
+        assert!(list.user_contexts.iter().any(|c| c.user_context == created.user_context));
+        bidi.browser()
+            .remove_user_context(created.user_context.clone())
+            .await
+            .map_err(bidi_to_wd)?;
+        let after = bidi.browser().get_user_contexts().await.map_err(bidi_to_wd)?;
+        assert!(after.user_contexts.iter().all(|c| c.user_context != created.user_context));
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// permissions
+// ---------------------------------------------------------------------------
+//
+// `permissions.setPermission` is optional in the BiDi spec and not
+// implemented by every driver. Test it best-effort: skip on
+// `unknown command` / `unknown method` / `unsupported operation`.
+#[tokio::test(flavor = "multi_thread")]
+async fn permissions_set_permission_best_effort() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let res = bidi
+            .permissions()
+            .set_permission(
+                serde_json::json!({"name": "geolocation"}),
+                thirtyfour::bidi::modules::permissions::PermissionState::Granted,
+                "https://example.com",
+            )
+            .await;
+        match res {
+            Ok(_) => {}
+            Err(e)
+                if matches!(
+                    e.error.as_str(),
+                    "unknown command" | "unknown method" | "unsupported operation"
+                ) => {}
+            Err(e) => return Err(bidi_to_wd(e)),
+        }
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// untyped escape hatch
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn send_raw_unknown_method_returns_typed_error() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let err = bidi
+            .send_raw("nope.notACommand", serde_json::json!({}))
+            .await
+            .expect_err("expected an error");
+        assert!(matches!(err.error.as_str(), "unknown command" | "unknown method"));
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+async fn spawn_local_http(body: &'static str) -> WebDriverResult<String> {
+    let listener = tokio::net::TcpListener::bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .map_err(|e| WebDriverError::FatalError(format!("bind localhost: {e}")))?;
+    let addr = listener
+        .local_addr()
+        .map_err(|e| WebDriverError::FatalError(format!("local_addr: {e}")))?;
+    let app = axum::Router::new().route("/", axum::routing::get(move || async move { body }));
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    Ok(format!("http://127.0.0.1:{}/", addr.port()))
+}
+
+// Touch unused-imports the test file declares so `use` lines stay tidy
+// even if a test gets removed.
+#[allow(dead_code)]
+fn _force_imports(_: browser::CreateUserContext) {}

--- a/thirtyfour/tests/common.rs
+++ b/thirtyfour/tests/common.rs
@@ -131,6 +131,46 @@ pub async fn launch_managed_chrome(caps: ChromeCapabilities) -> WebDriverResult<
     mgr.launch(caps).await
 }
 
+/// Launch a Firefox session against the binary's shared [`WebDriverManager`].
+/// Mirror of [`launch_managed_chrome`] for cross-browser tests
+/// (notably the BiDi suite, which is supported by both browsers).
+pub async fn launch_managed_firefox(caps: FirefoxCapabilities) -> WebDriverResult<WebDriver> {
+    let mgr = manager_for("firefox");
+    mgr.launch(caps).await
+}
+
+/// Launch a BiDi-enabled session for the browser named by the
+/// `THIRTYFOUR_BROWSER` env var (`"chrome"` | `"firefox"`, default Chrome).
+///
+/// Used by the BiDi integration test suites — BiDi is a W3C cross-browser
+/// protocol so the tests run on both via the env var.
+pub async fn launch_managed_bidi() -> WebDriverResult<WebDriver> {
+    let browser = std::env::var("THIRTYFOUR_BROWSER").unwrap_or_else(|_| "chrome".to_string());
+    match browser.as_str() {
+        "firefox" => {
+            let mut caps = DesiredCapabilities::firefox();
+            caps.set_headless()?;
+            caps.enable_bidi()?;
+            launch_managed_firefox(caps).await
+        }
+        _ => {
+            let mut caps = DesiredCapabilities::chrome();
+            caps.set_headless()?;
+            caps.set_no_sandbox()?;
+            caps.set_disable_gpu()?;
+            caps.set_disable_dev_shm_usage()?;
+            caps.add_arg("--no-sandbox")?;
+            caps.enable_bidi()?;
+            launch_managed_chrome(caps).await
+        }
+    }
+}
+
+/// Returns the active browser backend name for BiDi tests.
+pub fn bidi_browser() -> String {
+    std::env::var("THIRTYFOUR_BROWSER").unwrap_or_else(|_| "chrome".to_string())
+}
+
 /// Helper struct for running tests.
 pub struct TestHarness {
     browser: String,


### PR DESCRIPTION
## Summary

Adds a `bidi` cargo feature exposing typed commands and event subscription
over the W3C WebDriver BiDi protocol — the cross-browser successor to the
Chrome-only CDP layer. Sits alongside the existing classic-HTTP and CDP
APIs; opt in by calling `caps.enable_bidi()` and reaching the handle via
`driver.bidi().await?`.

The handle is connected lazily on first call and cached on the session,
so repeated calls are cheap. Cloning is cheap (`Arc`-shared transport).

## What changed

**New `thirtyfour::bidi` module** mirroring the layout of `cdp/`:
- Core: `mod.rs`, `handle.rs`, `command.rs`, `events.rs`, `error.rs`,
  `ids.rs`, `macros.rs`, `capabilities.rs`
- Transport: `transport/ws.rs` — JSON-RPC-ish dispatcher
  (`type: success|error|event`), oneshot for responses, broadcast for events
- Curated typed bindings under `bidi::modules::*` for **session, browser,
  browsing_context, script, network, storage, log, input, permissions** —
  the spec surface that's stable in chromedriver ≥ 115 and geckodriver ≥ 0.31

**Plumbing:**
- `Capabilities::enable_bidi()` sets W3C `webSocketUrl: true`.
- `WebDriver::bidi()` opens the WS lazily (cached in a `OnceCell` on
  `SessionHandle`) and returns a `BiDi` handle.
- `From<BidiError> for WebDriverError` so `?` works in mixed code.

**Manager fix surfaced during cross-browser work:** Firefox's RemoteAgent
binds the BiDi WS to a fixed default port (`9222`), so back-to-back
sessions race for it and the returned `webSocketUrl` capability stays
stale. The manager now passes `--websocket-port=0` to geckodriver so the
OS assigns a free port and the returned URL reflects the real bind. This
is a manager-level fix that benefits every Firefox-BiDi user, not just
the test suite.

**Spec/driver discrepancies caught by integration tests and fixed:**
- `storage.deleteCookies` returns `{ partitionKey }`, not `{}` — typed
  `Empty` was rejected; switched to a real `DeleteCookiesResult`.
- chromedriver sends `children: null` on `contextCreated`. Added a
  `null_to_default` deserializer for `BrowsingContextInfo::children` so
  the typed event deserialises on both Chrome and Firefox.
- chromedriver doesn't reliably fire `contextCreated` for top-level tabs
  from `browsingContext.create` — the test now uses an iframe-trigger,
  which is the spec-guaranteed path.

**Examples, docs, CI:**
- Three runnable examples — `bidi_basic`, `bidi_network_intercept`
  (full intercept loop with subscribe → continue → remove), and
  `bidi_log_events`.
- `README.md` feature list and `MIGRATION.md` quick-start updated.
- New `.github/workflows/bidi-test.yml` running a 2×2 matrix
  (`{chrome, firefox} × {typed, events}`) — 4 jobs.

## Test results

| Suite          | Chrome | Firefox |
| -------------- | ------ | ------- |
| `bidi_typed`   | 26 ✓   | 26 ✓    |
| `bidi_events`  | 12 ✓   | 12 ✓    |

**76 BiDi integration test runs across both drivers, all green** locally
against managed chromedriver and geckodriver. Pre-push checks
(`cargo fmt`, `cargo clippy --all-features --all-targets`,
`cargo doc --no-deps --all-features`, `cargo test --lib --all-features`,
`cargo test --doc --all-features`) all clean. Existing CDP tests still
pass — smoke-tested 3 of them.

## Reviewer notes

- BiDi handle creation is **opt-in** via `caps.enable_bidi()`. Default
  feature set is unchanged; nothing happens without the user adding
  `webSocketUrl: true` to capabilities.
- `WebDriver::bidi()` returns `WebDriverResult<BiDi>` because the WS dial
  can fail. Subsequent calls hit a `OnceCell` and skip the dial.
- The `BidiCommand` / `BidiEvent` traits intentionally mirror
  `CdpCommand` / `CdpEvent` so users familiar with the CDP layer can
  navigate BiDi without a second mental model.
- BiDi error codes are exposed as a `String` field on `BidiError` rather
  than a closed enum — the spec's error-code list grows over releases and
  forward-compat matters more than exhaustive matching.
- `RemoteValue` / `LocalValue` JSON shapes are deeply recursive and
  rarely need typed access; `script.*` exposes them as `serde_json::Value`
  so users pay no upfront serde cost and can decode themselves if needed.
- The `--websocket-port=0` change in `manager/process.rs` only affects
  Firefox launches and is otherwise transparent.

## Test plan
- [ ] CI: `bidi typed / chrome` passes
- [ ] CI: `bidi events / chrome` passes
- [ ] CI: `bidi typed / firefox` passes
- [ ] CI: `bidi events / firefox` passes
- [ ] CI: existing `cdp typed`, `cdp events`, `manager-test`, lint, doc, msrv jobs all still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)