### PR TITLE
Implement full WebDriver BiDi spec and document every module

### DIFF
--- a/docs/src/bidi/events.md
+++ b/docs/src/bidi/events.md
@@ -51,16 +51,25 @@ to see them.
 
 ## Common Event Types
 
-The most-used events are re-exported from
+Every typed event is re-exported from
 [`thirtyfour::bidi::events`][events-rustdoc] so a single `use` covers
 the common cases:
 
 ```rust
 use thirtyfour::bidi::events::{
-    Load, DomContentLoaded, NavigationStarted, FragmentNavigated,
+    // Page lifecycle
+    Load, DomContentLoaded, FragmentNavigated, HistoryUpdated,
+    NavigationStarted, NavigationCommitted, NavigationAborted, NavigationFailed,
+    // Tabs / frames
     ContextCreated, ContextDestroyed,
-    UserPromptOpened, UserPromptClosed,
+    // Downloads
+    DownloadWillBegin, DownloadEnd,
+    // User prompts and file dialogs
+    UserPromptOpened, UserPromptClosed, FileDialogOpened,
+    // Network
     BeforeRequestSent, ResponseStarted, ResponseCompleted, FetchError, AuthRequired,
+    // Script / log
+    RealmCreated, RealmDestroyed, ScriptMessage,
     LogEntryAdded,
 };
 ```

--- a/docs/src/bidi/overview.md
+++ b/docs/src/bidi/overview.md
@@ -12,12 +12,12 @@ typed commands grouped by module (`browsingContext.*`, `script.*`,
 `network.*`, …), event subscriptions, request interception. The
 trade-off is coverage vs. portability:
 
-|                       | CDP (Chromium-only) | BiDi (cross-browser) |
-|-----------------------|---------------------|-----------------------|
-| Surface area          | Larger              | Growing, but smaller |
-| Portable across browsers | No               | Yes                   |
-| Standardised          | No                  | Yes (W3C)             |
-| Connection            | Direct WebSocket    | Via WebDriver session |
+|                       | CDP (Chromium-only)        | BiDi (cross-browser)       |
+|-----------------------|----------------------------|----------------------------|
+| Surface area          | Larger, Chromium-specific  | Full W3C BiDi spec covered |
+| Portable across browsers | No                      | Yes                        |
+| Standardised          | No                         | Yes (W3C)                  |
+| Connection            | Direct WebSocket           | Via WebDriver session      |
 
 ## Enabling BiDi
 
@@ -81,14 +81,16 @@ The curated typed bindings live under [`bidi::modules`][modules-rustdoc]:
 | Module             | Use it for                                                                |
 |--------------------|---------------------------------------------------------------------------|
 | `session`          | `status`, `subscribe`/`unsubscribe`, `end`                                |
-| `browser`          | Top-level browser control, user contexts                                  |
-| `browsing_context` | Tabs, frames, navigation, screenshots, history                            |
+| `browser`          | Browser-wide control, user contexts, client windows, download behavior    |
+| `browsing_context` | Tabs, frames, navigation, screenshots, printing, locating nodes, CSP      |
 | `script`           | `evaluate`, `callFunction`, preload scripts, realms                       |
-| `network`          | Interception, modify request/response, auth                               |
+| `network`          | Interception, modify request/response, auth, data collectors, headers     |
 | `storage`          | Cookies and partition lookup                                              |
 | `log`              | `log.entryAdded` events                                                   |
-| `input`            | `performActions`, `releaseActions`, `setFiles`                            |
+| `input`            | `performActions`, `releaseActions`, `setFiles`, `fileDialogOpened` events |
 | `permissions`      | `setPermission`                                                           |
+| `emulation`        | Geolocation, locale, timezone, screen, user-agent, scripting & touch      |
+| `web_extension`    | Install / uninstall web extensions                                        |
 
 Each command in those modules is a Rust struct that implements
 [`BidiCommand`], pairing the request type with its response type and
@@ -107,6 +109,40 @@ A few helpers worth knowing about:
   [`InterceptGuard`][intercept-guard-rustdoc] you can `.remove().await`
   explicitly, or just let drop (best-effort cleanup runs in the
   background).
+
+## Emulation Overrides
+
+The `emulation` module overrides browser-emulated APIs (geolocation,
+locale, timezone, screen, user agent, scripting, touch, …). Each
+command applies globally by default; build the command struct directly
+to scope it to specific browsing contexts or user contexts. Pass `None`
+to clear an override.
+
+```rust
+use thirtyfour::bidi::modules::emulation::GeolocationCoordinates;
+# use thirtyfour::prelude::*;
+# async fn run(bidi: thirtyfour::bidi::BiDi) -> WebDriverResult<()> {
+bidi.emulation()
+    .set_geolocation_override(Some(GeolocationCoordinates {
+        latitude: -33.8688,
+        longitude: 151.2093,
+        accuracy: Some(50.0),
+        altitude: None,
+        altitude_accuracy: None,
+        heading: None,
+        speed: None,
+    }))
+    .await?;
+
+bidi.emulation().set_timezone_override(Some("Australia/Sydney".into())).await?;
+bidi.emulation().set_locale_override(Some("en-AU".into())).await?;
+# Ok(()) }
+```
+
+> Driver support for `emulation.*` is uneven at the time of writing —
+> chromedriver implements most, geckodriver lags. The wire shape is
+> stable; commands return `error("unsupported operation")` where the
+> driver doesn't yet handle them.
 
 ## The Untyped Escape Hatch
 

--- a/thirtyfour/src/bidi/command.rs
+++ b/thirtyfour/src/bidi/command.rs
@@ -1,22 +1,27 @@
-//! Core traits that pair a BiDi command's request type with its response
-//! type, and an event type with its method name.
+//! Core traits and marker types for BiDi commands and events.
 //!
-//! Implement [`BidiCommand`] for any command not in the curated set under
-//! [`crate::bidi::modules`]; the same `BiDi::send` / `EventStream`
-//! infrastructure will pick it up. [`BidiEvent`] is the same idea for events
-//! delivered to an active subscription.
+//! Every typed command implements [`BidiCommand`], pairing the request
+//! type with its response type and the wire method name. Every typed
+//! event implements [`BidiEvent`].
+//!
+//! Implement these traits for any command or event not in the curated
+//! set under [`crate::bidi::modules`] — the framework picks them up
+//! automatically via [`BiDi::send`](crate::bidi::BiDi::send) and
+//! [`BiDi::subscribe`](crate::bidi::BiDi::subscribe). There is no
+//! second-class API.
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 /// A typed BiDi command.
 ///
-/// `Self` is the request `params` type (must be [`Serialize`]); [`Returns`]
-/// is the typed `result` returned by [`crate::bidi::BiDi::send`]. `METHOD`
-/// is the wire name, e.g. `"browsingContext.navigate"`.
-///
-/// [`Returns`]: BidiCommand::Returns
+/// `Self` is the request `params` type (must be [`Serialize`]).
+/// [`Returns`](BidiCommand::Returns) is the deserialised `result` type
+/// returned by [`BiDi::send`](crate::bidi::BiDi::send).
+/// [`METHOD`](BidiCommand::METHOD) is the spec-defined wire name
+/// (e.g. `"browsingContext.navigate"`).
 ///
 /// # Example
+///
 /// ```
 /// use serde::{Deserialize, Serialize};
 /// use thirtyfour::bidi::BidiCommand;
@@ -41,29 +46,48 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 pub trait BidiCommand: Serialize {
     /// Wire name of the command (e.g. `"browsingContext.navigate"`).
     const METHOD: &'static str;
-    /// Response `result` type. Use [`Empty`] for commands that return `{}`.
+    /// Response `result` type. Use [`Empty`] for commands that return
+    /// an empty object (`{}`).
     type Returns: DeserializeOwned;
 }
 
-/// A typed BiDi event delivered through [`crate::bidi::BiDi::subscribe`].
+/// A typed BiDi event.
+///
+/// Implementations are deserialised into the `Self` type and delivered
+/// through [`BiDi::subscribe::<E>()`](crate::bidi::BiDi::subscribe).
+/// `METHOD` is the spec-defined wire name
+/// (e.g. `"browsingContext.load"`).
 pub trait BidiEvent: DeserializeOwned + Clone + Send + Sync + 'static {
     /// Wire name of the event (e.g. `"browsingContext.load"`).
     const METHOD: &'static str;
 }
 
-/// Marker type for BiDi commands whose response `result` body is `{}`.
+/// Marker type for BiDi commands whose response body is the empty
+/// object `{}`.
 ///
 /// Many commands (`session.subscribe`, `browsingContext.close`,
-/// `script.removePreloadScript`, …) return an empty object on success.
+/// `script.removePreloadScript`, every `emulation.*` setter, …)
+/// return `{}` on success. Implement [`BidiCommand`] with
+/// `type Returns = Empty;` to model that.
+///
+/// `Empty` is `Deserialize` with `deny_unknown_fields`, so a non-empty
+/// response body would be a deserialise error — useful as a defensive
+/// check that the spec hasn't started returning meaningful data.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Empty {}
 
-/// A raw event delivered by [`crate::bidi::BiDi::subscribe_raw`].
+/// A raw event delivered by
+/// [`BiDi::subscribe_raw`](crate::bidi::BiDi::subscribe_raw).
+///
+/// No filtering or deserialisation is performed — every event the
+/// driver pushes is surfaced as-is. Useful for debugging, dump
+/// recording, or implementing a typed event that hasn't been added to
+/// the curated set yet.
 #[derive(Debug, Clone)]
 pub struct RawEvent {
     /// Wire name of the event (e.g. `"network.beforeRequestSent"`).
     pub method: String,
-    /// Event params as raw JSON.
+    /// Event `params` as raw JSON.
     pub params: serde_json::Value,
 }

--- a/thirtyfour/src/bidi/error.rs
+++ b/thirtyfour/src/bidi/error.rs
@@ -1,32 +1,53 @@
 //! BiDi-specific error type.
 //!
-//! Failed BiDi commands return a JSON envelope of the form
+//! Failed BiDi commands respond with a JSON envelope of the form
 //! `{"type":"error","id":N,"error":"<code>","message":"...","stacktrace":"..."}`.
 //! [`BidiError`] is the typed view of that envelope.
+//!
+//! The full list of [W3C BiDi error codes][spec] is open-ended — the
+//! spec continues to add codes over time, and drivers can return
+//! values not yet documented. The `error` field is therefore a `String`
+//! rather than an enum.
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#errors
 
 use serde::Deserialize;
 use std::fmt;
 
-/// A BiDi command error.
+/// A failed BiDi command.
 ///
-/// The `error` field is one of the W3C BiDi-defined error codes (e.g.
-/// `"unknown command"`, `"no such frame"`, `"invalid argument"`); kept as a
-/// `String` because the spec adds new codes over time.
+/// The `error` field is a [W3C BiDi error code][spec] string
+/// (`"unknown command"`, `"no such frame"`, `"invalid argument"`,
+/// `"unsupported operation"`, …). Helpers on this type
+/// ([`is_session_ended`](Self::is_session_ended),
+/// [`is_no_such`](Self::is_no_such)) classify common categories.
+///
+/// `BidiError` implements `From<BidiError> for WebDriverError`, so it
+/// composes with code that uses `WebDriverResult<T>` — but you'll
+/// generally get more useful information from the typed shape directly.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#errors
 #[derive(Debug, Clone, thiserror::Error)]
 pub struct BidiError {
     /// The BiDi method that failed (e.g. `"browsingContext.navigate"`).
     pub command: String,
-    /// W3C BiDi error code (`"invalid argument"`, `"no such frame"`, …).
+    /// W3C BiDi error code — `"invalid argument"`, `"no such frame"`,
+    /// `"unsupported operation"`, etc.
     pub error: String,
     /// Human-readable message from the driver.
     pub message: String,
-    /// Optional stack trace from the driver.
+    /// Optional stack trace from the driver. When present, it points
+    /// into driver-internal code, not the page under test.
     pub stacktrace: Option<String>,
 }
 
 impl BidiError {
-    /// True if this error indicates the BiDi session ended (e.g. browser
-    /// closed). Detected by the W3C error code.
+    /// True if this error indicates the underlying WebDriver session
+    /// has ended (typically because the browser process exited).
+    ///
+    /// Detected from the error code; specifically matches
+    /// `"invalid session id"`, `"session not created"`, and
+    /// `"unable to close browser"`.
     pub fn is_session_ended(&self) -> bool {
         matches!(
             self.error.as_str(),
@@ -34,8 +55,12 @@ impl BidiError {
         )
     }
 
-    /// True if this error indicates the target referenced by the command
-    /// (browsing context, frame, element node, request, …) does not exist.
+    /// True if this error indicates that the target referenced by the
+    /// command (browsing context, frame, element node, request,
+    /// intercept, …) does not exist.
+    ///
+    /// Implemented as a prefix match on `"no such"`, which covers every
+    /// `no such X` error code defined by the spec.
     pub fn is_no_such(&self) -> bool {
         self.error.starts_with("no such")
     }
@@ -52,14 +77,14 @@ impl From<BidiError> for crate::error::WebDriverError {
         // BiDi errors carry richer information than the W3C HTTP error
         // shape, so we render them as `FatalError` strings rather than
         // pretending to be a typed W3C error code (would require synthetic
-        // `WebDriverErrorInfo`s). Users who want the typed BiDi shape
-        // should call `BiDi::send` directly and get back `BidiError`.
+        // `WebDriverErrorInfo`s). Callers who want the typed BiDi shape
+        // should use `BiDi::send` directly and match on `BidiError`.
         crate::error::WebDriverError::FatalError(e.to_string())
     }
 }
 
-/// Wire shape of an error envelope as it appears on the WebSocket. Used by
-/// the transport when parsing responses.
+/// Wire shape of an error envelope as it appears on the WebSocket.
+/// Used by the transport when parsing responses.
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct BidiErrorEnvelope {
     pub error: String,

--- a/thirtyfour/src/bidi/events.rs
+++ b/thirtyfour/src/bidi/events.rs
@@ -1,13 +1,24 @@
-//! Typed BiDi events.
+//! Typed BiDi events — re-exported from each module's `events`
+//! submodule for convenience.
 //!
-//! Each event implements [`crate::bidi::BidiEvent`] and is the typed
-//! payload for [`crate::bidi::BiDi::subscribe`]. Names are renamed
-//! where the bare W3C ones would collide.
+//! Each event implements [`BidiEvent`](crate::bidi::BidiEvent) and is
+//! the typed payload for
+//! [`BiDi::subscribe::<E>()`](crate::bidi::BiDi::subscribe). Names are
+//! renamed where the bare W3C ones would collide
+//! (`script.message` → [`ScriptMessage`],
+//! `log.entryAdded` → [`LogEntryAdded`]).
+//!
+//! See the [W3C events section][spec] for the canonical list of events
+//! and their wire shapes.
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#events
 
 pub use crate::bidi::modules::browsing_context::events::{
-    ContextCreated, ContextDestroyed, DomContentLoaded, FragmentNavigated, Load, NavigationStarted,
-    UserPromptClosed, UserPromptOpened,
+    ContextCreated, ContextDestroyed, DomContentLoaded, DownloadEnd, DownloadWillBegin,
+    FragmentNavigated, HistoryUpdated, Load, NavigationAborted, NavigationCommitted,
+    NavigationFailed, NavigationStarted, UserPromptClosed, UserPromptOpened,
 };
+pub use crate::bidi::modules::input::events::FileDialogOpened;
 pub use crate::bidi::modules::log::events::EntryAdded as LogEntryAdded;
 pub use crate::bidi::modules::network::events::{
     AuthRequired, BeforeRequestSent, FetchError, ResponseCompleted, ResponseStarted,

--- a/thirtyfour/src/bidi/handle.rs
+++ b/thirtyfour/src/bidi/handle.rs
@@ -1,7 +1,4 @@
 //! The [`BiDi`] handle — the entry point for WebDriver BiDi.
-//!
-//! Returned by [`crate::WebDriver::bidi`]. Cheap to clone (wraps an
-//! `Arc`-shared transport).
 
 use std::sync::Arc;
 
@@ -17,13 +14,40 @@ use super::transport::ws::BidiTransport;
 use crate::error::WebDriverResult;
 use crate::session::handle::SessionHandle;
 
-/// WebDriver BiDi handle.
+/// WebDriver BiDi connection handle.
 ///
-/// Cheap to clone; wraps an internal `Arc`. Open one with
-/// [`crate::WebDriver::bidi`]; the WebSocket is connected lazily on first
-/// call and reused thereafter.
+/// `BiDi` owns the WebSocket connection to the driver's BiDi endpoint
+/// and exposes typed access to every command and event via either:
+///
+/// - The module facades returned by [`session`](Self::session),
+///   [`browser`](Self::browser),
+///   [`browsing_context`](Self::browsing_context),
+///   [`script`](Self::script), [`network`](Self::network),
+///   [`storage`](Self::storage), [`log`](Self::log),
+///   [`input`](Self::input), [`permissions`](Self::permissions),
+///   [`emulation`](Self::emulation), and
+///   [`web_extension`](Self::web_extension); or
+/// - The lower-level [`send`](Self::send) /
+///   [`subscribe::<E>()`](Self::subscribe) primitives.
+///
+/// For commands or events outside the curated set, fall back to
+/// [`send_raw`](Self::send_raw) / [`subscribe_raw`](Self::subscribe_raw).
+///
+/// # Lifecycle and cloning
+///
+/// `BiDi` is cheap to clone — the underlying transport is `Arc`-wrapped
+/// — so it's idiomatic to pass clones into spawned tasks. The
+/// connection is established lazily by
+/// [`WebDriver::bidi`](crate::WebDriver::bidi) on first use; subsequent
+/// calls hand out clones of the same handle.
+///
+/// Subscription bookkeeping is reference-counted: each
+/// [`subscribe::<E>()`](Self::subscribe) call bumps a per-event
+/// counter, and the wire-level `session.unsubscribe` is sent
+/// automatically when the last stream for that event drops.
 ///
 /// # Example
+///
 /// ```no_run
 /// # use thirtyfour::prelude::*;
 /// # async fn run() -> WebDriverResult<()> {
@@ -42,8 +66,11 @@ pub struct BiDi {
 }
 
 impl BiDi {
-    /// Connect to the BiDi WebSocket discovered from the session's
-    /// capabilities.
+    /// Resolve the BiDi WebSocket URL from session capabilities and
+    /// connect.
+    ///
+    /// Internal: called once by
+    /// [`WebDriver::bidi`](crate::WebDriver::bidi) and cached.
     pub(crate) async fn connect(handle: Arc<SessionHandle>) -> WebDriverResult<Self> {
         let url = resolve_bidi_websocket_url(&handle)?;
         let transport = BidiTransport::connect(&url).await?;
@@ -54,7 +81,17 @@ impl BiDi {
 
     /// Send a typed BiDi command and decode its `result`.
     ///
+    /// `C: BidiCommand` carries both the wire method name (`C::METHOD`)
+    /// and the response type (`C::Returns`), so this is a single
+    /// generic surface for every command in the curated module set.
+    ///
+    /// Errors are returned as [`BidiError`], which mirrors the spec's
+    /// error envelope (`error`, `message`, optional `stacktrace`).
+    /// Serialise / deserialise failures are surfaced as a synthetic
+    /// `<serde>` command error.
+    ///
     /// # Example
+    ///
     /// ```no_run
     /// # use thirtyfour::prelude::*;
     /// # async fn run(driver: WebDriver) -> WebDriverResult<()> {
@@ -71,13 +108,16 @@ impl BiDi {
         serde_json::from_value(raw).map_err(serde_err)
     }
 
-    /// Send a BiDi command by name with the given params, returning the raw
-    /// `result` value. Useful for one-off commands that aren't in the
-    /// curated set under [`crate::bidi::modules`].
+    /// Send a BiDi command by name with the given params, returning the
+    /// raw `result` value.
     ///
-    /// `params` accepts anything `Serialize`. Pass `()` for commands that
-    /// take no parameters — the BiDi spec requires an object so the
-    /// transport coerces `null` to `{}`.
+    /// Useful for one-off commands that aren't in the curated set under
+    /// [`crate::bidi::modules`], or while prototyping a wire shape
+    /// before promoting it to a typed [`BidiCommand`] impl.
+    ///
+    /// `params` accepts anything `Serialize`. Pass `()` for commands
+    /// that take no parameters — the BiDi spec requires an object on
+    /// the wire, so the transport coerces `null` to `{}`.
     pub async fn send_raw<P: serde::Serialize>(
         &self,
         method: &str,
@@ -96,10 +136,11 @@ impl BiDi {
     ///
     /// For module-wide wildcards (e.g. `"browsingContext"` to receive
     /// every event in that module) there's no single typed event to
-    /// point at — fall back to [`Self::session`]`.subscribe(...)` and
-    /// [`Self::subscribe_raw`].
+    /// dispatch on — fall back to [`Self::session`]`.subscribe(...)`
+    /// followed by [`Self::subscribe_raw`].
     ///
     /// # Example
+    ///
     /// ```no_run
     /// # use thirtyfour::prelude::*;
     /// # use futures_util::StreamExt;
@@ -117,58 +158,83 @@ impl BiDi {
         Ok(EventStream::new(self.transport.clone(), self.transport.subscribe_events(), E::METHOD))
     }
 
-    /// Subscribe to all events on the BiDi connection as raw `(method, params)`.
+    /// Subscribe to every event on the BiDi connection as a raw
+    /// `(method, params)` stream.
     ///
     /// You're responsible for sending the matching `session.subscribe`
-    /// commands via [`Self::session`] — this method only returns the
-    /// local stream end and does no wire-level subscription on its own.
+    /// commands first via [`Self::session`] — this method only returns
+    /// the local stream end and does **no** wire-level subscription on
+    /// its own.
     pub fn subscribe_raw(&self) -> RawEventStream {
         RawEventStream::new(self.transport.subscribe_events())
     }
 
-    /// `session.*` module facade (status, subscribe, end, …).
+    /// Return the [`session.*`](crate::bidi::modules::session) facade
+    /// (status, subscribe, end).
     pub fn session(&self) -> modules::session::SessionModule<'_> {
         modules::session::SessionModule::new(self)
     }
 
-    /// `browser.*` module facade (close, user contexts).
+    /// Return the [`browser.*`](crate::bidi::modules::browser) facade
+    /// (close, user contexts, client windows, download behavior).
     pub fn browser(&self) -> modules::browser::BrowserModule<'_> {
         modules::browser::BrowserModule::new(self)
     }
 
-    /// `browsingContext.*` module facade (navigation, screenshots, tree …).
+    /// Return the [`browsingContext.*`](crate::bidi::modules::browsing_context)
+    /// facade (navigate, screenshots, tree, locate nodes, print, …).
     pub fn browsing_context(&self) -> modules::browsing_context::BrowsingContextModule<'_> {
         modules::browsing_context::BrowsingContextModule::new(self)
     }
 
-    /// `script.*` module facade (`evaluate`, `callFunction`, preload scripts).
+    /// Return the [`script.*`](crate::bidi::modules::script) facade
+    /// (`evaluate`, `callFunction`, preload scripts, realms).
     pub fn script(&self) -> modules::script::ScriptModule<'_> {
         modules::script::ScriptModule::new(self)
     }
 
-    /// `network.*` module facade (interception, modify req/resp).
+    /// Return the [`network.*`](crate::bidi::modules::network) facade
+    /// (interception, modify req/resp, data collectors, extra headers).
     pub fn network(&self) -> modules::network::NetworkModule<'_> {
         modules::network::NetworkModule::new(self)
     }
 
-    /// `storage.*` module facade (cookies, partitions).
+    /// Return the [`storage.*`](crate::bidi::modules::storage) facade
+    /// (cookies, partitions).
     pub fn storage(&self) -> modules::storage::StorageModule<'_> {
         modules::storage::StorageModule::new(self)
     }
 
-    /// `log.*` module facade (event-only — no commands).
+    /// Return the [`log.*`](crate::bidi::modules::log) facade
+    /// (event-only — subscribe via
+    /// [`subscribe::<LogEntryAdded>()`](Self::subscribe)).
     pub fn log(&self) -> modules::log::LogModule<'_> {
         modules::log::LogModule::new(self)
     }
 
-    /// `input.*` module facade (`performActions`, `releaseActions`, `setFiles`).
+    /// Return the [`input.*`](crate::bidi::modules::input) facade
+    /// (`performActions`, `releaseActions`, `setFiles`).
     pub fn input(&self) -> modules::input::InputModule<'_> {
         modules::input::InputModule::new(self)
     }
 
-    /// `permissions.*` module facade (`setPermission`).
+    /// Return the [`permissions.*`](crate::bidi::modules::permissions)
+    /// facade (`setPermission`).
     pub fn permissions(&self) -> modules::permissions::PermissionsModule<'_> {
         modules::permissions::PermissionsModule::new(self)
+    }
+
+    /// Return the [`emulation.*`](crate::bidi::modules::emulation)
+    /// facade (geolocation, locale, timezone, screen, user-agent
+    /// overrides).
+    pub fn emulation(&self) -> modules::emulation::EmulationModule<'_> {
+        modules::emulation::EmulationModule::new(self)
+    }
+
+    /// Return the [`webExtension.*`](crate::bidi::modules::web_extension)
+    /// facade (install / uninstall extensions).
+    pub fn web_extension(&self) -> modules::web_extension::WebExtensionModule<'_> {
+        modules::web_extension::WebExtensionModule::new(self)
     }
 }
 

--- a/thirtyfour/src/bidi/ids.rs
+++ b/thirtyfour/src/bidi/ids.rs
@@ -1,61 +1,175 @@
 //! Newtypes for opaque BiDi identifiers.
 //!
-//! The spec uses a handful of distinct string-shaped ids that are easy
-//! to mix up. These newtypes preserve the wire format
-//! (`#[serde(transparent)]`) while staying distinct in Rust.
+//! The W3C BiDi spec uses many distinct string-shaped identifiers
+//! ([`browsingContext.BrowsingContext`][bc], [`script.Realm`][realm],
+//! [`network.Request`][req], etc.). On the wire they all look the same
+//! — a JSON string — so it's easy to mix them up in Rust unless the
+//! types track the difference.
+//!
+//! Each newtype here is `#[serde(transparent)]` (so the wire shape is
+//! unchanged), implements `From<String>` / `From<&str>` /
+//! [`Display`](std::fmt::Display), and exposes [`as_str`](BrowsingContextId::as_str)
+//! for borrow access.
+//!
+//! [bc]: https://w3c.github.io/webdriver-bidi/#type-browsingContext-BrowsingContext
+//! [realm]: https://w3c.github.io/webdriver-bidi/#type-script-Realm
+//! [req]: https://w3c.github.io/webdriver-bidi/#type-network-Request
 
 use crate::common::protocol::string_id;
 
 string_id! {
-    /// Identifier for a browsing context (`browsingContext.BrowsingContext`).
-    /// On most drivers this is the same string used as a WebDriver classic
-    /// window handle.
+    /// Identifier for a browsing context. Mirrors the spec's
+    /// [`browsingContext.BrowsingContext`][spec] type.
+    ///
+    /// On most drivers this is the same string used as a WebDriver
+    /// Classic window handle — including for child frames, where it
+    /// identifies the frame as a navigable rather than the parent window.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-browsingContext-BrowsingContext
     BrowsingContextId
 }
 
 string_id! {
-    /// Identifier for a navigation initiated through BiDi
-    /// (`browsingContext.Navigation`).
+    /// Identifier for a navigation initiated through BiDi. Mirrors the
+    /// spec's [`browsingContext.Navigation`][spec] type.
+    ///
+    /// Returned by
+    /// [`browsingContext.navigate`](crate::bidi::modules::browsing_context::Navigate)
+    /// and surfaced on lifecycle events
+    /// ([`Load`](crate::bidi::events::Load), …) so you can correlate
+    /// "the navigation I started" against subsequent traffic.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-browsingContext-Navigation
     NavigationId
 }
 
 string_id! {
-    /// Identifier for a script realm (`script.Realm`). Stable while the
-    /// realm exists; reused across `script.evaluate` / `script.callFunction`.
+    /// Identifier for a JavaScript realm. Mirrors the spec's
+    /// [`script.Realm`][spec] type.
+    ///
+    /// A realm is the BiDi term for an execution context — a window's
+    /// main world, a worker, a sandbox. The id is stable for the
+    /// realm's lifetime and is preserved across calls into
+    /// [`script.evaluate`](crate::bidi::modules::script::Evaluate) /
+    /// [`script.callFunction`](crate::bidi::modules::script::CallFunction).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-Realm
     RealmId
 }
 
 string_id! {
     /// Identifier for a preload script registered via
-    /// `script.addPreloadScript`.
+    /// [`script.addPreloadScript`](crate::bidi::modules::script::AddPreloadScript).
+    /// Mirrors the spec's [`script.PreloadScript`][spec] type.
+    ///
+    /// Pass to
+    /// [`script.removePreloadScript`](crate::bidi::modules::script::RemovePreloadScript)
+    /// to uninstall.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-PreloadScript
     PreloadScriptId
 }
 
 string_id! {
-    /// Identifier for a network request (`network.Request`).
+    /// Identifier for a network request. Mirrors the spec's
+    /// [`network.Request`][spec] type.
+    ///
+    /// Stable across redirects — a redirected request keeps the same
+    /// id as the original.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-network-Request
     RequestId
 }
 
 string_id! {
-    /// Identifier for a network request interception
-    /// (`network.Intercept`).
+    /// Identifier for a network interception registered via
+    /// [`network.addIntercept`](crate::bidi::modules::network::AddIntercept).
+    /// Mirrors the spec's [`network.Intercept`][spec] type.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-network-Intercept
     InterceptId
 }
 
 string_id! {
-    /// Identifier for a user context — BiDi's "incognito-like" isolation
-    /// container (`browser.UserContext`).
+    /// Identifier for a [user context][spec] — BiDi's incognito-like
+    /// storage isolation primitive. Mirrors the spec's
+    /// [`browser.UserContext`][type-spec] type.
+    ///
+    /// The default user context is always called `"default"` and
+    /// cannot be removed.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#user-contexts
+    /// [type-spec]: https://w3c.github.io/webdriver-bidi/#type-browser-UserContext
     UserContextId
 }
 
 string_id! {
-    /// Opaque identifier for a script-shared DOM node
-    /// (`script.SharedReference.sharedId`). Stable across navigations
-    /// within the same browsing context.
+    /// Opaque identifier for a script-shared DOM node — the `sharedId`
+    /// field of a [`script.SharedReference`][spec].
+    ///
+    /// Stable across navigations within the same browsing context.
+    /// Pass to [`input.setFiles`](crate::bidi::modules::input::SetFiles)
+    /// or include in
+    /// [`script.callFunction`](crate::bidi::modules::script::CallFunction)
+    /// arguments to address a specific DOM node.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-SharedReference
     NodeId
 }
 
 string_id! {
-    /// Channel identifier for `script.message` events.
+    /// Channel identifier for [`script.message`](crate::bidi::events::ScriptMessage)
+    /// events. Mirrors the spec's [`script.Channel`][spec] type.
+    ///
+    /// Channels are created by passing a
+    /// [`script.ChannelValue`][channel] argument to
+    /// [`script.addPreloadScript`](crate::bidi::modules::script::AddPreloadScript);
+    /// the script can then post messages back through them.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-Channel
+    /// [channel]: https://w3c.github.io/webdriver-bidi/#type-script-ChannelValue
     ChannelId
+}
+
+string_id! {
+    /// Identifier for an OS-level browser window. Mirrors the spec's
+    /// [`browser.ClientWindow`][spec] type.
+    ///
+    /// One window can host many tabs (top-level browsing contexts).
+    /// Pass to
+    /// [`browser.setClientWindowState`](crate::bidi::modules::browser::SetClientWindowState)
+    /// to resize / maximise / minimise it.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-browser-ClientWindow
+    ClientWindowId
+}
+
+string_id! {
+    /// Identifier for a network data collector. Mirrors the spec's
+    /// [`network.Collector`][spec] type.
+    ///
+    /// Returned by
+    /// [`network.addDataCollector`](crate::bidi::modules::network::AddDataCollector);
+    /// pass to
+    /// [`network.getData`](crate::bidi::modules::network::GetData),
+    /// [`network.disownData`](crate::bidi::modules::network::DisownData),
+    /// or
+    /// [`network.removeDataCollector`](crate::bidi::modules::network::RemoveDataCollector).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-network-Collector
+    CollectorId
+}
+
+string_id! {
+    /// Identifier for an installed web extension. Mirrors the spec's
+    /// [`webExtension.Extension`][spec] type.
+    ///
+    /// Returned by
+    /// [`webExtension.install`](crate::bidi::modules::web_extension::Install);
+    /// pass to
+    /// [`webExtension.uninstall`](crate::bidi::modules::web_extension::Uninstall)
+    /// to remove.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-webExtension-Extension
+    ExtensionId
 }

--- a/thirtyfour/src/bidi/mod.rs
+++ b/thirtyfour/src/bidi/mod.rs
@@ -1,11 +1,36 @@
-//! WebDriver BiDi (W3C bidirectional protocol) support.
+//! [WebDriver BiDi] — W3C bidirectional WebDriver protocol.
 //!
-//! WebDriver BiDi is the W3C-standard cross-browser successor to parts of
-//! Chrome DevTools Protocol. It runs over a WebSocket negotiated by the
-//! `webSocketUrl: true` capability on `New Session`; the driver responds
-//! with the actual `ws://...` URL on the session's capabilities.
+//! WebDriver BiDi is the cross-browser, event-driven sibling to WebDriver
+//! Classic. It runs over a WebSocket that is negotiated by the standard
+//! [`webSocketUrl: true`][websocket-cap] capability on `New Session`; the
+//! driver responds with a `ws://…` URL the client connects to. Once
+//! connected, every BiDi command is a typed JSON envelope with an
+//! application-level `id`, and events are pushed to the client without
+//! polling.
 //!
-//! # Quick start
+//! `thirtyfour` ships curated typed bindings for every command and event
+//! defined in the W3C BiDi specification, plus an untyped escape hatch for
+//! anything browser-vendor-specific or newer than this crate.
+//!
+//! [`BiDi`][b] is the top-level handle returned by
+//! [`WebDriver::bidi`](crate::WebDriver::bidi). It implements
+//! [`BidiCommand`][bc]-based [`send`][b-send] and
+//! [`subscribe`][b-sub] methods plus per-module facades.
+//!
+//! [b]: crate::bidi::BiDi
+//! [bc]: crate::bidi::BidiCommand
+//! [b-send]: crate::bidi::BiDi::send
+//! [b-sub]: crate::bidi::BiDi::subscribe
+//!
+//! # Enabling
+//!
+//! BiDi is gated behind the `bidi` cargo feature **and** requires the
+//! `webSocketUrl` capability on the session:
+//!
+//! ```toml
+//! [dependencies]
+//! thirtyfour = { version = "*", features = ["bidi"] }
+//! ```
 //!
 //! ```no_run
 //! # use thirtyfour::prelude::*;
@@ -21,32 +46,92 @@
 //! # driver.quit().await }
 //! ```
 //!
+//! [`WebDriver::bidi`](crate::WebDriver::bidi) is async because it lazily
+//! dials the WebSocket on first use; subsequent calls clone the existing
+//! handle. [`BiDi`][b] itself is `Clone` and cheap to share — the
+//! underlying transport is `Arc`-backed.
+//!
 //! # Modules
 //!
-//! Curated typed bindings live under [`modules`](crate::bidi::modules):
+//! Each W3C BiDi module is mirrored by a Rust submodule under
+//! [`modules`](crate::bidi::modules), and most are reachable via a
+//! convenience facade on [`BiDi`][b].
 //!
-//! - [`session`](crate::bidi::modules::session) — protocol handshake,
-//!   subscription control, status.
-//! - [`browser`](crate::bidi::modules::browser) — top-level browser (close,
-//!   user contexts).
-//! - [`browsing_context`](crate::bidi::modules::browsing_context) — tabs,
-//!   frames, navigation, screenshots.
-//! - [`script`](crate::bidi::modules::script) — `evaluate`, `callFunction`,
-//!   preload scripts, realms.
-//! - [`network`](crate::bidi::modules::network) — interception,
-//!   modify-request/response, auth.
-//! - [`storage`](crate::bidi::modules::storage) — cookies and partition
-//!   lookup.
-//! - [`log`](crate::bidi::modules::log) — log entry events.
-//! - [`input`](crate::bidi::modules::input) — `performActions`,
-//!   `releaseActions`, `setFiles`.
-//! - [`permissions`](crate::bidi::modules::permissions) — `setPermission`.
+//! | BiDi module       | Rust module                                                       | Spec section                   |
+//! |-------------------|-------------------------------------------------------------------|--------------------------------|
+//! | `session`         | [`session`](crate::bidi::modules::session)                        | [§7.1][spec-session]           |
+//! | `browser`         | [`browser`](crate::bidi::modules::browser)                        | [§7.2][spec-browser]           |
+//! | `browsingContext` | [`browsing_context`](crate::bidi::modules::browsing_context)      | [§7.3][spec-bc]                |
+//! | `emulation`       | [`emulation`](crate::bidi::modules::emulation)                    | [§7.4][spec-emulation]         |
+//! | `network`         | [`network`](crate::bidi::modules::network)                        | [§7.5][spec-network]           |
+//! | `script`          | [`script`](crate::bidi::modules::script)                          | [§7.6][spec-script]            |
+//! | `storage`         | [`storage`](crate::bidi::modules::storage)                        | [§7.7][spec-storage]           |
+//! | `log`             | [`log`](crate::bidi::modules::log)                                | [§7.8][spec-log]               |
+//! | `input`           | [`input`](crate::bidi::modules::input)                            | [§7.9][spec-input]             |
+//! | `webExtension`    | [`web_extension`](crate::bidi::modules::web_extension)            | [§7.10][spec-webext]           |
+//! | `permissions`     | [`permissions`](crate::bidi::modules::permissions)                | [W3C Permissions][spec-perms]  |
+//!
+//! Every command in those modules is a Rust struct that implements
+//! [`BidiCommand`][bc], pairing the request type with its response type
+//! and the wire method name. Module facades wrap the most-used commands
+//! in ergonomic async methods. For everything else, build the struct
+//! directly and call [`BiDi::send`][b-send].
+//!
+//! # Events
+//!
+//! [`BiDi::subscribe::<E>()`](crate::bidi::BiDi::subscribe) returns a
+//! [`futures::Stream`](futures_util::Stream) of typed events. Subscribing
+//! also auto-sends the wire-level `session.subscribe` command for
+//! `E::METHOD`; when the last stream for an event drops the framework
+//! sends `session.unsubscribe` in the background.
+//!
+//! Common event types are re-exported from
+//! [`events`](crate::bidi::events):
+//!
+//! ```no_run
+//! # use thirtyfour::prelude::*;
+//! # use futures_util::StreamExt;
+//! # async fn run(driver: WebDriver) -> WebDriverResult<()> {
+//! use thirtyfour::bidi::events::Load;
+//! let bidi = driver.bidi().await?;
+//! let mut loads = bidi.subscribe::<Load>().await?;
+//! while let Some(event) = loads.next().await {
+//!     println!("loaded: {}", event.url);
+//! }
+//! # Ok(()) }
+//! ```
+//!
+//! See [`BiDi::subscribe_raw`](crate::bidi::BiDi::subscribe_raw) for an
+//! untyped, no-deserialize firehose.
 //!
 //! # Untyped escape hatch
 //!
 //! Anything outside the curated set goes through
-//! [`BiDi::send_raw`](crate::bidi::BiDi::send_raw) /
-//! [`BiDi::subscribe_raw`](crate::bidi::BiDi::subscribe_raw).
+//! [`BiDi::send_raw`](crate::bidi::BiDi::send_raw) (commands) and
+//! [`BiDi::subscribe_raw`](crate::bidi::BiDi::subscribe_raw) (events).
+//! The wire shapes for command parameters and event payloads are
+//! specified module-by-module in the [BiDi spec's modules section][spec-modules].
+//!
+//! # See also
+//!
+//! - [WebDriver BiDi specification][WebDriver BiDi]
+//! - [Chrome DevTools Protocol support](crate::cdp) — Chromium-only
+//!   counterpart, which can be used in the same session.
+//!
+//! [WebDriver BiDi]: https://w3c.github.io/webdriver-bidi/
+//! [websocket-cap]: https://w3c.github.io/webdriver-bidi/#establishing
+//! [spec-modules]: https://w3c.github.io/webdriver-bidi/#protocol-modules
+//! [spec-session]: https://w3c.github.io/webdriver-bidi/#module-session
+//! [spec-browser]: https://w3c.github.io/webdriver-bidi/#module-browser
+//! [spec-bc]: https://w3c.github.io/webdriver-bidi/#module-browsingContext
+//! [spec-emulation]: https://w3c.github.io/webdriver-bidi/#module-emulation
+//! [spec-network]: https://w3c.github.io/webdriver-bidi/#module-network
+//! [spec-script]: https://w3c.github.io/webdriver-bidi/#module-script
+//! [spec-storage]: https://w3c.github.io/webdriver-bidi/#module-storage
+//! [spec-log]: https://w3c.github.io/webdriver-bidi/#module-log
+//! [spec-input]: https://w3c.github.io/webdriver-bidi/#module-input
+//! [spec-webext]: https://w3c.github.io/webdriver-bidi/#module-webExtension
+//! [spec-perms]: https://w3c.github.io/permissions/#webdriver-bidi-extension
 
 pub mod events;
 pub mod modules;
@@ -63,7 +148,7 @@ pub use command::{BidiCommand, BidiEvent, Empty, RawEvent};
 pub use error::BidiError;
 pub use handle::BiDi;
 pub use ids::{
-    BrowsingContextId, ChannelId, InterceptId, NavigationId, NodeId, PreloadScriptId, RealmId,
-    RequestId, UserContextId,
+    BrowsingContextId, ChannelId, ClientWindowId, CollectorId, ExtensionId, InterceptId,
+    NavigationId, NodeId, PreloadScriptId, RealmId, RequestId, UserContextId,
 };
 pub use stream::{EventStream, RawEventStream};

--- a/thirtyfour/src/bidi/modules/browser.rs
+++ b/thirtyfour/src/bidi/modules/browser.rs
@@ -1,13 +1,48 @@
-//! `browser.*` BiDi module — top-level browser control and user contexts.
+//! `browser.*` — browser-wide control: shutdown, user contexts, OS-level
+//! windows, and download behavior.
+//!
+//! "Browser" here means the running browser instance, not an individual
+//! tab. Use this module to:
+//!
+//! - End the entire browser ([`Close`][close]).
+//! - Manage [user contexts][user-context-spec] — BiDi's incognito-like
+//!   isolation primitive ([`CreateUserContext`][cuc],
+//!   [`GetUserContexts`][guc], [`RemoveUserContext`][ruc]).
+//! - Inspect and manipulate OS-level browser windows
+//!   ([`GetClientWindows`][gcw], [`SetClientWindowState`][scws]).
+//! - Control how downloads are handled
+//!   ([`SetDownloadBehavior`][sdb]).
+//!
+//! See the [W3C `browser` module specification][spec] for the canonical
+//! definitions.
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#module-browser
+//! [user-context-spec]: https://w3c.github.io/webdriver-bidi/#user-contexts
+//! [close]: crate::bidi::modules::browser::Close
+//! [cuc]: crate::bidi::modules::browser::CreateUserContext
+//! [guc]: crate::bidi::modules::browser::GetUserContexts
+//! [ruc]: crate::bidi::modules::browser::RemoveUserContext
+//! [gcw]: crate::bidi::modules::browser::GetClientWindows
+//! [scws]: crate::bidi::modules::browser::SetClientWindowState
+//! [sdb]: crate::bidi::modules::browser::SetDownloadBehavior
 
 use serde::{Deserialize, Serialize};
 
 use crate::bidi::BiDi;
 use crate::bidi::command::{BidiCommand, Empty};
 use crate::bidi::error::BidiError;
-use crate::bidi::ids::UserContextId;
+use crate::bidi::ids::{ClientWindowId, UserContextId};
+use crate::common::protocol::string_enum;
 
-/// `browser.close`.
+/// [`browser.close`][spec] — terminate every WebDriver session and shut
+/// the browser process down.
+///
+/// After this command returns, the browser process exits and all
+/// associated tabs/windows close without prompting to unload. The
+/// behaviour when multiple WebDriver sessions are connected to the same
+/// browser is implementation-defined — see the spec.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-close
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct Close;
 
@@ -16,24 +51,62 @@ impl BidiCommand for Close {
     type Returns = Empty;
 }
 
-/// `browser.createUserContext`.
+/// [`browser.createUserContext`][spec] — open a new
+/// [user context][user-context-spec] (an isolated cookie / storage jar,
+/// roughly equivalent to a Chrome profile or a private-browsing window).
+///
+/// Per-user-context overrides for `acceptInsecureCerts`, proxy
+/// configuration, and unhandled-prompt behavior may be supplied; if
+/// omitted the session-level defaults apply.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-createUserContext
+/// [user-context-spec]: https://w3c.github.io/webdriver-bidi/#user-contexts
 #[derive(Debug, Clone, Default, Serialize)]
-pub struct CreateUserContext;
+#[serde(rename_all = "camelCase")]
+pub struct CreateUserContext {
+    /// Override the session's accept-insecure-certs flag for this user
+    /// context. Returns `unsupported operation` on drivers that can't
+    /// scope TLS handling per user context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accept_insecure_certs: Option<bool>,
+    /// Per-user-context [`session.ProxyConfiguration`][proxy] (passed
+    /// through as JSON). Returns `unsupported operation` when not
+    /// supported by the driver.
+    ///
+    /// [proxy]: https://w3c.github.io/webdriver-bidi/#type-session-ProxyConfiguration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proxy: Option<serde_json::Value>,
+    /// Per-user-context [`session.UserPromptHandler`][handler] override.
+    ///
+    /// [handler]: https://w3c.github.io/webdriver-bidi/#type-session-UserPromptHandler
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unhandled_prompt_behavior: Option<serde_json::Value>,
+}
 
 impl BidiCommand for CreateUserContext {
     const METHOD: &'static str = "browser.createUserContext";
     type Returns = UserContextInfo;
 }
 
-/// One user context (incognito-like partition).
+/// One user context. See [`type-browser-UserContextInfo`][spec].
+///
+/// Returned by [`CreateUserContext`] and as elements of
+/// [`GetUserContextsResult::user_contexts`].
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-browser-UserContextInfo
 #[derive(Debug, Clone, Deserialize)]
 pub struct UserContextInfo {
-    /// User context id.
+    /// User context id. The default user context is always called
+    /// `"default"` and cannot be removed.
     #[serde(rename = "userContext")]
     pub user_context: UserContextId,
 }
 
-/// `browser.getUserContexts`.
+/// [`browser.getUserContexts`][spec] — list every known user context.
+///
+/// The default user context is always present in the result.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-getUserContexts
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct GetUserContexts;
 
@@ -45,16 +118,22 @@ impl BidiCommand for GetUserContexts {
 /// Response for [`GetUserContexts`].
 #[derive(Debug, Clone, Deserialize)]
 pub struct GetUserContextsResult {
-    /// All known user contexts (always includes `"default"`).
+    /// All user contexts, including `"default"`.
     #[serde(rename = "userContexts")]
     pub user_contexts: Vec<UserContextInfo>,
 }
 
-/// `browser.removeUserContext`.
+/// [`browser.removeUserContext`][spec] — close a user context, including
+/// every navigable inside it (without firing `beforeunload`).
+///
+/// The default user context cannot be removed; passing it returns
+/// `invalid argument`.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-removeUserContext
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveUserContext {
-    /// User context to remove. The default user context cannot be removed.
+    /// User context to remove.
     pub user_context: UserContextId,
 }
 
@@ -63,7 +142,160 @@ impl BidiCommand for RemoveUserContext {
     type Returns = Empty;
 }
 
-/// Module facade returned by [`BiDi::browser`].
+string_enum! {
+    /// Window state. Used by [`ClientWindowInfo::state`] and as a
+    /// parameter to [`SetClientWindowState::state`].
+    ///
+    /// See [`type-browser-ClientWindowInfo`][spec] in the spec.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-browser-ClientWindowInfo
+    pub enum ClientWindowState {
+        /// Fills the entire screen with no chrome.
+        Fullscreen = "fullscreen",
+        /// Maximised within the OS desktop.
+        Maximized = "maximized",
+        /// Minimised to the dock/taskbar.
+        Minimized = "minimized",
+        /// Normal (windowed) state. Allows custom width/height/x/y.
+        Normal = "normal",
+    }
+}
+
+/// Properties of an OS-level browser window.
+///
+/// Mirrors the spec's [`browser.ClientWindowInfo`][spec] type.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-browser-ClientWindowInfo
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientWindowInfo {
+    /// Whether this window currently receives keyboard input from the OS.
+    /// Note that this is OS focus, not BiDi document focus — the active
+    /// document of an inactive window can still be queried.
+    pub active: bool,
+    /// Stable window id. Use it with [`SetClientWindowState`].
+    pub client_window: ClientWindowId,
+    /// Window height in CSS pixels.
+    pub height: u32,
+    /// Window width in CSS pixels.
+    pub width: u32,
+    /// Window x-coordinate in screen pixels.
+    pub x: i32,
+    /// Window y-coordinate in screen pixels.
+    pub y: i32,
+    /// Current window state.
+    pub state: ClientWindowState,
+}
+
+/// [`browser.getClientWindows`][spec] — enumerate every OS-level browser
+/// window.
+///
+/// One window can host many tabs (top-level browsing contexts); use
+/// [`browsing_context::GetTree`](crate::bidi::modules::browsing_context::GetTree)
+/// to list those.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-getClientWindows
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GetClientWindows;
+
+impl BidiCommand for GetClientWindows {
+    const METHOD: &'static str = "browser.getClientWindows";
+    type Returns = GetClientWindowsResult;
+}
+
+/// Response for [`GetClientWindows`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetClientWindowsResult {
+    /// All client windows.
+    #[serde(rename = "clientWindows")]
+    pub client_windows: Vec<ClientWindowInfo>,
+}
+
+/// [`browser.setClientWindowState`][spec] — change a window's state and
+/// (when `state == Normal`) optionally its position/size.
+///
+/// `width`/`height`/`x`/`y` are only respected when `state` is
+/// [`ClientWindowState::Normal`]; for `Maximized`, `Minimized`, or
+/// `Fullscreen` they are ignored. The driver returns the (possibly
+/// adjusted) post-transition window info as a [`ClientWindowInfo`].
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-setClientWindowState
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetClientWindowState {
+    /// Window to update.
+    pub client_window: ClientWindowId,
+    /// New state.
+    pub state: ClientWindowState,
+    /// New width in CSS pixels (only respected when `state == Normal`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub width: Option<u32>,
+    /// New height in CSS pixels (only respected when `state == Normal`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub height: Option<u32>,
+    /// New x-coordinate (only respected when `state == Normal`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub x: Option<i32>,
+    /// New y-coordinate (only respected when `state == Normal`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub y: Option<i32>,
+}
+
+impl BidiCommand for SetClientWindowState {
+    const METHOD: &'static str = "browser.setClientWindowState";
+    type Returns = ClientWindowInfo;
+}
+
+/// Download behaviour for [`SetDownloadBehavior::download_behavior`].
+///
+/// Matches the spec's `browser.DownloadBehavior` union of `"allowed"` and
+/// `"denied"`.
+///
+/// See [`SetDownloadBehavior`] for usage.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum DownloadBehavior {
+    /// Allow downloads, saving each file to `destination_folder`.
+    Allowed {
+        /// Destination folder on the host filesystem.
+        #[serde(rename = "destinationFolder")]
+        destination_folder: String,
+    },
+    /// Refuse all downloads. The browser cancels each one.
+    Denied,
+}
+
+/// [`browser.setDownloadBehavior`][spec] — configure how the browser
+/// handles downloads, either globally or per user context.
+///
+/// Pass `download_behavior: None` to clear any previously-set override.
+/// `user_contexts: None` (or omitted) sets the default behaviour;
+/// `user_contexts: Some(ids)` scopes the override to those contexts.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-setDownloadBehavior
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetDownloadBehavior {
+    /// New behaviour, or `None` to clear any prior override.
+    pub download_behavior: Option<DownloadBehavior>,
+    /// Restrict to these user contexts. `None` / empty → set the global
+    /// default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetDownloadBehavior {
+    const METHOD: &'static str = "browser.setDownloadBehavior";
+    type Returns = Empty;
+}
+
+/// Convenience facade for the `browser.*` module.
+///
+/// Returned by [`BiDi::browser`](crate::bidi::BiDi::browser). Methods on
+/// this facade cover the common, unscoped form of each command. For
+/// scoping (e.g. setting download behaviour for one user context only)
+/// build the command struct directly and send it via
+/// [`BiDi::send`](crate::bidi::BiDi::send).
 #[derive(Debug)]
 pub struct BrowserModule<'a> {
     bidi: &'a BiDi,
@@ -76,21 +308,102 @@ impl<'a> BrowserModule<'a> {
         }
     }
 
-    /// `browser.createUserContext` — opens an incognito-like partition.
-    pub async fn create_user_context(&self) -> Result<UserContextInfo, BidiError> {
-        self.bidi.send(CreateUserContext).await
+    /// Run [`browser.close`][spec] — terminate every WebDriver session
+    /// and shut the browser process down.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-close
+    pub async fn close(&self) -> Result<(), BidiError> {
+        self.bidi.send(Close).await?;
+        Ok(())
     }
 
-    /// `browser.getUserContexts` — list all current user contexts.
+    /// Create a new user context with default settings via
+    /// [`browser.createUserContext`][spec].
+    ///
+    /// For per-context proxy / TLS / prompt-handler overrides, build the
+    /// [`CreateUserContext`] struct directly.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-createUserContext
+    pub async fn create_user_context(&self) -> Result<UserContextInfo, BidiError> {
+        self.bidi.send(CreateUserContext::default()).await
+    }
+
+    /// List every user context via [`browser.getUserContexts`][spec].
+    ///
+    /// The default user context is always included in the result.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-getUserContexts
     pub async fn get_user_contexts(&self) -> Result<GetUserContextsResult, BidiError> {
         self.bidi.send(GetUserContexts).await
     }
 
-    /// `browser.removeUserContext` — close every context inside the partition.
+    /// Remove a user context via [`browser.removeUserContext`][spec].
+    ///
+    /// All top-level traversables inside the context are closed without
+    /// firing `beforeunload`. Returns `invalid argument` if `user_context`
+    /// is the default user context, and `no such user context` if it
+    /// doesn't exist.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-removeUserContext
     pub async fn remove_user_context(&self, user_context: UserContextId) -> Result<(), BidiError> {
         self.bidi
             .send(RemoveUserContext {
                 user_context,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// List every OS-level browser window via
+    /// [`browser.getClientWindows`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-getClientWindows
+    pub async fn get_client_windows(&self) -> Result<GetClientWindowsResult, BidiError> {
+        self.bidi.send(GetClientWindows).await
+    }
+
+    /// Change a window's state via
+    /// [`browser.setClientWindowState`][spec], without changing position
+    /// or size.
+    ///
+    /// To resize or reposition a window in [`ClientWindowState::Normal`],
+    /// build the [`SetClientWindowState`] struct directly and supply
+    /// `width` / `height` / `x` / `y`.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-setClientWindowState
+    pub async fn set_client_window_state(
+        &self,
+        client_window: ClientWindowId,
+        state: ClientWindowState,
+    ) -> Result<ClientWindowInfo, BidiError> {
+        self.bidi
+            .send(SetClientWindowState {
+                client_window,
+                state,
+                width: None,
+                height: None,
+                x: None,
+                y: None,
+            })
+            .await
+    }
+
+    /// Configure the global download behaviour via
+    /// [`browser.setDownloadBehavior`][spec].
+    ///
+    /// Pass `None` to clear any prior override. To scope the override to
+    /// specific user contexts, build the [`SetDownloadBehavior`] struct
+    /// directly and supply [`user_contexts`][SetDownloadBehavior::user_contexts].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browser-setDownloadBehavior
+    pub async fn set_download_behavior(
+        &self,
+        download_behavior: Option<DownloadBehavior>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetDownloadBehavior {
+                download_behavior,
+                user_contexts: None,
             })
             .await?;
         Ok(())

--- a/thirtyfour/src/bidi/modules/browsing_context.rs
+++ b/thirtyfour/src/bidi/modules/browsing_context.rs
@@ -1,4 +1,34 @@
-//! `browsingContext.*` BiDi module — tabs, frames, navigation, screenshots.
+//! `browsingContext.*` — tabs, frames, navigation, history, viewport,
+//! screenshots, printing, and locating DOM nodes.
+//!
+//! A "browsing context" is the spec's name for an HTML navigable: a
+//! top-level tab/window or a child frame inside one. Most automation
+//! workflows touch this module first — it covers everything from
+//! "navigate to this URL" to "render the page as a PDF" to "find the
+//! `<button>` matching this CSS selector".
+//!
+//! See the [W3C `browsingContext` module specification][spec] for the
+//! canonical definitions.
+//!
+//! # Common patterns
+//!
+//! - Get the active tab id with the [`top_level`][top_level] helper.
+//! - Wait for a navigation to complete by passing
+//!   [`ReadinessState::Complete`][rs] to [`navigate`][navigate].
+//! - Open a new tab with [`create`][create].
+//! - Subscribe to lifecycle events
+//!   ([`Load`][load], [`DomContentLoaded`][dcl],
+//!   [`NavigationStarted`][nav], …) via
+//!   [`BiDi::subscribe`](crate::bidi::BiDi::subscribe).
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#module-browsingContext
+//! [top_level]: crate::bidi::modules::browsing_context::BrowsingContextModule::top_level
+//! [navigate]: crate::bidi::modules::browsing_context::BrowsingContextModule::navigate
+//! [create]: crate::bidi::modules::browsing_context::BrowsingContextModule::create
+//! [rs]: crate::bidi::modules::browsing_context::ReadinessState::Complete
+//! [load]: crate::bidi::modules::browsing_context::events::Load
+//! [dcl]: crate::bidi::modules::browsing_context::events::DomContentLoaded
+//! [nav]: crate::bidi::modules::browsing_context::events::NavigationStarted
 
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -9,21 +39,28 @@ use crate::bidi::ids::{BrowsingContextId, NavigationId, UserContextId};
 use crate::common::protocol::string_enum;
 
 string_enum! {
-    /// Wait condition for [`Navigate`] (`browsingContext.navigate`).
+    /// Stage of document loading at which a navigation command will return.
+    ///
+    /// Used by [`Navigate::wait`] and [`Reload::wait`]. Mirrors the spec's
+    /// [`browsingContext.ReadinessState`][spec] type.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-browsingContext-ReadinessState
     pub enum ReadinessState {
         /// Resolve as soon as the navigation has been initiated.
         None = "none",
-        /// Resolve when the document has been parsed.
+        /// Resolve when the document has been parsed (`document.readyState
+        /// == "interactive"`).
         Interactive = "interactive",
-        /// Resolve when the load event has fired.
+        /// Resolve when the `load` event has fired.
         Complete = "complete",
     }
 }
 
 string_enum! {
-    /// Lifecycle phase for [`events::DomContentLoaded`]-style events.
+    /// Lifecycle phase used by some events. Mirrors the W3C HTML spec's
+    /// document-lifecycle naming.
     pub enum LifecyclePhase {
-        /// Document has loaded.
+        /// `load` fired.
         Load = "load",
         /// `DOMContentLoaded` fired.
         DomContentLoaded = "DOMContentLoaded",
@@ -31,7 +68,7 @@ string_enum! {
 }
 
 string_enum! {
-    /// New-context creation type.
+    /// New-context creation type — the `type` field on [`Create`].
     pub enum CreateType {
         /// Open as a new tab in the existing window.
         Tab = "tab",
@@ -41,17 +78,18 @@ string_enum! {
 }
 
 string_enum! {
-    /// Image format for [`CaptureScreenshot`].
+    /// Image format type — the `type` field on [`ImageFormat`].
     pub enum ImageFormatType {
-        /// PNG.
+        /// PNG (lossless).
         Png = "png",
-        /// JPEG (optionally lossy).
+        /// JPEG (lossy; pair with [`ImageFormat::quality`]).
         Jpeg = "jpeg",
     }
 }
 
 string_enum! {
-    /// History traversal direction in [`TraverseHistory`].
+    /// History traversal direction. Reserved for future use — current
+    /// `traverseHistory` callers pass a signed delta directly.
     pub enum TraversalDirection {
         /// Equivalent to clicking the browser back button.
         Back = "back",
@@ -60,15 +98,22 @@ string_enum! {
     }
 }
 
-/// `browsingContext.getTree`.
+/// [`browsingContext.getTree`][spec] — return the tree of browsing contexts.
+///
+/// With no parameters this returns every top-level context as a separate
+/// root. Set [`root`][Self::root] to limit the result to one subtree, or
+/// [`max_depth`][Self::max_depth] to limit recursion.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-getTree
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetTree {
-    /// Limit traversal depth. `Some(0)` returns just the matched roots.
+    /// Maximum traversal depth. `Some(0)` returns just the matched roots
+    /// without children.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_depth: Option<u32>,
-    /// Restrict the tree to descendants of this context. `None` returns all
-    /// top-level contexts.
+    /// Restrict the tree to descendants of this context. `None` returns
+    /// every top-level context.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub root: Option<BrowsingContextId>,
 }
@@ -82,17 +127,21 @@ impl BidiCommand for GetTree {
 #[derive(Debug, Clone, Deserialize)]
 pub struct GetTreeResult {
     /// One node per top-level context (or one node if [`GetTree::root`] was
-    /// set). Children populate [`BrowsingContextInfo::children`].
+    /// set). Descendants are populated via [`BrowsingContextInfo::children`].
     pub contexts: Vec<BrowsingContextInfo>,
 }
 
 /// A node in the browsing-context tree.
+///
+/// Mirrors the spec's [`browsingContext.Info`][spec] type.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-browsingContext-Info
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BrowsingContextInfo {
     /// Identifier for this context.
     pub context: BrowsingContextId,
-    /// Top-level context id this node belongs to.
+    /// Parent context id. `None` for top-level contexts.
     pub parent: Option<BrowsingContextId>,
     /// User context (incognito-like partition) the context lives in.
     #[serde(default)]
@@ -104,10 +153,13 @@ pub struct BrowsingContextInfo {
     pub children: Vec<BrowsingContextInfo>,
     /// Current document URL.
     pub url: String,
-    /// Whether this context is the active OS-level window.
+    /// The browsing context that opened this one (`window.opener`),
+    /// preserved across navigations. `None` when there is no opener.
     #[serde(default)]
     pub original_opener: Option<BrowsingContextId>,
-    /// Reflects `client_window` on newer drivers.
+    /// Id of the OS-level client window hosting this context. Match
+    /// against [`browser::ClientWindowInfo::client_window`](crate::bidi::modules::browser::ClientWindowInfo::client_window).
+    /// May be omitted by older drivers.
     #[serde(default, rename = "clientWindow")]
     pub client_window: Option<String>,
 }
@@ -122,15 +174,24 @@ where
     Ok(Option::<T>::deserialize(d)?.unwrap_or_default())
 }
 
-/// `browsingContext.navigate`.
+/// [`browsingContext.navigate`][spec] — navigate the given context to a URL.
+///
+/// `wait` controls when the call resolves: `None` returns as soon as the
+/// navigation has been initiated, while [`ReadinessState::Complete`]
+/// waits for the `load` event. The default if omitted is the spec's
+/// `committed` state (resolves once the document has been replaced) —
+/// some drivers behave like `Complete` instead.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-navigate
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Navigate {
     /// Browsing context to navigate.
     pub context: BrowsingContextId,
-    /// URL to load.
+    /// Destination URL. May be relative — the spec resolves it against
+    /// the document's base URL.
     pub url: String,
-    /// Wait condition. Defaults to `Complete`.
+    /// Wait condition.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wait: Option<ReadinessState>,
 }
@@ -140,22 +201,31 @@ impl BidiCommand for Navigate {
     type Returns = NavigateResult;
 }
 
-/// Response for [`Navigate`].
+/// Response for [`Navigate`] / [`Reload`].
 #[derive(Debug, Clone, Deserialize)]
 pub struct NavigateResult {
-    /// Server-assigned navigation id (`None` if `wait: None`).
+    /// Server-assigned navigation id. `None` if [`Navigate::wait`] was
+    /// [`ReadinessState::None`] (no navigation tracked).
     pub navigation: Option<NavigationId>,
-    /// Final URL after redirects.
+    /// Final URL after any redirects.
     pub url: String,
 }
 
-/// `browsingContext.reload`.
+/// [`browsingContext.reload`][spec] — reload the active document.
+///
+/// Behaves identically to [`Navigate`] except that the destination is the
+/// current document's URL and the navigation history-handling is `reload`.
+/// `ignore_cache: Some(true)` requests a cache bypass (Ctrl+Shift+R
+/// equivalent); some drivers don't yet implement that and respond with
+/// `unsupported operation`.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-reload
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Reload {
     /// Browsing context to reload.
     pub context: BrowsingContextId,
-    /// If true, bypass HTTP caches.
+    /// If `true`, bypass HTTP caches.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_cache: Option<bool>,
     /// Wait condition.
@@ -168,19 +238,32 @@ impl BidiCommand for Reload {
     type Returns = NavigateResult;
 }
 
-/// `browsingContext.create`.
+/// [`browsingContext.create`][spec] — open a new tab or window.
+///
+/// Optional fields:
+/// - [`reference_context`][Self::reference_context] sets the opener of
+///   the new context (so `window.opener` and the new context's user
+///   context inherit from this one).
+/// - [`background`][Self::background] keeps the new tab/window behind
+///   the current one.
+/// - [`user_context`][Self::user_context] places it in a specific user
+///   context (incompatible with `reference_context`).
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-create
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Create {
-    /// Whether to create a tab or window.
+    /// Whether to create a tab or a top-level window.
     pub r#type: CreateType,
-    /// Optional reference context (used as opener / parent).
+    /// Reference context — used as opener / parent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reference_context: Option<BrowsingContextId>,
-    /// Whether to bring the new context to the foreground.
+    /// `Some(true)` to keep the new context behind; default is to bring
+    /// it to the foreground.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub background: Option<bool>,
-    /// User context to put it in.
+    /// User context to place the new context in. Mutually exclusive with
+    /// [`reference_context`][Self::reference_context].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_context: Option<UserContextId>,
 }
@@ -197,12 +280,18 @@ pub struct CreateResult {
     pub context: BrowsingContextId,
 }
 
-/// `browsingContext.close`.
+/// [`browsingContext.close`][spec] — close a context.
+///
+/// Closing a top-level context closes its tab (and the window if it was
+/// the last tab). Set [`prompt_unload`][Self::prompt_unload] to `true` to
+/// honour any `beforeunload` handler; the default is to skip it.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-close
 #[derive(Debug, Clone, Serialize)]
 pub struct Close {
     /// Browsing context to close.
     pub context: BrowsingContextId,
-    /// If true, bypass any `beforeunload` prompt.
+    /// If `true`, run the `beforeunload` prompt before closing.
     #[serde(rename = "promptUnload", skip_serializing_if = "Option::is_none")]
     pub prompt_unload: Option<bool>,
 }
@@ -212,10 +301,16 @@ impl BidiCommand for Close {
     type Returns = Empty;
 }
 
-/// `browsingContext.activate`.
+/// [`browsingContext.activate`][spec] — focus a top-level context (its
+/// OS-level window).
+///
+/// Used for tests that depend on the focused state — most automation
+/// works without it.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-activate
 #[derive(Debug, Clone, Serialize)]
 pub struct Activate {
-    /// Browsing context to activate (focus the OS-level window).
+    /// Browsing context to activate.
     pub context: BrowsingContextId,
 }
 
@@ -224,16 +319,24 @@ impl BidiCommand for Activate {
     type Returns = Empty;
 }
 
-/// `browsingContext.captureScreenshot`.
+/// [`browsingContext.captureScreenshot`][spec] — render the page to a
+/// base64-encoded image.
+///
+/// Defaults to a viewport-sized PNG. For a full-page screenshot pass
+/// `origin: Some(ScreenshotOrigin::Document)`. JPEG quality is set via
+/// [`ImageFormat::quality`].
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-captureScreenshot
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CaptureScreenshot {
     /// Browsing context to capture.
     pub context: BrowsingContextId,
-    /// `viewport` (default) or `document` for a full-document screenshot.
+    /// `Viewport` (default) — only the visible portion.
+    /// `Document` — the entire scrollable document.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub origin: Option<ScreenshotOrigin>,
-    /// Output format.
+    /// Output format. Defaults to PNG.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<ImageFormat>,
 }
@@ -249,6 +352,9 @@ string_enum! {
 }
 
 /// Image format options for [`CaptureScreenshot::format`].
+///
+/// `quality` is ignored for PNG and is interpreted as a 0.0..=1.0
+/// quality factor for JPEG.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageFormat {
@@ -267,30 +373,37 @@ impl BidiCommand for CaptureScreenshot {
 /// Response for [`CaptureScreenshot`].
 #[derive(Debug, Clone, Deserialize)]
 pub struct CaptureScreenshotResult {
-    /// Base64-encoded image bytes.
+    /// Base64-encoded image bytes (PNG bytes start with `iVBOR…`, JPEG
+    /// with `/9j/…`).
     pub data: String,
 }
 
-/// `browsingContext.setViewport`.
+/// [`browsingContext.setViewport`][spec] — set viewport dimensions and/or
+/// device pixel ratio for a context.
+///
+/// Pass `viewport: None` to reset to the driver default; the same goes
+/// for `device_pixel_ratio`.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-setViewport
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetViewport {
     /// Browsing context to resize.
     pub context: BrowsingContextId,
-    /// Pixel viewport. `None` resets to driver default.
+    /// New viewport size. `None` resets to driver default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub viewport: Option<Viewport>,
-    /// Device pixel ratio. `None` keeps current.
+    /// New device pixel ratio. `None` keeps the current value.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device_pixel_ratio: Option<f64>,
 }
 
-/// Viewport shape used by [`SetViewport`].
+/// Viewport size in CSS pixels for [`SetViewport`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Viewport {
-    /// Pixel width.
+    /// Width in CSS pixels.
     pub width: u32,
-    /// Pixel height.
+    /// Height in CSS pixels.
     pub height: u32,
 }
 
@@ -299,7 +412,13 @@ impl BidiCommand for SetViewport {
     type Returns = Empty;
 }
 
-/// `browsingContext.traverseHistory`.
+/// [`browsingContext.traverseHistory`][spec] — back/forward through the
+/// session history.
+///
+/// `delta` is signed: negative goes backwards, positive forwards. Zero
+/// reloads the current entry.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-traverseHistory
 #[derive(Debug, Clone, Serialize)]
 pub struct TraverseHistory {
     /// Browsing context to traverse.
@@ -313,23 +432,344 @@ impl BidiCommand for TraverseHistory {
     type Returns = Empty;
 }
 
-/// `browsingContext.handleUserPrompt`.
+/// [`browsingContext.handleUserPrompt`][spec] — accept or dismiss a
+/// JavaScript modal dialog (`alert` / `confirm` / `prompt` /
+/// `beforeunload`).
+///
+/// Pass `accept: Some(true)` to accept, `Some(false)` to dismiss, or
+/// `None` to use the driver's default. `user_text` is only meaningful for
+/// `prompt()` dialogs.
+///
+/// Returns `no such alert` if there is no open dialog.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-handleUserPrompt
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HandleUserPrompt {
     /// Browsing context whose dialog should be handled.
     pub context: BrowsingContextId,
-    /// Accept the dialog (`true`) or dismiss (`false`). `None` lets the
-    /// driver pick the default.
+    /// `true` to accept, `false` to dismiss, `None` for driver default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accept: Option<bool>,
-    /// Text to type for `prompt()` dialogs.
+    /// Text to type into a `prompt()` dialog.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_text: Option<String>,
 }
 
 impl BidiCommand for HandleUserPrompt {
     const METHOD: &'static str = "browsingContext.handleUserPrompt";
+    type Returns = Empty;
+}
+
+string_enum! {
+    /// Locator strategy for [`Locator::locator_type`]. Mirrors the spec's
+    /// [`browsingContext.Locator`][spec] union.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-browsingContext-Locator
+    pub enum LocatorType {
+        /// Match by accessibility role and/or name.
+        Accessibility = "accessibility",
+        /// CSS selector.
+        Css = "css",
+        /// Frame/context locator: find the element hosting another navigable.
+        Context = "context",
+        /// Inner-text match (case-sensitive by default).
+        InnerText = "innerText",
+        /// XPath expression.
+        XPath = "xpath",
+    }
+}
+
+string_enum! {
+    /// Match type for [`Locator::match_type`] (inner-text locator).
+    pub enum InnerTextMatchType {
+        /// Whole inner text equals the search value.
+        Full = "full",
+        /// Search value appears as a substring of inner text.
+        Partial = "partial",
+    }
+}
+
+/// Selector spec passed to [`LocateNodes`]. Mirrors the spec's
+/// [`browsingContext.Locator`][spec] union — the constructor functions
+/// ([`Locator::css`], [`Locator::xpath`], …) are usually more
+/// ergonomic than building the struct by hand.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-browsingContext-Locator
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Locator {
+    /// Strategy.
+    #[serde(rename = "type")]
+    pub locator_type: LocatorType,
+    /// Selector value. Shape varies by strategy:
+    /// - `Css`, `XPath`, `InnerText` — a JSON string.
+    /// - `Accessibility` — an object with optional `role` / `name` keys.
+    /// - `Context` — `{ "context": "<browsing-context-id>" }`.
+    pub value: serde_json::Value,
+    /// Inner-text only — perform a case-insensitive match.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore_case: Option<bool>,
+    /// Inner-text only — full vs partial match (default `Full`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_type: Option<InnerTextMatchType>,
+    /// Inner-text only — recursion depth limit (`None` = unbounded).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_depth: Option<u32>,
+}
+
+impl Locator {
+    /// CSS selector locator.
+    pub fn css(selector: impl Into<String>) -> Self {
+        Self {
+            locator_type: LocatorType::Css,
+            value: serde_json::Value::String(selector.into()),
+            ignore_case: None,
+            match_type: None,
+            max_depth: None,
+        }
+    }
+
+    /// XPath expression locator.
+    pub fn xpath(expression: impl Into<String>) -> Self {
+        Self {
+            locator_type: LocatorType::XPath,
+            value: serde_json::Value::String(expression.into()),
+            ignore_case: None,
+            match_type: None,
+            max_depth: None,
+        }
+    }
+
+    /// Inner-text locator.
+    pub fn inner_text(text: impl Into<String>) -> Self {
+        Self {
+            locator_type: LocatorType::InnerText,
+            value: serde_json::Value::String(text.into()),
+            ignore_case: None,
+            match_type: None,
+            max_depth: None,
+        }
+    }
+
+    /// Accessibility locator (role and/or name).
+    pub fn accessibility(role: Option<String>, name: Option<String>) -> Self {
+        let mut value = serde_json::Map::new();
+        if let Some(role) = role {
+            value.insert("role".to_string(), serde_json::Value::String(role));
+        }
+        if let Some(name) = name {
+            value.insert("name".to_string(), serde_json::Value::String(name));
+        }
+        Self {
+            locator_type: LocatorType::Accessibility,
+            value: serde_json::Value::Object(value),
+            ignore_case: None,
+            match_type: None,
+            max_depth: None,
+        }
+    }
+
+    /// Context locator — find the host element for another navigable.
+    pub fn context(context: BrowsingContextId) -> Self {
+        let mut value = serde_json::Map::new();
+        value.insert("context".to_string(), serde_json::Value::String(context.0));
+        Self {
+            locator_type: LocatorType::Context,
+            value: serde_json::Value::Object(value),
+            ignore_case: None,
+            match_type: None,
+            max_depth: None,
+        }
+    }
+}
+
+/// [`browsingContext.locateNodes`][spec] — find every node matching a
+/// locator.
+///
+/// Returns the nodes as serialized [`script.NodeRemoteValue`][node-spec]
+/// JSON values (each contains a `sharedId` you can use to address the
+/// node from [`script.callFunction`][script-spec] or
+/// [`input.setFiles`](crate::bidi::modules::input::SetFiles)).
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-locateNodes
+/// [node-spec]: https://w3c.github.io/webdriver-bidi/#type-script-NodeRemoteValue
+/// [script-spec]: https://w3c.github.io/webdriver-bidi/#command-script-callFunction
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocateNodes {
+    /// Browsing context to search.
+    pub context: BrowsingContextId,
+    /// Locator describing the strategy.
+    pub locator: Locator,
+    /// Maximum number of nodes to return (`>= 1`). `None` returns every
+    /// match.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_node_count: Option<u32>,
+    /// Custom [`script.SerializationOptions`][opts] for the returned
+    /// nodes (controls depth, max length, ownership, …).
+    ///
+    /// [opts]: https://w3c.github.io/webdriver-bidi/#type-script-SerializationOptions
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub serialization_options: Option<serde_json::Value>,
+    /// Restrict the search to descendants of these
+    /// [`script.SharedReference`][shared] nodes.
+    ///
+    /// [shared]: https://w3c.github.io/webdriver-bidi/#type-script-SharedReference
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_nodes: Option<Vec<serde_json::Value>>,
+}
+
+impl BidiCommand for LocateNodes {
+    const METHOD: &'static str = "browsingContext.locateNodes";
+    type Returns = LocateNodesResult;
+}
+
+/// Response for [`LocateNodes`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct LocateNodesResult {
+    /// Serialized matching nodes — each is a
+    /// [`script.NodeRemoteValue`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-NodeRemoteValue
+    pub nodes: Vec<serde_json::Value>,
+}
+
+string_enum! {
+    /// Page orientation for [`Print::orientation`].
+    pub enum PrintOrientation {
+        /// Portrait (taller than wide). Default.
+        Portrait = "portrait",
+        /// Landscape (wider than tall).
+        Landscape = "landscape",
+    }
+}
+
+/// Print margins (in centimeters). Mirrors
+/// [`browsingContext.PrintMarginParameters`][spec].
+///
+/// All four fields default to 1.0 cm if omitted.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-browsingContext-PrintMarginParameters
+#[derive(Debug, Clone, Serialize)]
+pub struct PrintMargin {
+    /// Bottom margin (cm).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bottom: Option<f64>,
+    /// Left margin (cm).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub left: Option<f64>,
+    /// Right margin (cm).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub right: Option<f64>,
+    /// Top margin (cm).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top: Option<f64>,
+}
+
+/// Page size in centimeters. Mirrors
+/// [`browsingContext.PrintPageParameters`][spec]; defaults are 21.59 cm
+/// (8.5 in) wide by 27.94 cm (11 in) tall.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-browsingContext-PrintPageParameters
+#[derive(Debug, Clone, Serialize)]
+pub struct PrintPage {
+    /// Page height (cm).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub height: Option<f64>,
+    /// Page width (cm).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub width: Option<f64>,
+}
+
+/// [`browsingContext.print`][spec] — render the page as a base64-encoded
+/// PDF.
+///
+/// All formatting fields are optional; the spec defaults are portrait
+/// orientation, 1 cm margins, US Letter page size, scale 1.0, no
+/// background colors, and shrink-to-fit enabled.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-print
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Print {
+    /// Browsing context to print.
+    pub context: BrowsingContextId,
+    /// Include background colors and images.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background: Option<bool>,
+    /// Page margins.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub margin: Option<PrintMargin>,
+    /// Page orientation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub orientation: Option<PrintOrientation>,
+    /// Page size.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page: Option<PrintPage>,
+    /// Page ranges to include. Each entry is either a 1-based page
+    /// number (JSON integer) or a `"start-end"` string (JSON string).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_ranges: Option<Vec<serde_json::Value>>,
+    /// Zoom factor (0.1..=2.0; default 1.0).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scale: Option<f64>,
+    /// Shrink content to fit the page width.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shrink_to_fit: Option<bool>,
+}
+
+impl BidiCommand for Print {
+    const METHOD: &'static str = "browsingContext.print";
+    type Returns = PrintResult;
+}
+
+/// Response for [`Print`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct PrintResult {
+    /// Base64-encoded PDF bytes (start with `JVBERi…`).
+    pub data: String,
+}
+
+/// [`browsingContext.setBypassCSP`][spec] — toggle Content-Security-Policy
+/// enforcement.
+///
+/// When CSP bypass is on, `eval()`, `new Function()`, inline scripts, and
+/// resource loads that CSP would normally block are allowed. The wire
+/// shape only accepts `true` (enable bypass) or `null` (clear the
+/// override) — we model that as `Option<bool>` and silently omit `false`.
+///
+/// Use [`contexts`][Self::contexts] / [`user_contexts`][Self::user_contexts]
+/// to scope the override; an unscoped call applies the default.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-setBypassCSP
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetBypassCsp {
+    /// `Some(true)` to bypass CSP, `None` to clear the override. The
+    /// wire only accepts `true` or `null`; we always omit `false`.
+    #[serde(serialize_with = "serialize_bypass")]
+    pub bypass: Option<bool>,
+    /// Restrict to specific browsing contexts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// Restrict to specific user contexts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+fn serialize_bypass<S: serde::Serializer>(
+    value: &Option<bool>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match value {
+        Some(true) => serializer.serialize_bool(true),
+        _ => serializer.serialize_none(),
+    }
+}
+
+impl BidiCommand for SetBypassCsp {
+    const METHOD: &'static str = "browsingContext.setBypassCSP";
     type Returns = Empty;
 }
 
@@ -341,7 +781,13 @@ impl BidiCommand for HandleUserPrompt {
 pub(crate) mod events {
     use super::*;
 
-    /// `browsingContext.contextCreated`.
+    /// [`browsingContext.contextCreated`][spec] — a new tab, window, or
+    /// frame has been created.
+    ///
+    /// The wrapped [`BrowsingContextInfo`] carries the new context's id,
+    /// parent (for iframes), URL, and user context.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-contextCreated
     #[derive(Debug, Clone, Deserialize)]
     pub struct ContextCreated(pub BrowsingContextInfo);
 
@@ -349,7 +795,10 @@ pub(crate) mod events {
         const METHOD: &'static str = "browsingContext.contextCreated";
     }
 
-    /// `browsingContext.contextDestroyed`.
+    /// [`browsingContext.contextDestroyed`][spec] — a context has been
+    /// torn down (tab closed, frame removed, etc.).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-contextDestroyed
     #[derive(Debug, Clone, Deserialize)]
     pub struct ContextDestroyed(pub BrowsingContextInfo);
 
@@ -357,7 +806,10 @@ pub(crate) mod events {
         const METHOD: &'static str = "browsingContext.contextDestroyed";
     }
 
-    /// `browsingContext.navigationStarted`.
+    /// [`browsingContext.navigationStarted`][spec] — a navigation has
+    /// been initiated (before any network traffic).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-navigationStarted
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct NavigationStarted {
@@ -375,7 +827,10 @@ pub(crate) mod events {
         const METHOD: &'static str = "browsingContext.navigationStarted";
     }
 
-    /// `browsingContext.load` — page load event.
+    /// [`browsingContext.load`][spec] — the document's `load` event has
+    /// fired.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-load
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Load {
@@ -393,7 +848,10 @@ pub(crate) mod events {
         const METHOD: &'static str = "browsingContext.load";
     }
 
-    /// `browsingContext.domContentLoaded`.
+    /// [`browsingContext.domContentLoaded`][spec] — the document's
+    /// `DOMContentLoaded` event has fired.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-domContentLoaded
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct DomContentLoaded {
@@ -411,7 +869,10 @@ pub(crate) mod events {
         const METHOD: &'static str = "browsingContext.domContentLoaded";
     }
 
-    /// `browsingContext.fragmentNavigated`.
+    /// [`browsingContext.fragmentNavigated`][spec] — the URL fragment
+    /// (`#…`) changed without a full navigation.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-fragmentNavigated
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct FragmentNavigated {
@@ -419,7 +880,7 @@ pub(crate) mod events {
         pub context: BrowsingContextId,
         /// Navigation id.
         pub navigation: Option<NavigationId>,
-        /// New URL.
+        /// New URL (including the new fragment).
         pub url: String,
         /// Timestamp.
         pub timestamp: u64,
@@ -429,7 +890,13 @@ pub(crate) mod events {
         const METHOD: &'static str = "browsingContext.fragmentNavigated";
     }
 
-    /// `browsingContext.userPromptOpened`.
+    /// [`browsingContext.userPromptOpened`][spec] — a JS dialog
+    /// (`alert`/`confirm`/`prompt`/`beforeunload`) has opened.
+    ///
+    /// Pair with [`HandleUserPrompt`] (or
+    /// [`BrowsingContextModule::handle_user_prompt`]) to drive it.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-userPromptOpened
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct UserPromptOpened {
@@ -449,7 +916,10 @@ pub(crate) mod events {
         const METHOD: &'static str = "browsingContext.userPromptOpened";
     }
 
-    /// `browsingContext.userPromptClosed`.
+    /// [`browsingContext.userPromptClosed`][spec] — a JS dialog has been
+    /// dismissed or accepted.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-userPromptClosed
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct UserPromptClosed {
@@ -457,7 +927,7 @@ pub(crate) mod events {
         pub context: BrowsingContextId,
         /// Whether the prompt was accepted.
         pub accepted: bool,
-        /// Text the user typed (for prompt dialogs).
+        /// Text the user typed (for `prompt()` dialogs only).
         #[serde(default)]
         pub user_text: Option<String>,
     }
@@ -465,9 +935,182 @@ pub(crate) mod events {
     impl BidiEvent for UserPromptClosed {
         const METHOD: &'static str = "browsingContext.userPromptClosed";
     }
+
+    /// [`browsingContext.historyUpdated`][spec] — `history.pushState` or
+    /// `history.replaceState` has run.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-historyUpdated
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct HistoryUpdated {
+        /// Context.
+        pub context: BrowsingContextId,
+        /// Updated URL.
+        pub url: String,
+        /// Driver timestamp (ms since epoch).
+        pub timestamp: u64,
+        /// User context.
+        #[serde(default)]
+        pub user_context: Option<UserContextId>,
+    }
+
+    impl BidiEvent for HistoryUpdated {
+        const METHOD: &'static str = "browsingContext.historyUpdated";
+    }
+
+    /// [`browsingContext.downloadWillBegin`][spec] — fired just before a
+    /// download starts.
+    ///
+    /// Pair with
+    /// [`browser.setDownloadBehavior`](crate::bidi::modules::browser::SetDownloadBehavior)
+    /// to control whether the download proceeds and where it's saved.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-downloadWillBegin
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DownloadWillBegin {
+        /// Context that triggered the download.
+        pub context: BrowsingContextId,
+        /// Navigation id (the download is associated with the navigation
+        /// request).
+        pub navigation: Option<NavigationId>,
+        /// Source URL.
+        pub url: String,
+        /// Driver timestamp (ms since epoch).
+        pub timestamp: u64,
+        /// User context.
+        #[serde(default)]
+        pub user_context: Option<UserContextId>,
+        /// Browser-suggested filename.
+        pub suggested_filename: String,
+    }
+
+    impl BidiEvent for DownloadWillBegin {
+        const METHOD: &'static str = "browsingContext.downloadWillBegin";
+    }
+
+    /// [`browsingContext.downloadEnd`][spec] — fired when a download
+    /// finishes (`Complete`) or is canceled (`Canceled`).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-downloadEnd
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DownloadEnd {
+        /// Final status.
+        pub status: DownloadEndStatus,
+        /// Where the file was saved. Only meaningful when
+        /// `status == Complete`; even then it can be `None` if the
+        /// driver doesn't expose the path.
+        #[serde(default)]
+        pub filepath: Option<String>,
+        /// Context that triggered the download.
+        pub context: BrowsingContextId,
+        /// Navigation id.
+        pub navigation: Option<NavigationId>,
+        /// Source URL.
+        pub url: String,
+        /// Driver timestamp (ms since epoch).
+        pub timestamp: u64,
+        /// User context.
+        #[serde(default)]
+        pub user_context: Option<UserContextId>,
+    }
+
+    impl BidiEvent for DownloadEnd {
+        const METHOD: &'static str = "browsingContext.downloadEnd";
+    }
+
+    /// [`browsingContext.navigationAborted`][spec] — the navigation was
+    /// abandoned (e.g. another navigation took over).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-navigationAborted
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NavigationAborted {
+        /// Context.
+        pub context: BrowsingContextId,
+        /// Navigation id.
+        pub navigation: Option<NavigationId>,
+        /// URL.
+        pub url: String,
+        /// Timestamp.
+        pub timestamp: u64,
+        /// User context.
+        #[serde(default)]
+        pub user_context: Option<UserContextId>,
+    }
+
+    impl BidiEvent for NavigationAborted {
+        const METHOD: &'static str = "browsingContext.navigationAborted";
+    }
+
+    /// [`browsingContext.navigationCommitted`][spec] — the navigation
+    /// has reached the "committed" state (the new document has been
+    /// installed; equivalent to the spec's `committed` ready state).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-navigationCommitted
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NavigationCommitted {
+        /// Context.
+        pub context: BrowsingContextId,
+        /// Navigation id.
+        pub navigation: Option<NavigationId>,
+        /// URL.
+        pub url: String,
+        /// Timestamp.
+        pub timestamp: u64,
+        /// User context.
+        #[serde(default)]
+        pub user_context: Option<UserContextId>,
+    }
+
+    impl BidiEvent for NavigationCommitted {
+        const METHOD: &'static str = "browsingContext.navigationCommitted";
+    }
+
+    /// [`browsingContext.navigationFailed`][spec] — the navigation
+    /// failed (network error, blocked, etc.).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-browsingContext-navigationFailed
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct NavigationFailed {
+        /// Context.
+        pub context: BrowsingContextId,
+        /// Navigation id.
+        pub navigation: Option<NavigationId>,
+        /// URL.
+        pub url: String,
+        /// Timestamp.
+        pub timestamp: u64,
+        /// User context.
+        #[serde(default)]
+        pub user_context: Option<UserContextId>,
+    }
+
+    impl BidiEvent for NavigationFailed {
+        const METHOD: &'static str = "browsingContext.navigationFailed";
+    }
 }
 
-/// Module facade returned by [`BiDi::browsing_context`].
+string_enum! {
+    /// Status field of [`events::DownloadEnd`].
+    pub enum DownloadEndStatus {
+        /// The download finished successfully.
+        Complete = "complete",
+        /// The download was canceled.
+        Canceled = "canceled",
+    }
+}
+
+/// Convenience facade for the `browsingContext.*` module.
+///
+/// Returned by [`BiDi::browsing_context`](crate::bidi::BiDi::browsing_context).
+/// Methods cover the common, unscoped form of each command — for finer
+/// control (per-context CSP bypass, multi-page-range printing, etc.)
+/// build the command struct directly and send it via
+/// [`BiDi::send`](crate::bidi::BiDi::send).
 #[derive(Debug)]
 pub struct BrowsingContextModule<'a> {
     bidi: &'a BiDi,
@@ -480,7 +1123,11 @@ impl<'a> BrowsingContextModule<'a> {
         }
     }
 
-    /// `browsingContext.getTree` — full tree of all top-level contexts.
+    /// Run [`browsingContext.getTree`][spec] — return every top-level
+    /// context (and their descendants), or just the subtree rooted at
+    /// `root` if supplied.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-getTree
     pub async fn get_tree(
         &self,
         root: Option<BrowsingContextId>,
@@ -493,12 +1140,12 @@ impl<'a> BrowsingContextModule<'a> {
             .await
     }
 
-    /// Convenience: id of the first top-level browsing context.
+    /// Return the id of the first top-level browsing context — i.e. "the
+    /// active tab".
     ///
-    /// Wraps `getTree` and returns `tree.contexts[0].context`. Errors if
-    /// the driver reports no top-level contexts (a fresh session always
-    /// has at least one). Use this when you just want "the active tab"
-    /// — most automation scripts want the first top-level context.
+    /// Implemented in terms of [`get_tree`](Self::get_tree). Errors with
+    /// a synthetic [`BidiError`] if the driver reports no top-level
+    /// contexts (which never happens in a healthy session).
     pub async fn top_level(&self) -> Result<BrowsingContextId, BidiError> {
         let tree = self.get_tree(None).await?;
         tree.contexts.into_iter().next().map(|c| c.context).ok_or_else(|| BidiError {
@@ -509,15 +1156,19 @@ impl<'a> BrowsingContextModule<'a> {
         })
     }
 
-    /// Convenience: ids of every top-level browsing context.
+    /// Return the ids of every top-level browsing context.
     ///
-    /// Wraps `getTree` and returns each `tree.contexts[*].context`.
+    /// Implemented in terms of [`get_tree`](Self::get_tree).
     pub async fn top_levels(&self) -> Result<Vec<BrowsingContextId>, BidiError> {
         let tree = self.get_tree(None).await?;
         Ok(tree.contexts.into_iter().map(|c| c.context).collect())
     }
 
-    /// `browsingContext.navigate`.
+    /// Navigate `context` to `url` via [`browsingContext.navigate`][spec].
+    ///
+    /// `wait` controls when the call resolves; see [`ReadinessState`].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-navigate
     pub async fn navigate(
         &self,
         context: BrowsingContextId,
@@ -533,7 +1184,12 @@ impl<'a> BrowsingContextModule<'a> {
             .await
     }
 
-    /// `browsingContext.reload`.
+    /// Reload `context` via [`browsingContext.reload`][spec].
+    ///
+    /// `ignore_cache: true` requests a cache bypass — some drivers
+    /// (currently geckodriver) respond with `unsupported operation`.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-reload
     pub async fn reload(
         &self,
         context: BrowsingContextId,
@@ -549,7 +1205,12 @@ impl<'a> BrowsingContextModule<'a> {
             .await
     }
 
-    /// `browsingContext.create` — open a new tab or window.
+    /// Open a new tab or window via [`browsingContext.create`][spec].
+    ///
+    /// For per-create options (opener, user context, background) build a
+    /// [`Create`] directly.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-create
     pub async fn create(&self, kind: CreateType) -> Result<CreateResult, BidiError> {
         self.bidi
             .send(Create {
@@ -561,7 +1222,10 @@ impl<'a> BrowsingContextModule<'a> {
             .await
     }
 
-    /// `browsingContext.close`.
+    /// Close a context via [`browsingContext.close`][spec], skipping any
+    /// `beforeunload` prompt.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-close
     pub async fn close(&self, context: BrowsingContextId) -> Result<(), BidiError> {
         self.bidi
             .send(Close {
@@ -572,7 +1236,9 @@ impl<'a> BrowsingContextModule<'a> {
         Ok(())
     }
 
-    /// `browsingContext.activate`.
+    /// Focus a context via [`browsingContext.activate`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-activate
     pub async fn activate(&self, context: BrowsingContextId) -> Result<(), BidiError> {
         self.bidi
             .send(Activate {
@@ -582,8 +1248,13 @@ impl<'a> BrowsingContextModule<'a> {
         Ok(())
     }
 
-    /// `browsingContext.captureScreenshot` — viewport, PNG. Returns
-    /// base64-encoded PNG bytes.
+    /// Capture a viewport-sized PNG screenshot of `context`.
+    ///
+    /// Wraps [`browsingContext.captureScreenshot`][spec]; see
+    /// [`CaptureScreenshot`] to capture the entire scrolled document or
+    /// to render JPEG.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-captureScreenshot
     pub async fn capture_screenshot(
         &self,
         context: BrowsingContextId,
@@ -597,7 +1268,11 @@ impl<'a> BrowsingContextModule<'a> {
             .await
     }
 
-    /// `browsingContext.setViewport`.
+    /// Set the viewport of `context` via
+    /// [`browsingContext.setViewport`][spec]. Pass `None` to reset to
+    /// the driver default.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-setViewport
     pub async fn set_viewport(
         &self,
         context: BrowsingContextId,
@@ -613,7 +1288,10 @@ impl<'a> BrowsingContextModule<'a> {
         Ok(())
     }
 
-    /// `browsingContext.traverseHistory`.
+    /// Step through `context`'s session history via
+    /// [`browsingContext.traverseHistory`][spec]. `delta` is signed.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-traverseHistory
     pub async fn traverse_history(
         &self,
         context: BrowsingContextId,
@@ -628,7 +1306,10 @@ impl<'a> BrowsingContextModule<'a> {
         Ok(())
     }
 
-    /// `browsingContext.handleUserPrompt`.
+    /// Accept or dismiss a JS dialog via
+    /// [`browsingContext.handleUserPrompt`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-handleUserPrompt
     pub async fn handle_user_prompt(
         &self,
         context: BrowsingContextId,
@@ -640,6 +1321,68 @@ impl<'a> BrowsingContextModule<'a> {
                 context,
                 accept,
                 user_text,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Find every node in `context` matching `locator` via
+    /// [`browsingContext.locateNodes`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-locateNodes
+    pub async fn locate_nodes(
+        &self,
+        context: BrowsingContextId,
+        locator: Locator,
+    ) -> Result<LocateNodesResult, BidiError> {
+        self.bidi
+            .send(LocateNodes {
+                context,
+                locator,
+                max_node_count: None,
+                serialization_options: None,
+                start_nodes: None,
+            })
+            .await
+    }
+
+    /// Render `context` as a base64-encoded PDF using the driver's
+    /// default page settings. Wraps [`browsingContext.print`][spec].
+    ///
+    /// For custom page size, margins, scale, or page ranges build a
+    /// [`Print`] directly and send it via
+    /// [`BiDi::send`](crate::bidi::BiDi::send).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-print
+    pub async fn print(&self, context: BrowsingContextId) -> Result<PrintResult, BidiError> {
+        self.bidi
+            .send(Print {
+                context,
+                background: None,
+                margin: None,
+                orientation: None,
+                page: None,
+                page_ranges: None,
+                scale: None,
+                shrink_to_fit: None,
+            })
+            .await
+    }
+
+    /// Toggle global Content-Security-Policy bypass via
+    /// [`browsingContext.setBypassCSP`][spec].
+    ///
+    /// `Some(true)` enables bypass, `None` clears the override. To scope
+    /// the override to specific contexts/user-contexts, build the
+    /// [`SetBypassCsp`] struct directly.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-browsingContext-setBypassCSP
+    pub async fn set_bypass_csp(&self, bypass: Option<bool>) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetBypassCsp {
+                bypass,
+                contexts: None,
+                user_contexts: None,
             })
             .await?;
         Ok(())

--- a/thirtyfour/src/bidi/modules/emulation.rs
+++ b/thirtyfour/src/bidi/modules/emulation.rs
@@ -1,0 +1,700 @@
+//! `emulation.*` — override browser-exposed environmental APIs
+//! (geolocation, locale, timezone, screen, user agent, scripting,
+//! touch, scrollbars, forced-colors theme, network conditions).
+//!
+//! Each command follows the same scoping pattern:
+//!
+//! - **No `contexts` and no `user_contexts`** — the override applies as
+//!   the new default (every existing and future top-level traversable).
+//! - **`contexts` only** — restrict to the given top-level traversables.
+//! - **`user_contexts` only** — restrict to the given user contexts
+//!   (and every traversable inside them).
+//! - **Both** — invalid; the spec returns `invalid argument`.
+//!
+//! Pass `None` (or the variant that the spec defines as "clear", e.g.
+//! `coordinates: None` for geolocation) to remove a previously-set
+//! override.
+//!
+//! Driver support varies. Chromium implements most commands; Firefox
+//! lags. Calls return `unsupported operation` when the driver hasn't
+//! implemented a particular override yet.
+//!
+//! See the [W3C `emulation` module specification][spec] for the
+//! canonical definitions.
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#module-emulation
+
+use serde::{Deserialize, Serialize};
+
+use crate::bidi::BiDi;
+use crate::bidi::command::{BidiCommand, Empty};
+use crate::bidi::error::BidiError;
+use crate::bidi::ids::{BrowsingContextId, UserContextId};
+use crate::common::protocol::string_enum;
+
+string_enum! {
+    /// Theme value for [`SetForcedColorsModeThemeOverride::theme`].
+    pub enum ForcedColorsModeTheme {
+        /// Light theme.
+        Light = "light",
+        /// Dark theme.
+        Dark = "dark",
+    }
+}
+
+/// [`emulation.setForcedColorsModeThemeOverride`][spec] — override the
+/// CSS forced-colors theme.
+///
+/// Affects the value returned by `matchMedia('(prefers-color-scheme:
+/// dark)')` and the in-page rendering. Pass `theme: None` to clear.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setForcedColorsModeThemeOverride
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetForcedColorsModeThemeOverride {
+    /// New theme, or `None` to clear.
+    pub theme: Option<ForcedColorsModeTheme>,
+    /// Browsing-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// User-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetForcedColorsModeThemeOverride {
+    const METHOD: &'static str = "emulation.setForcedColorsModeThemeOverride";
+    type Returns = Empty;
+}
+
+/// Geolocation coordinates for [`SetGeolocationOverride`]. Mirrors the
+/// spec's [`emulation.GeolocationCoordinates`][spec] type.
+///
+/// Lat/long are required; the rest mirror the
+/// [Geolocation API's `Coordinates`][coords] interface and are
+/// optional. Note `altitude_accuracy` requires `altitude`.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-emulation-GeolocationCoordinates
+/// [coords]: https://www.w3.org/TR/geolocation/#coordinates_interface
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeolocationCoordinates {
+    /// Latitude in degrees, -90.0..=90.0.
+    pub latitude: f64,
+    /// Longitude in degrees, -180.0..=180.0.
+    pub longitude: f64,
+    /// Accuracy in meters (default 1.0).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accuracy: Option<f64>,
+    /// Altitude in meters above the WGS-84 ellipsoid.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub altitude: Option<f64>,
+    /// Altitude accuracy in meters. Requires `altitude`.
+    #[serde(rename = "altitudeAccuracy", skip_serializing_if = "Option::is_none")]
+    pub altitude_accuracy: Option<f64>,
+    /// Heading (bearing) in degrees, 0.0..=360.0.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heading: Option<f64>,
+    /// Speed in m/s.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speed: Option<f64>,
+}
+
+/// Geolocation override variant. Mirrors the spec's
+/// `emulation.SetGeolocationOverrideParameters` discriminated body.
+///
+/// Use [`Coordinates`][Self::Coordinates] (with `Some(coords)` to set or
+/// `None` to clear) to override with a position, or [`Error`][Self::Error]
+/// to make the Geolocation API report a `GeolocationPositionError`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum GeolocationOverride {
+    /// Override with explicit coordinates, or clear by passing `None`.
+    Coordinates {
+        /// Coordinates payload. `None` clears the override.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        coordinates: Option<GeolocationCoordinates>,
+    },
+    /// Override with a position-error. Drives the
+    /// [`GeolocationPositionError`][api] callback in JS.
+    ///
+    /// [api]: https://www.w3.org/TR/geolocation/#position_error_interface
+    Error {
+        /// Error payload — currently the spec only defines
+        /// [`PositionUnavailable`][GeolocationPositionError::PositionUnavailable].
+        error: GeolocationPositionError,
+    },
+}
+
+/// Position error variant for [`GeolocationOverride::Error`]. Mirrors
+/// the spec's `emulation.GeolocationPositionError` type.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum GeolocationPositionError {
+    /// Browser reports `POSITION_UNAVAILABLE` to JS.
+    PositionUnavailable,
+}
+
+/// [`emulation.setGeolocationOverride`][spec] — override the page's
+/// geolocation reading.
+///
+/// Use [`GeolocationOverride::Coordinates`] with `Some(coords)` to fake
+/// a location, `None` to clear, or [`GeolocationOverride::Error`] to
+/// make the API report failure.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setGeolocationOverride
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetGeolocationOverride {
+    /// Override (coordinates or error).
+    #[serde(flatten)]
+    pub geolocation: GeolocationOverride,
+    /// Browsing-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// User-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetGeolocationOverride {
+    const METHOD: &'static str = "emulation.setGeolocationOverride";
+    type Returns = Empty;
+}
+
+/// [`emulation.setLocaleOverride`][spec] — override the navigator
+/// locale.
+///
+/// `locale` must be a structurally-valid BCP-47 language tag
+/// (`"en-GB"`, `"ja"`, `"de-AT"`, …); `None` clears the override.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setLocaleOverride
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetLocaleOverride {
+    /// BCP-47 locale tag, or `None` to clear.
+    pub locale: Option<String>,
+    /// Browsing-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// User-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetLocaleOverride {
+    const METHOD: &'static str = "emulation.setLocaleOverride";
+    type Returns = Empty;
+}
+
+/// Network conditions for [`SetNetworkConditions`]. Mirrors the spec's
+/// `emulation.NetworkConditions` union — currently only the `offline`
+/// variant is defined.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum NetworkConditions {
+    /// Force the network stack offline. The browser fails every fetch
+    /// and refuses new WebSocket / WebTransport connections.
+    Offline,
+}
+
+/// [`emulation.setNetworkConditions`][spec] — override per-context
+/// network conditions.
+///
+/// Pass `network_conditions: None` to clear. The spec currently only
+/// defines an "offline" mode; bandwidth/latency throttling is
+/// implementation-defined for now.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setNetworkConditions
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetNetworkConditions {
+    /// New conditions, or `None` to clear the override.
+    pub network_conditions: Option<NetworkConditions>,
+    /// Browsing-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// User-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetNetworkConditions {
+    const METHOD: &'static str = "emulation.setNetworkConditions";
+    type Returns = Empty;
+}
+
+/// Screen area in CSS pixels for [`SetScreenSettingsOverride`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScreenArea {
+    /// Width in CSS pixels.
+    pub width: u32,
+    /// Height in CSS pixels.
+    pub height: u32,
+}
+
+/// [`emulation.setScreenSettingsOverride`][spec] — emulate a different
+/// screen size for the page (`screen.width`, `screen.height`,
+/// `screen.availWidth`, `screen.availHeight`).
+///
+/// Pass `screen_area: None` to clear.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setScreenSettingsOverride
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetScreenSettingsOverride {
+    /// Override, or `None` to clear.
+    pub screen_area: Option<ScreenArea>,
+    /// Browsing-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// User-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetScreenSettingsOverride {
+    const METHOD: &'static str = "emulation.setScreenSettingsOverride";
+    type Returns = Empty;
+}
+
+string_enum! {
+    /// Natural orientation of the emulated device for
+    /// [`ScreenOrientation::natural`].
+    pub enum ScreenOrientationNatural {
+        /// Natural portrait (taller than wide). Default for phones.
+        Portrait = "portrait",
+        /// Natural landscape (wider than tall). Default for tablets in
+        /// landscape mode.
+        Landscape = "landscape",
+    }
+}
+
+string_enum! {
+    /// Current orientation for [`ScreenOrientation::orientation_type`].
+    /// Maps to the values exposed by the [Screen Orientation API][api].
+    ///
+    /// [api]: https://www.w3.org/TR/screen-orientation/
+    pub enum ScreenOrientationType {
+        /// Portrait, primary direction.
+        PortraitPrimary = "portrait-primary",
+        /// Portrait, secondary (180° from primary).
+        PortraitSecondary = "portrait-secondary",
+        /// Landscape, primary direction.
+        LandscapePrimary = "landscape-primary",
+        /// Landscape, secondary (180° from primary).
+        LandscapeSecondary = "landscape-secondary",
+    }
+}
+
+/// Screen orientation for [`SetScreenOrientationOverride`]. Pairs the
+/// device's natural orientation with the current orientation type.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScreenOrientation {
+    /// Natural orientation of the (emulated) device.
+    pub natural: ScreenOrientationNatural,
+    /// Current orientation type.
+    #[serde(rename = "type")]
+    pub orientation_type: ScreenOrientationType,
+}
+
+/// [`emulation.setScreenOrientationOverride`][spec] — override the
+/// reported screen orientation.
+///
+/// Pass `screen_orientation: None` to clear.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setScreenOrientationOverride
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetScreenOrientationOverride {
+    /// Override, or `None` to clear.
+    pub screen_orientation: Option<ScreenOrientation>,
+    /// Browsing-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// User-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetScreenOrientationOverride {
+    const METHOD: &'static str = "emulation.setScreenOrientationOverride";
+    type Returns = Empty;
+}
+
+/// [`emulation.setUserAgentOverride`][spec] — override `navigator.userAgent`.
+///
+/// `user_agent: None` clears the override. Note this affects the
+/// outgoing `User-Agent` header as well as `navigator.userAgent`, but
+/// does **not** override Client Hint headers — for those you'll need
+/// driver-specific extensions.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setUserAgentOverride
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetUserAgentOverride {
+    /// New user-agent string, or `None` to clear.
+    pub user_agent: Option<String>,
+    /// Browsing-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// User-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetUserAgentOverride {
+    const METHOD: &'static str = "emulation.setUserAgentOverride";
+    type Returns = Empty;
+}
+
+/// [`emulation.setScriptingEnabled`][spec] — disable JavaScript
+/// execution.
+///
+/// The spec only defines two wire values: `false` (disable) and `null`
+/// (clear the override). There is intentionally no way to selectively
+/// _re-enable_ scripting — the spec calls this out, since untrusted
+/// re-enable would defeat the security purpose.
+///
+/// To preserve that constraint while keeping a familiar `Option<bool>`
+/// API, this struct silently omits the field if `enabled == Some(true)`
+/// (which is equivalent to "no override"). Use `Some(false)` to
+/// disable, `None` to clear.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setScriptingEnabled
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetScriptingEnabled {
+    /// `Some(false)` to disable scripting, `None` to clear.
+    /// `Some(true)` is silently dropped (the wire shape forbids it).
+    #[serde(serialize_with = "serialize_disable_only")]
+    pub enabled: Option<bool>,
+    /// Browsing-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// User-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+fn serialize_disable_only<S: serde::Serializer>(
+    value: &Option<bool>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match value {
+        Some(false) => serializer.serialize_bool(false),
+        _ => serializer.serialize_none(),
+    }
+}
+
+impl BidiCommand for SetScriptingEnabled {
+    const METHOD: &'static str = "emulation.setScriptingEnabled";
+    type Returns = Empty;
+}
+
+string_enum! {
+    /// Scrollbar style for [`SetScrollbarTypeOverride::scrollbar_type`].
+    pub enum ScrollbarType {
+        /// Classic scrollbars — reserve space alongside content.
+        Classic = "classic",
+        /// Overlay scrollbars — drawn on top of content.
+        Overlay = "overlay",
+    }
+}
+
+/// [`emulation.setScrollbarTypeOverride`][spec] — override the page's
+/// scrollbar style.
+///
+/// `scrollbar_type: None` clears the override.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setScrollbarTypeOverride
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetScrollbarTypeOverride {
+    /// New style, or `None` to clear.
+    pub scrollbar_type: Option<ScrollbarType>,
+    /// Browsing-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// User-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetScrollbarTypeOverride {
+    const METHOD: &'static str = "emulation.setScrollbarTypeOverride";
+    type Returns = Empty;
+}
+
+/// [`emulation.setTimezoneOverride`][spec] — override the system
+/// timezone for the page.
+///
+/// `timezone` accepts either an IANA timezone name (`"Australia/Sydney"`,
+/// `"Europe/Berlin"`) or a UTC offset string (`"+10:00"`, `"-05:00"`).
+/// `None` clears the override. Invalid values are rejected with
+/// `invalid argument`.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setTimezoneOverride
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetTimezoneOverride {
+    /// IANA timezone name or UTC-offset string. `None` clears.
+    pub timezone: Option<String>,
+    /// Browsing-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// User-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetTimezoneOverride {
+    const METHOD: &'static str = "emulation.setTimezoneOverride";
+    type Returns = Empty;
+}
+
+/// [`emulation.setTouchOverride`][spec] — emulate
+/// `navigator.maxTouchPoints` (drives feature-detection of touch
+/// support, e.g. `'ontouchstart' in window`).
+///
+/// `max_touch_points: None` clears the override; values must be `>= 1`.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setTouchOverride
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetTouchOverride {
+    /// New `maxTouchPoints` value (`>= 1`), or `None` to clear.
+    pub max_touch_points: Option<u32>,
+    /// Browsing-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// User-context scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetTouchOverride {
+    const METHOD: &'static str = "emulation.setTouchOverride";
+    type Returns = Empty;
+}
+
+/// Convenience facade for the `emulation.*` module.
+///
+/// Returned by [`BiDi::emulation`](crate::bidi::BiDi::emulation). Every
+/// method here applies the override globally. To scope an override to
+/// specific browsing contexts or user contexts, build the command
+/// struct directly and supply [`contexts`][SetUserAgentOverride::contexts]
+/// or [`user_contexts`][SetUserAgentOverride::user_contexts].
+#[derive(Debug)]
+pub struct EmulationModule<'a> {
+    bidi: &'a BiDi,
+}
+
+impl<'a> EmulationModule<'a> {
+    pub(crate) fn new(bidi: &'a BiDi) -> Self {
+        Self {
+            bidi,
+        }
+    }
+
+    /// Override the forced-colors theme globally via
+    /// [`emulation.setForcedColorsModeThemeOverride`][spec].
+    ///
+    /// Pass `None` to clear.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setForcedColorsModeThemeOverride
+    pub async fn set_forced_colors_mode_theme_override(
+        &self,
+        theme: Option<ForcedColorsModeTheme>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetForcedColorsModeThemeOverride {
+                theme,
+                contexts: None,
+                user_contexts: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Override geolocation globally via
+    /// [`emulation.setGeolocationOverride`][spec], using explicit
+    /// coordinates (or `None` to clear).
+    ///
+    /// To make the API report a position-error instead, build a
+    /// [`SetGeolocationOverride`] with [`GeolocationOverride::Error`].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setGeolocationOverride
+    pub async fn set_geolocation_override(
+        &self,
+        coordinates: Option<GeolocationCoordinates>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetGeolocationOverride {
+                geolocation: GeolocationOverride::Coordinates {
+                    coordinates,
+                },
+                contexts: None,
+                user_contexts: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Override the navigator locale globally via
+    /// [`emulation.setLocaleOverride`][spec].
+    ///
+    /// `locale` is a BCP-47 tag (`"en-GB"`, etc.); `None` clears.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setLocaleOverride
+    pub async fn set_locale_override(&self, locale: Option<String>) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetLocaleOverride {
+                locale,
+                contexts: None,
+                user_contexts: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Override network conditions globally via
+    /// [`emulation.setNetworkConditions`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setNetworkConditions
+    pub async fn set_network_conditions(
+        &self,
+        conditions: Option<NetworkConditions>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetNetworkConditions {
+                network_conditions: conditions,
+                contexts: None,
+                user_contexts: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Override the reported screen size globally via
+    /// [`emulation.setScreenSettingsOverride`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setScreenSettingsOverride
+    pub async fn set_screen_settings_override(
+        &self,
+        screen_area: Option<ScreenArea>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetScreenSettingsOverride {
+                screen_area,
+                contexts: None,
+                user_contexts: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Override screen orientation globally via
+    /// [`emulation.setScreenOrientationOverride`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setScreenOrientationOverride
+    pub async fn set_screen_orientation_override(
+        &self,
+        orientation: Option<ScreenOrientation>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetScreenOrientationOverride {
+                screen_orientation: orientation,
+                contexts: None,
+                user_contexts: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Override the user-agent string globally via
+    /// [`emulation.setUserAgentOverride`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setUserAgentOverride
+    pub async fn set_user_agent_override(
+        &self,
+        user_agent: Option<String>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetUserAgentOverride {
+                user_agent,
+                contexts: None,
+                user_contexts: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Disable JavaScript globally via
+    /// [`emulation.setScriptingEnabled`][spec].
+    ///
+    /// Pass `Some(false)` to disable, `None` to clear.
+    /// `Some(true)` is silently dropped — see [`SetScriptingEnabled`].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setScriptingEnabled
+    pub async fn set_scripting_enabled(&self, enabled: Option<bool>) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetScriptingEnabled {
+                enabled,
+                contexts: None,
+                user_contexts: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Override scrollbar style globally via
+    /// [`emulation.setScrollbarTypeOverride`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setScrollbarTypeOverride
+    pub async fn set_scrollbar_type_override(
+        &self,
+        scrollbar_type: Option<ScrollbarType>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetScrollbarTypeOverride {
+                scrollbar_type,
+                contexts: None,
+                user_contexts: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Override timezone globally via
+    /// [`emulation.setTimezoneOverride`][spec].
+    ///
+    /// `timezone` is an IANA name (`"Australia/Sydney"`) or a UTC
+    /// offset (`"+10:00"`); `None` clears.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setTimezoneOverride
+    pub async fn set_timezone_override(&self, timezone: Option<String>) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetTimezoneOverride {
+                timezone,
+                contexts: None,
+                user_contexts: None,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Override `navigator.maxTouchPoints` globally via
+    /// [`emulation.setTouchOverride`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-emulation-setTouchOverride
+    pub async fn set_touch_override(&self, max_touch_points: Option<u32>) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetTouchOverride {
+                max_touch_points,
+                contexts: None,
+                user_contexts: None,
+            })
+            .await?;
+        Ok(())
+    }
+}

--- a/thirtyfour/src/bidi/modules/input.rs
+++ b/thirtyfour/src/bidi/modules/input.rs
@@ -1,24 +1,72 @@
-//! `input.*` BiDi module — `performActions`, `releaseActions`, `setFiles`.
+//! `input.*` — synthesise pointer / key / wheel input and drive
+//! `<input type=file>` dialogs.
 //!
-//! Action sources (key, pointer, wheel, none) follow the same JSON shape
-//! as W3C WebDriver classic actions. Action source objects are passed
-//! through as `serde_json::Value` so callers can construct them with the
-//! `json!` macro or build their own typed wrappers.
+//! The action format is identical to W3C WebDriver Classic's
+//! [Actions API][actions] — each entry in
+//! [`PerformActions::actions`][pa] describes one input source (a
+//! keyboard, a pointer, or a wheel) and its sequence of actions. The
+//! Rust API treats each source as a [`serde_json::Value`] so callers
+//! can build them with the `json!` macro, deserialize them from JSON
+//! test fixtures, or wrap them in their own typed helpers.
+//!
+//! [pa]: crate::bidi::modules::input::PerformActions::actions
+//!
+//! See the [W3C `input` module specification][spec] for the canonical
+//! definitions, including the
+//! [`input.SourceActions`][source-actions-spec] union the
+//! action-source entries follow.
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#module-input
+//! [actions]: https://www.w3.org/TR/webdriver2/#actions
+//! [source-actions-spec]: https://w3c.github.io/webdriver-bidi/#type-input-SourceActions
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::bidi::BiDi;
-use crate::bidi::command::{BidiCommand, Empty};
+use crate::bidi::command::{BidiCommand, BidiEvent, Empty};
 use crate::bidi::error::BidiError;
-use crate::bidi::ids::{BrowsingContextId, NodeId};
+use crate::bidi::ids::{BrowsingContextId, NodeId, UserContextId};
 
-/// `input.performActions`.
+/// [`input.performActions`][spec] — execute a batch of input actions.
+///
+/// `actions` is an array of [`input.SourceActions`][src] JSON objects.
+/// Each source has an `id`, a `type` (`"key"`, `"pointer"`, `"wheel"`,
+/// or `"none"`), optional per-source `parameters`, and an array of
+/// individual actions to perform on that source.
+///
+/// Example: type "hi" through a synthesized keyboard.
+///
+/// ```no_run
+/// # use thirtyfour::prelude::*;
+/// # use thirtyfour::bidi::modules::input::PerformActions;
+/// # use serde_json::json;
+/// # async fn run(bidi: thirtyfour::bidi::BiDi, ctx: thirtyfour::bidi::BrowsingContextId)
+/// # -> WebDriverResult<()> {
+/// bidi.send(PerformActions {
+///     context: ctx,
+///     actions: vec![json!({
+///         "id": "kbd",
+///         "type": "key",
+///         "actions": [
+///             {"type": "keyDown", "value": "h"},
+///             {"type": "keyUp",   "value": "h"},
+///             {"type": "keyDown", "value": "i"},
+///             {"type": "keyUp",   "value": "i"},
+///         ]
+///     })],
+/// }).await?;
+/// # Ok(()) }
+/// ```
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-input-performActions
+/// [src]: https://w3c.github.io/webdriver-bidi/#type-input-SourceActions
 #[derive(Debug, Clone, Serialize)]
 pub struct PerformActions {
     /// Browsing context the actions apply to.
     pub context: BrowsingContextId,
-    /// One entry per input source. Each is a JSON object with `id`, `type`,
-    /// optional `parameters`, and an `actions` array.
+    /// One entry per input source. See [`input.SourceActions`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-input-SourceActions
     pub actions: Vec<serde_json::Value>,
 }
 
@@ -27,10 +75,16 @@ impl BidiCommand for PerformActions {
     type Returns = Empty;
 }
 
-/// `input.releaseActions`.
+/// [`input.releaseActions`][spec] — release any sticky input state
+/// (held modifier keys, depressed buttons) for `context`.
+///
+/// Useful as cleanup between tests so that a leftover keydown from one
+/// scenario doesn't bleed into the next.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-input-releaseActions
 #[derive(Debug, Clone, Serialize)]
 pub struct ReleaseActions {
-    /// Browsing context.
+    /// Browsing context to release.
     pub context: BrowsingContextId,
 }
 
@@ -39,20 +93,37 @@ impl BidiCommand for ReleaseActions {
     type Returns = Empty;
 }
 
-/// `input.setFiles`.
+/// [`input.setFiles`][spec] — set the file list on an
+/// `<input type=file>` element.
+///
+/// Construct the [`element`][Self::element] reference with
+/// [`shared_reference`] from a [`NodeId`] returned by
+/// [`script.callFunction`](crate::bidi::modules::script::CallFunction)
+/// or
+/// [`browsingContext.locateNodes`](crate::bidi::modules::browsing_context::LocateNodes).
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-input-setFiles
 #[derive(Debug, Clone, Serialize)]
 pub struct SetFiles {
     /// Browsing context.
     pub context: BrowsingContextId,
-    /// Element to set files on, as a BiDi `script.SharedReference`. Use
-    /// [`shared_reference`] to construct.
+    /// Element to set files on — a [`script.SharedReference`][spec]
+    /// JSON value (`{"sharedId":"…"}`). Use [`shared_reference`] to
+    /// build one from a [`NodeId`].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-SharedReference
     pub element: serde_json::Value,
-    /// File paths.
+    /// File paths to attach. Paths must be absolute on the host
+    /// filesystem; the spec doesn't define remote-driver upload — for
+    /// Selenium Grid scenarios upload the file to the grid first via
+    /// the WebDriver Classic file-upload endpoint.
     pub files: Vec<String>,
 }
 
-/// Wrap a [`NodeId`] in the `script.SharedReference` JSON shape that
-/// `input.setFiles` expects (`{"sharedId":"…"}`).
+/// Wrap a [`NodeId`] in the [`script.SharedReference`][spec] JSON shape
+/// expected by [`SetFiles::element`].
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-SharedReference
 pub fn shared_reference(node: &NodeId) -> serde_json::Value {
     serde_json::json!({"sharedId": node.as_str()})
 }
@@ -62,7 +133,9 @@ impl BidiCommand for SetFiles {
     type Returns = Empty;
 }
 
-/// Module facade returned by [`BiDi::input`].
+/// Convenience facade for the `input.*` module.
+///
+/// Returned by [`BiDi::input`](crate::bidi::BiDi::input).
 #[derive(Debug)]
 pub struct InputModule<'a> {
     bidi: &'a BiDi,
@@ -75,7 +148,10 @@ impl<'a> InputModule<'a> {
         }
     }
 
-    /// `input.performActions`.
+    /// Execute a batch of input actions via
+    /// [`input.performActions`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-input-performActions
     pub async fn perform_actions(
         &self,
         context: BrowsingContextId,
@@ -90,7 +166,10 @@ impl<'a> InputModule<'a> {
         Ok(())
     }
 
-    /// `input.releaseActions`.
+    /// Release any sticky input state via
+    /// [`input.releaseActions`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-input-releaseActions
     pub async fn release_actions(&self, context: BrowsingContextId) -> Result<(), BidiError> {
         self.bidi
             .send(ReleaseActions {
@@ -100,7 +179,10 @@ impl<'a> InputModule<'a> {
         Ok(())
     }
 
-    /// `input.setFiles`.
+    /// Set the files on an `<input type=file>` element via
+    /// [`input.setFiles`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-input-setFiles
     pub async fn set_files(
         &self,
         context: BrowsingContextId,
@@ -115,5 +197,43 @@ impl<'a> InputModule<'a> {
             })
             .await?;
         Ok(())
+    }
+}
+
+/// Events surfaced by the `input.*` module.
+pub(crate) mod events {
+    use super::*;
+
+    /// [`input.fileDialogOpened`][spec] — fires when the browser opens
+    /// a native file picker (e.g. when the user clicks an
+    /// `<input type=file>`).
+    ///
+    /// Pair with [`SetFiles`] to programmatically supply files —
+    /// natively-opened pickers can't be driven by simulated clicks
+    /// alone.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-input-fileDialogOpened
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct FileDialogOpened {
+        /// Browsing context that triggered the dialog.
+        pub context: BrowsingContextId,
+        /// Whether the input accepts multiple files (the `multiple`
+        /// HTML attribute).
+        pub multiple: bool,
+        /// User context id of the originating context.
+        #[serde(default)]
+        pub user_context: Option<UserContextId>,
+        /// The `<input>` element that opened the dialog, as a
+        /// [`script.SharedReference`][spec] JSON value. May be absent
+        /// when the dialog wasn't directly triggered by a DOM element.
+        ///
+        /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-SharedReference
+        #[serde(default)]
+        pub element: Option<serde_json::Value>,
+    }
+
+    impl BidiEvent for FileDialogOpened {
+        const METHOD: &'static str = "input.fileDialogOpened";
     }
 }

--- a/thirtyfour/src/bidi/modules/log.rs
+++ b/thirtyfour/src/bidi/modules/log.rs
@@ -1,4 +1,14 @@
-//! `log.*` BiDi module — event-only.
+//! `log.*` — JavaScript console output and uncaught-exception observation.
+//!
+//! The log module is event-only: there are no commands. Subscribe to
+//! [`LogEntryAdded`](crate::bidi::events::LogEntryAdded) via
+//! [`BiDi::subscribe`](crate::bidi::BiDi::subscribe) to receive every
+//! `console.*` call and every uncaught JavaScript exception.
+//!
+//! See the [W3C `log` module specification][spec] for the canonical
+//! definitions.
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#module-log
 
 use serde::Deserialize;
 
@@ -8,7 +18,8 @@ use crate::bidi::ids::RealmId;
 use crate::common::protocol::string_enum;
 
 string_enum! {
-    /// Severity for [`events::EntryAdded`].
+    /// Log entry severity for [`events::EntryAdded::level`]. Mirrors
+    /// the spec's `log.LogLevel` enumeration.
     pub enum LogLevel {
         /// `console.debug` and friends.
         Debug = "debug",
@@ -25,33 +36,52 @@ string_enum! {
 pub(crate) mod events {
     use super::*;
 
-    /// `log.entryAdded`. Modeled as a JSON-flexible struct since the spec
-    /// distinguishes `console`, `javascript`, and other entry types via the
-    /// `type` field with different schemas. Common fields are typed; the
-    /// rest land in [`EntryAdded::extra`].
+    /// [`log.entryAdded`][spec] — fires for every `console.*` call and
+    /// uncaught exception.
+    ///
+    /// The spec models the entry as a discriminated union over `type`:
+    /// `"console"` and `"javascript"` are the standard variants, each
+    /// with its own type-specific fields. This struct types the common
+    /// fields and routes the rest through [`EntryAdded::extra`] so the
+    /// caller can destructure with serde where needed.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-log-entryAdded
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct EntryAdded {
-        /// Entry kind (`"console"`, `"javascript"`, …).
+        /// Entry kind. `"console"` for `console.*` calls,
+        /// `"javascript"` for uncaught exceptions, plus any
+        /// driver-specific values.
         #[serde(rename = "type")]
         pub entry_type: String,
         /// Severity.
         pub level: LogLevel,
-        /// Source realm.
+        /// Source realm — a [`script.Source`][spec] JSON value.
+        ///
+        /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-Source
         #[serde(default)]
         pub source: serde_json::Value,
-        /// Coalesced text.
+        /// Coalesced text representation. For `console.log("a", 1)`
+        /// this is something like `"a 1"` — the underlying argument
+        /// values live in [`extra`][Self::extra]`.args`.
         #[serde(default)]
         pub text: Option<String>,
-        /// Driver timestamp (ms since epoch).
+        /// Driver timestamp (ms since unix epoch).
         pub timestamp: u64,
-        /// Stack trace (if any).
+        /// Stack trace as a [`script.StackTrace`][spec] JSON value (or
+        /// `null` if no stack was captured).
+        ///
+        /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-StackTrace
         #[serde(default)]
         pub stack_trace: serde_json::Value,
-        /// JS realm id (where applicable).
+        /// JavaScript realm the entry came from (where applicable).
         #[serde(default)]
         pub realm: Option<RealmId>,
-        /// Extra type-specific fields (e.g. `method` and `args` for console).
+        /// Type-specific extras — e.g. `method` (`"log"`, `"warn"`,
+        /// …) and `args` (array of [`script.RemoteValue`][rv]) for
+        /// `"console"` entries.
+        ///
+        /// [rv]: https://w3c.github.io/webdriver-bidi/#type-script-RemoteValue
         #[serde(flatten)]
         pub extra: serde_json::Map<String, serde_json::Value>,
     }
@@ -61,9 +91,14 @@ pub(crate) mod events {
     }
 }
 
-/// Module facade returned by [`BiDi::log`]. The `log` module is event-only
-/// in the spec — there are no commands. The facade exists for symmetry with
-/// the other modules.
+/// Module facade returned by [`BiDi::log`](crate::bidi::BiDi::log).
+///
+/// The `log` module is event-only — the spec defines no commands. This
+/// facade exists for symmetry with the other modules; subscribe to
+/// [`events::EntryAdded`] (or
+/// [`bidi::events::LogEntryAdded`](crate::bidi::events::LogEntryAdded))
+/// via [`BiDi::subscribe`](crate::bidi::BiDi::subscribe) to receive log
+/// entries.
 #[derive(Debug)]
 pub struct LogModule<'a> {
     #[allow(dead_code)]

--- a/thirtyfour/src/bidi/modules/mod.rs
+++ b/thirtyfour/src/bidi/modules/mod.rs
@@ -1,26 +1,51 @@
-//! Curated typed bindings for WebDriver BiDi modules.
+//! Curated typed bindings for every WebDriver BiDi module.
 //!
-//! Each submodule mirrors a [W3C BiDi spec module]. Commands implement
-//! [`crate::bidi::BidiCommand`] and events implement
-//! [`crate::bidi::BidiEvent`]; both flow through [`crate::bidi::BiDi`].
+//! Each submodule mirrors a [W3C BiDi spec module][spec-modules]:
 //!
-//! [W3C BiDi spec module]: https://w3c.github.io/webdriver-bidi/#protocol-modules
+//! - Commands implement [`BidiCommand`](crate::bidi::BidiCommand) and are
+//!   sent via [`BiDi::send`](crate::bidi::BiDi::send) (or the matching
+//!   façade method).
+//! - Events implement [`BidiEvent`](crate::bidi::BidiEvent) and are
+//!   surfaced via [`BiDi::subscribe`](crate::bidi::BiDi::subscribe).
+//!
+//! Each module's docs link directly to the corresponding spec section
+//! and every command/event has a link to its own spec entry. Where the
+//! spec talks about CDDL "remote end" / "local end" definitions, the
+//! rule of thumb is:
+//!
+//! - **Remote end definition** → command parameters / event params
+//!   _sent or received by the client_. Modelled as a `Serialize` /
+//!   `Deserialize` struct on the Rust side.
+//! - **Local end definition** → the response the client deserialises.
+//!   Modelled as the `Returns` associated type of the command.
+//!
+//! [spec-modules]: https://w3c.github.io/webdriver-bidi/#protocol-modules
 
-/// `browser.*` — top-level browser control and user contexts.
+/// `browser.*` — top-level browser control, user contexts, client windows,
+/// download behavior. See [`browser`].
 pub mod browser;
-/// `browsingContext.*` — tabs, frames, navigation, screenshots.
+/// `browsingContext.*` — tabs, frames, navigation, screenshots, printing,
+/// node location, CSP bypass. See [`browsing_context`].
 pub mod browsing_context;
-/// `input.*` — `performActions`, `releaseActions`, `setFiles`.
+/// `emulation.*` — geolocation, locale, timezone, screen, user agent,
+/// scripting and touch overrides. See [`emulation`].
+pub mod emulation;
+/// `input.*` — `performActions`, `releaseActions`, `setFiles`, plus the
+/// `fileDialogOpened` event. See [`input`].
 pub mod input;
-/// `log.*` — log entry events.
+/// `log.*` — log entry events. See [`log`].
 pub mod log;
-/// `network.*` — interception and request/response control.
+/// `network.*` — interception, request/response control, data collectors,
+/// extra headers. See [`network`].
 pub mod network;
-/// `permissions.*` — `setPermission`.
+/// `permissions.*` — `setPermission`. See [`permissions`].
 pub mod permissions;
 /// `script.*` — `evaluate`, `callFunction`, preload scripts, realms.
+/// See [`script`].
 pub mod script;
-/// `session.*` — protocol handshake, subscription, status.
+/// `session.*` — protocol handshake, subscription, status. See [`session`].
 pub mod session;
-/// `storage.*` — cookies and partitions.
+/// `storage.*` — cookies and partition lookup. See [`storage`].
 pub mod storage;
+/// `webExtension.*` — install / uninstall web extensions. See [`web_extension`].
+pub mod web_extension;

--- a/thirtyfour/src/bidi/modules/network.rs
+++ b/thirtyfour/src/bidi/modules/network.rs
@@ -1,47 +1,145 @@
-//! `network.*` BiDi module — request observation, interception, and modify
-//! request/response.
+//! `network.*` — observe, intercept, and modify HTTP traffic.
+//!
+//! This module covers four overlapping use-cases:
+//!
+//! 1. **Observation** — subscribe to [`BeforeRequestSent`][brs],
+//!    [`ResponseStarted`][rs], [`ResponseCompleted`][rc], or
+//!    [`FetchError`][fe] to watch every request the page makes
+//!    (including subresources) without altering it.
+//! 2. **Interception** — register an [`AddIntercept`][ai] to pause
+//!    requests in selected phases, then continue, fail, or synthesize
+//!    a response using [`ContinueRequest`][creq] / [`FailRequest`][fr]
+//!    / [`ProvideResponse`][pr] / [`ContinueResponse`][cresp] /
+//!    [`ContinueWithAuth`][cwa].
+//! 3. **Body capture** — register an [`AddDataCollector`][adc] to
+//!    retain request and/or response bodies, then read them back via
+//!    [`GetData`][gd].
+//! 4. **Header injection / cache control** — apply session-level
+//!    [`SetExtraHeaders`][seh] and [`SetCacheBehavior`][scb] without
+//!    touching individual requests.
+//!
+//! See the [W3C `network` module specification][spec] for the canonical
+//! definitions, including [URL pattern matching][spec-urlpattern] (used by
+//! intercepts) and the request/response data shapes.
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#module-network
+//! [spec-urlpattern]: https://w3c.github.io/webdriver-bidi/#type-network-UrlPattern
+//! [brs]: crate::bidi::modules::network::events::BeforeRequestSent
+//! [rs]: crate::bidi::modules::network::events::ResponseStarted
+//! [rc]: crate::bidi::modules::network::events::ResponseCompleted
+//! [fe]: crate::bidi::modules::network::events::FetchError
+//! [ai]: crate::bidi::modules::network::AddIntercept
+//! [creq]: crate::bidi::modules::network::ContinueRequest
+//! [fr]: crate::bidi::modules::network::FailRequest
+//! [pr]: crate::bidi::modules::network::ProvideResponse
+//! [cresp]: crate::bidi::modules::network::ContinueResponse
+//! [cwa]: crate::bidi::modules::network::ContinueWithAuth
+//! [adc]: crate::bidi::modules::network::AddDataCollector
+//! [gd]: crate::bidi::modules::network::GetData
+//! [seh]: crate::bidi::modules::network::SetExtraHeaders
+//! [scb]: crate::bidi::modules::network::SetCacheBehavior
 
 use serde::{Deserialize, Serialize};
 
 use crate::bidi::BiDi;
 use crate::bidi::command::{BidiCommand, BidiEvent, Empty};
 use crate::bidi::error::BidiError;
-use crate::bidi::ids::{BrowsingContextId, InterceptId, RequestId, UserContextId};
+use crate::bidi::ids::{BrowsingContextId, CollectorId, InterceptId, RequestId, UserContextId};
 use crate::common::protocol::string_enum;
 
 string_enum! {
-    /// Phase a [`AddIntercept`] should fire on.
+    /// Phase that an [`AddIntercept`] should pause on.
+    ///
+    /// Mirrors the spec's [`network.InterceptPhase`][spec] enumeration.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-network-InterceptPhase
     pub enum InterceptPhase {
-        /// Before the request leaves the network stack.
+        /// Pause the request before it leaves the network stack. The
+        /// matching [`events::BeforeRequestSent`] event arrives with
+        /// `is_blocked = true`. Resume with [`ContinueRequest`],
+        /// abandon with [`FailRequest`], or fake a response with
+        /// [`ProvideResponse`].
         BeforeRequestSent = "beforeRequestSent",
-        /// When the response arrives, before delivery.
+        /// Pause the response when its headers arrive but before it is
+        /// delivered to the page. The matching
+        /// [`events::ResponseStarted`] event arrives with
+        /// `is_blocked = true`. Resume with [`ContinueResponse`].
         ResponseStarted = "responseStarted",
-        /// On HTTP 401 / proxy auth.
+        /// Pause on HTTP 401 / 407 challenges. The matching
+        /// [`events::AuthRequired`] event arrives with
+        /// `is_blocked = true`. Resume with [`ContinueWithAuth`].
         AuthRequired = "authRequired",
     }
 }
 
 string_enum! {
-    /// HTTP cache mode for [`SetCacheBehavior`].
+    /// HTTP cache mode for [`SetCacheBehavior`]. Mirrors the spec's
+    /// `cacheBehavior` enumeration on
+    /// [`network.setCacheBehavior`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-setCacheBehavior
     pub enum CacheBehavior {
-        /// Default — honour cache headers.
+        /// Honour cache headers (the browser's default behaviour).
         Default = "default",
-        /// Bypass cache entirely.
+        /// Bypass any in-browser cache.
         Bypass = "bypass",
     }
 }
 
-/// `network.addIntercept`.
+string_enum! {
+    /// Body kind for [`AddDataCollector::data_types`] and
+    /// [`GetData::data_type`].
+    ///
+    /// Mirrors the spec's [`network.DataType`][spec] type.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-network-DataType
+    pub enum DataType {
+        /// Request bodies.
+        Request = "request",
+        /// Response bodies.
+        Response = "response",
+    }
+}
+
+string_enum! {
+    /// Storage backing for an [`AddDataCollector`].
+    ///
+    /// Currently only `blob` is defined; the enum exists for forward
+    /// compatibility (the spec mentions a future `stream` collector
+    /// type).
+    pub enum CollectorType {
+        /// In-memory blob.
+        Blob = "blob",
+    }
+}
+
+/// [`network.addIntercept`][spec] — register an interception that pauses
+/// requests in the named phases.
+///
+/// `phases` selects which lifecycle stages will pause. `url_patterns`
+/// scopes the intercept to URLs matching any of the supplied
+/// [`network.UrlPattern`s][pattern] (string-or-object form, passed through
+/// as JSON); empty/None matches every URL. `contexts` scopes to specific
+/// top-level browsing contexts.
+///
+/// Prefer the convenience [`NetworkModule::add_intercept`] facade — it
+/// returns an [`InterceptGuard`] that auto-removes the intercept on drop.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-addIntercept
+/// [pattern]: https://w3c.github.io/webdriver-bidi/#type-network-UrlPattern
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AddIntercept {
     /// Phase(s) to intercept.
     pub phases: Vec<InterceptPhase>,
-    /// Restrict to specific browsing contexts. Empty = global.
+    /// Restrict to specific top-level browsing contexts. Empty = any.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub contexts: Vec<BrowsingContextId>,
-    /// URL match patterns. Each is a string-or-object per BiDi
-    /// `network.UrlPattern`. Pass-through as JSON.
+    /// URL match patterns. Each entry is a [`network.UrlPattern`][pattern]
+    /// JSON value (string variant: `{"type":"string","pattern":"…"}`,
+    /// object variant: `{"type":"pattern","hostname":"…",…}`).
+    ///
+    /// [pattern]: https://w3c.github.io/webdriver-bidi/#type-network-UrlPattern
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url_patterns: Option<Vec<serde_json::Value>>,
 }
@@ -54,11 +152,18 @@ impl BidiCommand for AddIntercept {
 /// Response for [`AddIntercept`].
 #[derive(Debug, Clone, Deserialize)]
 pub struct AddInterceptResult {
-    /// Server-assigned intercept id.
+    /// Server-assigned intercept id. Pass to [`RemoveIntercept`] to drop
+    /// the interception.
     pub intercept: InterceptId,
 }
 
-/// `network.removeIntercept`.
+/// [`network.removeIntercept`][spec] — drop a previously-registered
+/// intercept.
+///
+/// Already-paused requests are unaffected — only future requests stop
+/// matching. Use [`InterceptGuard`] to manage this automatically.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-removeIntercept
 #[derive(Debug, Clone, Serialize)]
 pub struct RemoveIntercept {
     /// Intercept id returned by [`AddIntercept`].
@@ -70,26 +175,43 @@ impl BidiCommand for RemoveIntercept {
     type Returns = Empty;
 }
 
-/// `network.continueRequest` — let an intercepted request proceed,
+/// [`network.continueRequest`][spec] — release a paused request,
 /// optionally with modifications.
+///
+/// Only valid for requests paused in the
+/// [`InterceptPhase::BeforeRequestSent`] phase. Each optional field
+/// overrides the corresponding part of the original request. Bytes-typed
+/// fields use the spec's [`network.BytesValue`][bytes]
+/// (`{"type":"string","value":…}` or `{"type":"base64","value":…}`).
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-continueRequest
+/// [bytes]: https://w3c.github.io/webdriver-bidi/#type-network-BytesValue
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContinueRequest {
     /// Request to continue.
     pub request: RequestId,
-    /// Override request body (BiDi `network.BytesValue`).
+    /// Override request body (BiDi [`network.BytesValue`][bytes]).
+    ///
+    /// [bytes]: https://w3c.github.io/webdriver-bidi/#type-network-BytesValue
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<serde_json::Value>,
-    /// Override cookies (BiDi `network.CookieHeader[]`).
+    /// Override cookies — array of
+    /// [`network.CookieHeader`][cookie] JSON values.
+    ///
+    /// [cookie]: https://w3c.github.io/webdriver-bidi/#type-network-CookieHeader
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cookies: Option<Vec<serde_json::Value>>,
-    /// Override headers (BiDi `network.Header[]`).
+    /// Override headers — array of
+    /// [`network.Header`][header] JSON values.
+    ///
+    /// [header]: https://w3c.github.io/webdriver-bidi/#type-network-Header
     #[serde(skip_serializing_if = "Option::is_none")]
     pub headers: Option<Vec<serde_json::Value>>,
-    /// Override HTTP method.
+    /// Override the HTTP method (e.g. `"POST"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<String>,
-    /// Override URL.
+    /// Override the request URL (must be an absolute URL).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }
@@ -99,26 +221,40 @@ impl BidiCommand for ContinueRequest {
     type Returns = Empty;
 }
 
-/// `network.continueResponse` — let an intercepted response proceed,
+/// [`network.continueResponse`][spec] — release a paused response,
 /// optionally with modifications.
+///
+/// Only valid for requests paused in
+/// [`InterceptPhase::ResponseStarted`]. The response body is delivered
+/// from the network as-is; only the status, headers, cookies, and
+/// (for an `authRequired` follow-up) credentials can be overridden.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-continueResponse
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContinueResponse {
     /// Request whose response is being continued.
     pub request: RequestId,
-    /// Override cookies.
+    /// Override cookies — array of
+    /// [`network.SetCookieHeader`][cookie] JSON values.
+    ///
+    /// [cookie]: https://w3c.github.io/webdriver-bidi/#type-network-SetCookieHeader
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cookies: Option<Vec<serde_json::Value>>,
-    /// Override credentials (basic-auth).
+    /// Override credentials (BiDi [`network.AuthCredentials`][creds]).
+    ///
+    /// [creds]: https://w3c.github.io/webdriver-bidi/#type-network-AuthCredentials
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credentials: Option<serde_json::Value>,
-    /// Override headers.
+    /// Override headers — array of [`network.Header`][header] JSON values.
+    ///
+    /// [header]: https://w3c.github.io/webdriver-bidi/#type-network-Header
     #[serde(skip_serializing_if = "Option::is_none")]
     pub headers: Option<Vec<serde_json::Value>>,
-    /// Override status reason phrase.
+    /// Override the status reason phrase (e.g. `"OK"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason_phrase: Option<String>,
-    /// Override status code.
+    /// Override the status code (e.g. `200`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_code: Option<u16>,
 }
@@ -128,36 +264,50 @@ impl BidiCommand for ContinueResponse {
     type Returns = Empty;
 }
 
-/// `network.continueWithAuth` — answer an `authRequired` intercept.
+/// [`network.continueWithAuth`][spec] — answer an `authRequired` intercept.
+///
+/// Use the [`AuthAction`] enum to pick provide-credentials, cancel the
+/// challenge, or fall back to the browser's default behaviour (which is
+/// to prompt the user).
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-continueWithAuth
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContinueWithAuth {
     /// Request to continue.
     pub request: RequestId,
-    /// Action and credentials. Use [`AuthAction`] helpers below.
+    /// Action and credentials.
     #[serde(flatten)]
     pub action: AuthAction,
 }
 
-/// Action passed to [`ContinueWithAuth`].
+/// Action variant for [`ContinueWithAuth`].
+///
+/// Mirrors the spec's `network.ContinueWithAuthCredentials` /
+/// `network.ContinueWithAuthNoCredentials` union.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "action", rename_all = "lowercase")]
 pub enum AuthAction {
-    /// Provide credentials.
+    /// Provide credentials to satisfy the challenge.
     ProvideCredentials {
         /// Credentials object.
         credentials: AuthCredentials,
     },
-    /// Cancel the auth request.
+    /// Cancel the auth request — the user-agent treats this as if the
+    /// user dismissed the dialog.
     Cancel,
-    /// Default — let the browser handle it.
+    /// Default — fall back to the browser's normal behaviour
+    /// (typically prompts the user).
     Default,
 }
 
-/// Basic-auth credentials.
+/// Basic-auth credentials. Mirrors
+/// [`network.AuthCredentials`][spec].
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-network-AuthCredentials
 #[derive(Debug, Clone, Serialize)]
 pub struct AuthCredentials {
-    /// Auth scheme (`"basic"`).
+    /// Auth scheme. The spec only defines `"password"`.
     pub r#type: String,
     /// Username.
     pub username: String,
@@ -166,10 +316,10 @@ pub struct AuthCredentials {
 }
 
 impl AuthCredentials {
-    /// Construct a basic-auth credentials object.
+    /// Construct a basic-auth ("password") credentials object.
     pub fn basic(username: impl Into<String>, password: impl Into<String>) -> Self {
         Self {
-            r#type: "basic".to_string(),
+            r#type: "password".to_string(),
             username: username.into(),
             password: password.into(),
         }
@@ -181,7 +331,12 @@ impl BidiCommand for ContinueWithAuth {
     type Returns = Empty;
 }
 
-/// `network.failRequest` — fail an intercepted request.
+/// [`network.failRequest`][spec] — fail an intercepted request.
+///
+/// Only valid in [`InterceptPhase::BeforeRequestSent`]. The page sees the
+/// request as a network error.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-failRequest
 #[derive(Debug, Clone, Serialize)]
 pub struct FailRequest {
     /// Request to fail.
@@ -193,26 +348,39 @@ impl BidiCommand for FailRequest {
     type Returns = Empty;
 }
 
-/// `network.provideResponse` — synthesize a response for an intercepted
-/// request (instead of letting it reach the network).
+/// [`network.provideResponse`][spec] — supply a synthetic response for
+/// an intercepted request (the actual network request is skipped).
+///
+/// Most useful in [`InterceptPhase::BeforeRequestSent`] for stubbing
+/// fetches in tests. The response progresses through the rest of the
+/// lifecycle as if it had come from the wire.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-provideResponse
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProvideResponse {
     /// Request to respond to.
     pub request: RequestId,
-    /// Response body (`network.BytesValue`).
+    /// Response body — a [`network.BytesValue`][bytes].
+    ///
+    /// [bytes]: https://w3c.github.io/webdriver-bidi/#type-network-BytesValue
     #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<serde_json::Value>,
-    /// Cookies.
+    /// `Set-Cookie` headers — array of
+    /// [`network.SetCookieHeader`][cookie] JSON values.
+    ///
+    /// [cookie]: https://w3c.github.io/webdriver-bidi/#type-network-SetCookieHeader
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cookies: Option<Vec<serde_json::Value>>,
-    /// Headers.
+    /// Response headers — array of [`network.Header`][header] JSON values.
+    ///
+    /// [header]: https://w3c.github.io/webdriver-bidi/#type-network-Header
     #[serde(skip_serializing_if = "Option::is_none")]
     pub headers: Option<Vec<serde_json::Value>>,
-    /// Reason phrase.
+    /// Reason phrase (e.g. `"OK"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason_phrase: Option<String>,
-    /// Status code.
+    /// Status code (defaults to `200` if omitted).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_code: Option<u16>,
 }
@@ -222,22 +390,191 @@ impl BidiCommand for ProvideResponse {
     type Returns = Empty;
 }
 
-/// `network.setCacheBehavior`.
+/// [`network.setCacheBehavior`][spec] — switch HTTP-cache behaviour
+/// globally or for specific contexts.
+///
+/// `Bypass` disables the in-browser cache for matching requests
+/// (analogous to Chrome's "Disable cache" checkbox).
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-setCacheBehavior
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetCacheBehavior {
-    /// Cache mode.
+    /// New cache mode.
     pub cache_behavior: CacheBehavior,
-    /// Restrict to specific browsing contexts. Empty = global.
+    /// Restrict to specific browsing contexts. Empty = applies as the
+    /// new default.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub contexts: Vec<BrowsingContextId>,
-    /// Restrict to specific user contexts. Empty = global.
+    /// Restrict to specific user contexts. Empty = applies as the new
+    /// default.
     #[serde(rename = "userContexts", skip_serializing_if = "Vec::is_empty")]
     pub user_contexts: Vec<UserContextId>,
 }
 
 impl BidiCommand for SetCacheBehavior {
     const METHOD: &'static str = "network.setCacheBehavior";
+    type Returns = Empty;
+}
+
+/// [`network.addDataCollector`][spec] — start retaining request and/or
+/// response bodies for later retrieval via [`GetData`].
+///
+/// `max_encoded_data_size` is a per-item byte limit; bodies that exceed
+/// it are still observed but not retained. Scope is mutually exclusive:
+/// supply at most one of `contexts` / `user_contexts`. Either matches a
+/// set of top-level traversables; an unscoped collector retains data from
+/// every navigation.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-addDataCollector
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddDataCollector {
+    /// Body kinds to retain.
+    pub data_types: Vec<DataType>,
+    /// Per-item maximum encoded size in bytes. Items larger than this
+    /// are not retained.
+    pub max_encoded_data_size: u64,
+    /// Backing storage type (defaults to [`CollectorType::Blob`]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collector_type: Option<CollectorType>,
+    /// Restrict to specific top-level browsing contexts. Mutually
+    /// exclusive with [`user_contexts`][Self::user_contexts].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// Restrict to specific user contexts. Mutually exclusive with
+    /// [`contexts`][Self::contexts].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for AddDataCollector {
+    const METHOD: &'static str = "network.addDataCollector";
+    type Returns = AddDataCollectorResult;
+}
+
+/// Response for [`AddDataCollector`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct AddDataCollectorResult {
+    /// Server-assigned collector id. Pass to [`GetData`],
+    /// [`DisownData`], or [`RemoveDataCollector`].
+    pub collector: CollectorId,
+}
+
+/// [`network.removeDataCollector`][spec] — drop a data collector and
+/// release every request's retained data for that collector.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-removeDataCollector
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoveDataCollector {
+    /// Collector id to remove.
+    pub collector: CollectorId,
+}
+
+impl BidiCommand for RemoveDataCollector {
+    const METHOD: &'static str = "network.removeDataCollector";
+    type Returns = Empty;
+}
+
+/// [`network.getData`][spec] — fetch retained body data for a request.
+///
+/// `collector` is optional: if omitted, the driver returns the data from
+/// any collector that retained it. `disown: true` releases the data
+/// after returning it (saves memory) — but requires `collector` to be
+/// supplied so the driver knows which collector to release from.
+///
+/// Errors:
+/// - `no such network collector` — `collector` references an unknown id.
+/// - `no such network data` — no collector retained body data for the
+///   `(request, data_type)` pair.
+/// - `unavailable network data` — data was retained but is no longer
+///   available (typically because it exceeded `max_encoded_data_size`).
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-getData
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetData {
+    /// Body kind to retrieve.
+    pub data_type: DataType,
+    /// Request to look up.
+    pub request: RequestId,
+    /// Restrict to a specific collector.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collector: Option<CollectorId>,
+    /// If `true`, release the data after fetching (requires
+    /// `collector`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disown: Option<bool>,
+}
+
+impl BidiCommand for GetData {
+    const METHOD: &'static str = "network.getData";
+    type Returns = GetDataResult;
+}
+
+/// Response for [`GetData`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetDataResult {
+    /// Body payload as a [`network.BytesValue`][spec]
+    /// (`{"type":"string","value":…}` or
+    /// `{"type":"base64","value":…}`).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-network-BytesValue
+    pub bytes: serde_json::Value,
+}
+
+/// [`network.disownData`][spec] — release retained body data for one
+/// collector without removing the collector itself.
+///
+/// Useful when you want to keep collecting future data but explicitly
+/// drop one captured request's payload.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-disownData
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisownData {
+    /// Body kind to release.
+    pub data_type: DataType,
+    /// Collector to disown for.
+    pub collector: CollectorId,
+    /// Request to release data for.
+    pub request: RequestId,
+}
+
+impl BidiCommand for DisownData {
+    const METHOD: &'static str = "network.disownData";
+    type Returns = Empty;
+}
+
+/// [`network.setExtraHeaders`][spec] — install headers that the driver
+/// adds to every outgoing request (overwriting matching headers).
+///
+/// Scope:
+/// - No `contexts` / `user_contexts` → set the default extra headers.
+/// - `contexts` → scope to those top-level traversables.
+/// - `user_contexts` → scope to those user contexts.
+///
+/// `contexts` and `user_contexts` are mutually exclusive.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-setExtraHeaders
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetExtraHeaders {
+    /// Headers to install. Each entry is a [`network.Header`][header]
+    /// JSON value (`{"name":"…","value":{"type":"string","value":"…"}}`).
+    ///
+    /// [header]: https://w3c.github.io/webdriver-bidi/#type-network-Header
+    pub headers: Vec<serde_json::Value>,
+    /// Restrict to these top-level browsing contexts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contexts: Option<Vec<BrowsingContextId>>,
+    /// Restrict to these user contexts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_contexts: Option<Vec<UserContextId>>,
+}
+
+impl BidiCommand for SetExtraHeaders {
+    const METHOD: &'static str = "network.setExtraHeaders";
     type Returns = Empty;
 }
 
@@ -249,23 +586,34 @@ impl BidiCommand for SetCacheBehavior {
 pub(crate) mod events {
     use super::*;
 
-    /// `network.beforeRequestSent`.
+    /// [`network.beforeRequestSent`][spec] — fires just before a request
+    /// leaves the network stack.
+    ///
+    /// If `is_blocked` is `true`, an intercept paused the request — call
+    /// [`ContinueRequest`], [`FailRequest`], or [`ProvideResponse`] with
+    /// `request.id`.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-network-beforeRequestSent
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct BeforeRequestSent {
-        /// Browsing context the request belongs to (top-level for nav).
+        /// Browsing context the request belongs to. `None` for requests
+        /// without an associated navigable (e.g. service workers).
         pub context: Option<BrowsingContextId>,
-        /// Underlying request data (BiDi `network.RequestData`).
+        /// Underlying request data.
         pub request: RequestData,
         /// Driver timestamp (ms since epoch).
         pub timestamp: u64,
-        /// Optional initiator info.
+        /// Optional initiator info ([`network.Initiator`][init]).
+        ///
+        /// [init]: https://w3c.github.io/webdriver-bidi/#type-network-Initiator
         #[serde(default)]
         pub initiator: Option<serde_json::Value>,
         /// Whether the request is currently blocked by an intercept.
         #[serde(default)]
         pub is_blocked: bool,
-        /// Intercept ids that match this request.
+        /// Intercept ids that match this request (only populated when
+        /// `is_blocked` is `true`).
         #[serde(default)]
         pub intercepts: Vec<InterceptId>,
     }
@@ -274,7 +622,13 @@ pub(crate) mod events {
         const METHOD: &'static str = "network.beforeRequestSent";
     }
 
-    /// `network.responseStarted`.
+    /// [`network.responseStarted`][spec] — fires when response headers
+    /// arrive but before the body is delivered.
+    ///
+    /// If `is_blocked` is `true`, an intercept paused the response —
+    /// call [`ContinueResponse`] with `request.id`.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-network-responseStarted
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct ResponseStarted {
@@ -282,11 +636,11 @@ pub(crate) mod events {
         pub context: Option<BrowsingContextId>,
         /// Request data.
         pub request: RequestData,
-        /// Response data.
+        /// Response data (headers, status, …).
         pub response: ResponseData,
         /// Driver timestamp.
         pub timestamp: u64,
-        /// Whether currently blocked by an intercept.
+        /// Whether the response is currently blocked by an intercept.
         #[serde(default)]
         pub is_blocked: bool,
         /// Intercept ids that match this response.
@@ -298,7 +652,10 @@ pub(crate) mod events {
         const METHOD: &'static str = "network.responseStarted";
     }
 
-    /// `network.responseCompleted`.
+    /// [`network.responseCompleted`][spec] — fires when the response is
+    /// fully received (or the request is cancelled).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-network-responseCompleted
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct ResponseCompleted {
@@ -316,7 +673,10 @@ pub(crate) mod events {
         const METHOD: &'static str = "network.responseCompleted";
     }
 
-    /// `network.fetchError`.
+    /// [`network.fetchError`][spec] — fires when a request fails before
+    /// completing (network error, DNS failure, blocked by extension, …).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-network-fetchError
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct FetchError {
@@ -326,7 +686,7 @@ pub(crate) mod events {
         pub request: RequestData,
         /// Driver timestamp.
         pub timestamp: u64,
-        /// Error string (browser-defined).
+        /// Browser-defined error text.
         pub error_text: String,
     }
 
@@ -334,7 +694,11 @@ pub(crate) mod events {
         const METHOD: &'static str = "network.fetchError";
     }
 
-    /// `network.authRequired`.
+    /// [`network.authRequired`][spec] — fires on an HTTP 401 / 407
+    /// challenge. Pair with [`ContinueWithAuth`] when an
+    /// [`InterceptPhase::AuthRequired`] intercept matches.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-network-authRequired
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct AuthRequired {
@@ -342,11 +706,12 @@ pub(crate) mod events {
         pub context: Option<BrowsingContextId>,
         /// Request data.
         pub request: RequestData,
-        /// Response data (status will be 401 / 407).
+        /// Response data (status will be 401 or 407; `authChallenges` is
+        /// populated).
         pub response: ResponseData,
         /// Driver timestamp.
         pub timestamp: u64,
-        /// Whether currently blocked by an intercept.
+        /// Whether the response is currently blocked by an intercept.
         #[serde(default)]
         pub is_blocked: bool,
     }
@@ -360,32 +725,47 @@ pub(crate) mod events {
 // Wire-shape types reused by events.
 // ---------------------------------------------------------------------------
 
-/// Subset of BiDi's `network.RequestData` we model strongly. Vendor or
-/// rarely-used fields fall through to [`RequestData::extra`].
+/// Strongly-typed subset of BiDi's [`network.RequestData`][spec].
+///
+/// Vendor-specific or rarely-used fields (timing breakdown, body size,
+/// destination, initiator type, …) flow through into
+/// [`RequestData::extra`]. Strongly-typed extras can be added later
+/// without breaking the wire shape.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-network-RequestData
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RequestData {
     /// Request id. The BiDi wire shape names this field `request` — we
-    /// rename it to `id` so the typical access pattern is
-    /// `event.request.id` rather than the awkward `event.request.request`.
+    /// rename it to `id` so callers can write
+    /// `event.request.id` instead of the doubly-nested
+    /// `event.request.request`.
     #[serde(rename = "request")]
     pub id: RequestId,
-    /// HTTP method.
+    /// HTTP method (`"GET"`, `"POST"`, …).
     pub method: String,
-    /// Full URL.
+    /// Full request URL.
     pub url: String,
-    /// Headers (`network.Header[]`).
+    /// Headers — array of [`network.Header`][hdr].
+    ///
+    /// [hdr]: https://w3c.github.io/webdriver-bidi/#type-network-Header
     #[serde(default)]
     pub headers: Vec<serde_json::Value>,
-    /// Cookies sent on the request.
+    /// Cookies sent on the request — array of
+    /// [`network.Cookie`][cookie].
+    ///
+    /// [cookie]: https://w3c.github.io/webdriver-bidi/#type-network-Cookie
     #[serde(default)]
     pub cookies: Vec<serde_json::Value>,
-    /// Other fields (timing, body size, …).
+    /// Other fields from the wire shape (timing, body size, destination,
+    /// initiator type, …).
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
-/// Subset of BiDi's `network.ResponseData` we model strongly.
+/// Strongly-typed subset of BiDi's [`network.ResponseData`][spec].
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-network-ResponseData
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResponseData {
@@ -398,10 +778,13 @@ pub struct ResponseData {
     pub status: u16,
     /// Status reason phrase.
     pub status_text: String,
-    /// Headers.
+    /// Headers — array of [`network.Header`][hdr].
+    ///
+    /// [hdr]: https://w3c.github.io/webdriver-bidi/#type-network-Header
     #[serde(default)]
     pub headers: Vec<serde_json::Value>,
-    /// Other fields (mime type, encoding, …).
+    /// Other fields from the wire shape (mime type, encoded vs decoded
+    /// size, `authChallenges`, …).
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
 }
@@ -410,10 +793,13 @@ pub struct ResponseData {
 ///
 /// Returned by [`NetworkModule::add_intercept`]. Holds the
 /// [`InterceptId`] so you can pass it explicitly to
-/// `bidi.network().remove_intercept(...)` or call [`Self::remove`]
+/// [`NetworkModule::remove_intercept`] or call [`Self::remove`]
 /// directly. If the guard is dropped without calling `remove`, a
-/// best-effort `network.removeIntercept` is scheduled on the current
-/// tokio runtime (errors are swallowed — this is just a safety net).
+/// best-effort `network.removeIntercept` is spawned on the current
+/// tokio runtime — errors are swallowed because this is a safety net,
+/// not a primary cleanup path.
+///
+/// Prefer the explicit `.remove().await` form when you want errors.
 #[derive(Debug)]
 pub struct InterceptGuard {
     bidi: BiDi,
@@ -469,7 +855,12 @@ impl Drop for InterceptGuard {
     }
 }
 
-/// Module facade returned by [`BiDi::network`].
+/// Convenience facade for the `network.*` module.
+///
+/// Returned by [`BiDi::network`](crate::bidi::BiDi::network). For
+/// scoped variants of these commands (per-context cache mode, scoped
+/// data collectors, scoped extra headers) build the command struct
+/// directly and send it via [`BiDi::send`](crate::bidi::BiDi::send).
 #[derive(Debug)]
 pub struct NetworkModule<'a> {
     bidi: &'a BiDi,
@@ -482,12 +873,14 @@ impl<'a> NetworkModule<'a> {
         }
     }
 
-    /// `network.addIntercept` — register an intercept and return an
-    /// [`InterceptGuard`].
+    /// Register a global intercept and return an [`InterceptGuard`].
     ///
-    /// Call [`InterceptGuard::remove`] when you're done. Letting the guard
-    /// drop also schedules a best-effort `network.removeIntercept` on the
-    /// current tokio runtime (errors are swallowed).
+    /// Wraps [`network.addIntercept`][spec]. The returned guard removes
+    /// the intercept on drop (best-effort; spawned on the current tokio
+    /// runtime); call [`InterceptGuard::remove`] for explicit error
+    /// handling.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-addIntercept
     pub async fn add_intercept(
         &self,
         phases: Vec<InterceptPhase>,
@@ -504,7 +897,9 @@ impl<'a> NetworkModule<'a> {
         Ok(InterceptGuard::new(self.bidi.clone(), result.intercept))
     }
 
-    /// `network.removeIntercept`.
+    /// Drop an intercept by id via [`network.removeIntercept`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-removeIntercept
     pub async fn remove_intercept(&self, intercept: InterceptId) -> Result<(), BidiError> {
         self.bidi
             .send(RemoveIntercept {
@@ -514,7 +909,13 @@ impl<'a> NetworkModule<'a> {
         Ok(())
     }
 
-    /// `network.continueRequest` (no modifications).
+    /// Release a paused request unmodified via
+    /// [`network.continueRequest`][spec].
+    ///
+    /// To modify the request first (rewrite URL, headers, body), build a
+    /// [`ContinueRequest`] struct directly.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-continueRequest
     pub async fn continue_request(&self, request: RequestId) -> Result<(), BidiError> {
         self.bidi
             .send(ContinueRequest {
@@ -529,7 +930,10 @@ impl<'a> NetworkModule<'a> {
         Ok(())
     }
 
-    /// `network.continueResponse` (no modifications).
+    /// Release a paused response unmodified via
+    /// [`network.continueResponse`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-continueResponse
     pub async fn continue_response(&self, request: RequestId) -> Result<(), BidiError> {
         self.bidi
             .send(ContinueResponse {
@@ -544,7 +948,9 @@ impl<'a> NetworkModule<'a> {
         Ok(())
     }
 
-    /// `network.failRequest`.
+    /// Fail a paused request via [`network.failRequest`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-failRequest
     pub async fn fail_request(&self, request: RequestId) -> Result<(), BidiError> {
         self.bidi
             .send(FailRequest {
@@ -554,13 +960,110 @@ impl<'a> NetworkModule<'a> {
         Ok(())
     }
 
-    /// `network.setCacheBehavior` — global.
+    /// Set the global cache mode via [`network.setCacheBehavior`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-setCacheBehavior
     pub async fn set_cache_behavior(&self, mode: CacheBehavior) -> Result<(), BidiError> {
         self.bidi
             .send(SetCacheBehavior {
                 cache_behavior: mode,
                 contexts: vec![],
                 user_contexts: vec![],
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Register a global data collector via
+    /// [`network.addDataCollector`][spec]. Pair with [`get_data`](Self::get_data).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-addDataCollector
+    pub async fn add_data_collector(
+        &self,
+        data_types: Vec<DataType>,
+        max_encoded_data_size: u64,
+    ) -> Result<AddDataCollectorResult, BidiError> {
+        self.bidi
+            .send(AddDataCollector {
+                data_types,
+                max_encoded_data_size,
+                collector_type: None,
+                contexts: None,
+                user_contexts: None,
+            })
+            .await
+    }
+
+    /// Drop a data collector via [`network.removeDataCollector`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-removeDataCollector
+    pub async fn remove_data_collector(&self, collector: CollectorId) -> Result<(), BidiError> {
+        self.bidi
+            .send(RemoveDataCollector {
+                collector,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Fetch retained body data for `request` via
+    /// [`network.getData`][spec].
+    ///
+    /// To restrict the lookup to one collector or to disown after read,
+    /// build the [`GetData`] struct directly.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-getData
+    pub async fn get_data(
+        &self,
+        data_type: DataType,
+        request: RequestId,
+    ) -> Result<GetDataResult, BidiError> {
+        self.bidi
+            .send(GetData {
+                data_type,
+                request,
+                collector: None,
+                disown: None,
+            })
+            .await
+    }
+
+    /// Release retained data for one collector via
+    /// [`network.disownData`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-disownData
+    pub async fn disown_data(
+        &self,
+        data_type: DataType,
+        collector: CollectorId,
+        request: RequestId,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(DisownData {
+                data_type,
+                collector,
+                request,
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Apply extra request headers globally via
+    /// [`network.setExtraHeaders`][spec].
+    ///
+    /// To scope to specific contexts/user-contexts build a
+    /// [`SetExtraHeaders`] struct directly.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-network-setExtraHeaders
+    pub async fn set_extra_headers(
+        &self,
+        headers: Vec<serde_json::Value>,
+    ) -> Result<(), BidiError> {
+        self.bidi
+            .send(SetExtraHeaders {
+                headers,
+                contexts: None,
+                user_contexts: None,
             })
             .await?;
         Ok(())

--- a/thirtyfour/src/bidi/modules/permissions.rs
+++ b/thirtyfour/src/bidi/modules/permissions.rs
@@ -1,4 +1,13 @@
-//! `permissions.*` BiDi module — `setPermission`.
+//! `permissions.*` — grant, deny, or reset a [Permissions API][permapi]
+//! permission for a given origin.
+//!
+//! Defined by the [W3C Permissions specification's WebDriver-BiDi
+//! extension][spec] (a separate document from the core BiDi spec). Driver
+//! support is uneven — Chromium supports it; geckodriver currently
+//! returns `unknown command`.
+//!
+//! [permapi]: https://www.w3.org/TR/permissions/
+//! [spec]: https://w3c.github.io/permissions/#webdriver-bidi-extension
 
 use serde::Serialize;
 
@@ -9,31 +18,42 @@ use crate::bidi::ids::UserContextId;
 use crate::common::protocol::string_enum;
 
 string_enum! {
-    /// Permission state for [`SetPermission`].
+    /// Target state for [`SetPermission::state`]. Mirrors the spec's
+    /// `permissions.PermissionState` enumeration.
     pub enum PermissionState {
-        /// Allow.
+        /// Allow the permission without prompting.
         Granted = "granted",
-        /// Deny.
+        /// Deny the permission without prompting.
         Denied = "denied",
-        /// Reset to default ("ask").
+        /// Reset to default ("ask the user").
         Prompt = "prompt",
     }
 }
 
-/// `permissions.setPermission`.
+/// [`permissions.setPermission`][spec] — set the state of a permission
+/// for a given origin.
+///
+/// `descriptor` is a [Permissions API descriptor][descriptor] —
+/// typically `{"name": "<name>"}` for a basic permission, or with
+/// extra fields for permissions like `"push"` or `"midi"`.
+///
+/// [spec]: https://w3c.github.io/permissions/#webdriver-bidi-command-permissions-setPermission
+/// [descriptor]: https://www.w3.org/TR/permissions/#permission-descriptor
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetPermission {
-    /// Permission descriptor (`{"name":"geolocation"}`, etc.) — see
-    /// [Permissions API].
+    /// Permission descriptor, e.g. `{"name":"geolocation"}`,
+    /// `{"name":"midi","sysex":true}`. See [Permissions API].
     ///
     /// [Permissions API]: https://www.w3.org/TR/permissions/#permission-descriptor
     pub descriptor: serde_json::Value,
-    /// New state.
+    /// Target state.
     pub state: PermissionState,
-    /// Origin string (e.g. `"https://example.com"`).
+    /// Origin string (e.g. `"https://example.com"`). Must be an ASCII
+    /// serialised origin — paths and trailing slashes are not allowed.
     pub origin: String,
-    /// Restrict to a user context.
+    /// Restrict the change to a specific user context. `None` applies
+    /// to the default user context.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_context: Option<UserContextId>,
 }
@@ -43,7 +63,12 @@ impl BidiCommand for SetPermission {
     type Returns = Empty;
 }
 
-/// Module facade returned by [`BiDi::permissions`].
+/// Convenience facade for the `permissions.*` module.
+///
+/// Returned by [`BiDi::permissions`](crate::bidi::BiDi::permissions). To
+/// scope the change to a non-default user context, build a
+/// [`SetPermission`] struct directly and supply
+/// [`user_context`][SetPermission::user_context].
 #[derive(Debug)]
 pub struct PermissionsModule<'a> {
     bidi: &'a BiDi,
@@ -56,7 +81,14 @@ impl<'a> PermissionsModule<'a> {
         }
     }
 
-    /// `permissions.setPermission`.
+    /// Set a permission for `origin` to `state` via
+    /// [`permissions.setPermission`][spec].
+    ///
+    /// `descriptor` is a [Permissions API descriptor][desc] JSON object
+    /// (`{"name":"geolocation"}`, etc.).
+    ///
+    /// [spec]: https://w3c.github.io/permissions/#webdriver-bidi-command-permissions-setPermission
+    /// [desc]: https://www.w3.org/TR/permissions/#permission-descriptor
     pub async fn set_permission(
         &self,
         descriptor: serde_json::Value,

--- a/thirtyfour/src/bidi/modules/script.rs
+++ b/thirtyfour/src/bidi/modules/script.rs
@@ -1,9 +1,40 @@
-//! `script.*` BiDi module — `evaluate`, `callFunction`, preload scripts, realms.
+//! `script.*` — execute JavaScript, manage preload scripts, observe realms.
 //!
-//! Remote-object trees in BiDi (`RemoteValue`) are deeply recursive and
-//! mostly used as opaque round-trip data: this module exposes them as
-//! [`serde_json::Value`] so users don't pay an upfront serde cost, and can
-//! deserialize themselves if/when they want to.
+//! BiDi's script module is the bidirectional successor to WebDriver
+//! Classic's `Execute Script` endpoint. It can:
+//!
+//! - Run an expression ([`Evaluate`][ev]) or call a function with
+//!   arguments ([`CallFunction`][cf]) in any [`script.Realm`][realm-spec].
+//! - Install preload scripts ([`AddPreloadScript`][aps]) that run at
+//!   document-start of every navigation, including in iframes.
+//! - Enumerate realms ([`GetRealms`][gr]) and observe their lifecycle
+//!   ([`RealmCreated`][rc], [`RealmDestroyed`][rd]).
+//! - Receive messages from preload-script channels ([`Message`][msg]).
+//! - Release retained references to remote objects ([`Disown`][dis]).
+//!
+//! The spec models JavaScript values as a deeply-recursive
+//! [`script.RemoteValue`][remotevalue-spec] tree. To keep the Rust API
+//! ergonomic this module exposes those values as [`serde_json::Value`]
+//! — round-trip them as-is, or destructure with serde when you need
+//! them strongly typed. Arguments to [`CallFunction`][cf] follow the
+//! sibling [`script.LocalValue`][localvalue-spec] shape.
+//!
+//! [ev]: crate::bidi::modules::script::Evaluate
+//! [cf]: crate::bidi::modules::script::CallFunction
+//! [aps]: crate::bidi::modules::script::AddPreloadScript
+//! [gr]: crate::bidi::modules::script::GetRealms
+//! [rc]: crate::bidi::modules::script::events::RealmCreated
+//! [rd]: crate::bidi::modules::script::events::RealmDestroyed
+//! [msg]: crate::bidi::modules::script::events::Message
+//! [dis]: crate::bidi::modules::script::Disown
+//!
+//! See the [W3C `script` module specification][spec] for the canonical
+//! definitions.
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#module-script
+//! [realm-spec]: https://w3c.github.io/webdriver-bidi/#type-script-Realm
+//! [remotevalue-spec]: https://w3c.github.io/webdriver-bidi/#type-script-RemoteValue
+//! [localvalue-spec]: https://w3c.github.io/webdriver-bidi/#type-script-LocalValue
 
 use serde::{Deserialize, Serialize};
 
@@ -14,51 +45,69 @@ use crate::bidi::ids::{BrowsingContextId, ChannelId, PreloadScriptId, RealmId};
 use crate::common::protocol::string_enum;
 
 string_enum! {
-    /// Mode controlling how `evaluate` / `callFunction` resolve return-value
-    /// references.
+    /// Result-ownership mode for [`Evaluate`] / [`CallFunction`]. Mirrors
+    /// the spec's [`script.ResultOwnership`][spec] type.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-ResultOwnership
     pub enum ResultOwnership {
-        /// Return references owned by the calling realm; release explicitly
-        /// via `script.disown`.
+        /// Retain the returned object reference; release it later via
+        /// [`Disown`].
         Root = "root",
-        /// Drop references as soon as the response is delivered.
+        /// Drop the reference as soon as the response is delivered
+        /// (default).
         None = "none",
     }
 }
 
-/// `script.Target` — addressing a script realm.
+/// Target realm or context for [`Evaluate`] / [`CallFunction`] /
+/// [`Disown`]. Mirrors the spec's [`script.Target`][spec] union.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-Target
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum Target {
-    /// Address by realm id (most precise; survives navigations).
+    /// Address by realm id (most precise; survives same-origin navigations).
     Realm {
         /// Realm to evaluate in.
         realm: RealmId,
     },
-    /// Address by browsing-context id; the driver picks the active realm.
+    /// Address by browsing-context id; the driver picks the active
+    /// realm. Optional `sandbox` selects a named isolated realm
+    /// instead.
     Context {
         /// Browsing context to evaluate in.
         context: BrowsingContextId,
-        /// Optional sandbox name. Each `(context, sandbox)` is its own realm.
+        /// Optional sandbox name. Each `(context, sandbox)` pair lives
+        /// in its own realm, isolated from the page's main world.
         #[serde(skip_serializing_if = "Option::is_none")]
         sandbox: Option<String>,
     },
 }
 
-/// `script.evaluate`.
+/// [`script.evaluate`][spec] — run a JavaScript expression in a realm.
+///
+/// `expression` is parsed as a JavaScript expression (NOT a script). To
+/// `await` a top-level promise, set [`await_promise`][Self::await_promise]
+/// — the wire-level `expression` then runs inside the BiDi runtime's
+/// implicit `async`.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-script-evaluate
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Evaluate {
-    /// Source code to evaluate. May contain `await` if `awaitPromise: true`.
+    /// Expression source.
     pub expression: String,
     /// Realm or context to evaluate in.
     pub target: Target,
-    /// If true, await any returned promise before resolving.
+    /// If `true`, await any returned promise before resolving.
     pub await_promise: bool,
-    /// Whether the result reference should be retained.
+    /// Whether to retain the result reference. Defaults to
+    /// [`ResultOwnership::None`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result_ownership: Option<ResultOwnership>,
-    /// If true, treat the call as a user activation (allows
-    /// `Document.requestStorageAccess()`, etc.).
+    /// If `true`, treat the call as a user activation — gates APIs
+    /// like `Document.requestStorageAccess()` and pop-ups behind a
+    /// real user gesture.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_activation: Option<bool>,
 }
@@ -68,11 +117,11 @@ impl BidiCommand for Evaluate {
     type Returns = EvaluateResult;
 }
 
-/// Response for [`Evaluate`] / [`CallFunction`].
+/// Result of [`Evaluate`] / [`CallFunction`]. Mirrors the spec's
+/// [`script.EvaluateResult`][spec] union — either a successful return
+/// value or an exception.
 ///
-/// The driver returns one of two shapes — success (with `result`) or
-/// exception (with `exceptionDetails`). Modeled here as a tagged enum on
-/// `type`.
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-EvaluateResult
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum EvaluateResult {
@@ -80,21 +129,27 @@ pub enum EvaluateResult {
     Success {
         /// Realm the value lives in.
         realm: RealmId,
-        /// Returned value (BiDi `RemoteValue`).
+        /// Returned value as a [`script.RemoteValue`][spec] JSON tree.
+        ///
+        /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-RemoteValue
         result: serde_json::Value,
     },
     /// Threw an exception.
     Exception {
         /// Realm the throw happened in.
         realm: RealmId,
-        /// Exception details (BiDi `ExceptionDetails`).
+        /// Exception details — a [`script.ExceptionDetails`][spec]
+        /// JSON value.
+        ///
+        /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-ExceptionDetails
         #[serde(rename = "exceptionDetails")]
         exception_details: serde_json::Value,
     },
 }
 
 impl EvaluateResult {
-    /// Borrow the `result` value if this is a success, else `None`.
+    /// Borrow the `result` value if this is a [`Success`][Self::Success],
+    /// else `None`.
     pub fn ok_value(&self) -> Option<&serde_json::Value> {
         match self {
             EvaluateResult::Success {
@@ -111,26 +166,47 @@ impl EvaluateResult {
     }
 }
 
-/// `script.callFunction`.
+/// [`script.callFunction`][spec] — call a JavaScript function with
+/// arguments and a `this` binding.
+///
+/// `function_declaration` is the source of a function expression:
+///
+/// ```js
+/// function (a, b) { return a + b; }
+/// // or
+/// (a, b) => a + b
+/// ```
+///
+/// Arguments are passed as [`script.LocalValue`][local] JSON values
+/// (primitive shape: `{"type":"number","value":1}`,
+/// `{"type":"string","value":"hi"}`, etc.). Use
+/// [`this`][Self::this] to set the `this` binding.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-script-callFunction
+/// [local]: https://w3c.github.io/webdriver-bidi/#type-script-LocalValue
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallFunction {
-    /// Function-source string. Receives `this` and arguments per BiDi semantics.
+    /// Function-source string (a function expression or arrow function).
     pub function_declaration: String,
-    /// If true, await any returned promise before resolving.
+    /// If `true`, await any returned promise before resolving.
     pub await_promise: bool,
     /// Realm or context to call in.
     pub target: Target,
-    /// Arguments passed to the function (BiDi `LocalValue` JSON).
+    /// Arguments — array of [`script.LocalValue`][local] JSON values.
+    ///
+    /// [local]: https://w3c.github.io/webdriver-bidi/#type-script-LocalValue
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub arguments: Vec<serde_json::Value>,
-    /// Optional `this` reference (BiDi `LocalValue` JSON).
+    /// Optional `this` reference (a [`script.LocalValue`][local]).
+    ///
+    /// [local]: https://w3c.github.io/webdriver-bidi/#type-script-LocalValue
     #[serde(skip_serializing_if = "Option::is_none")]
     pub this: Option<serde_json::Value>,
-    /// Whether the result reference should be retained.
+    /// Whether to retain the result reference.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result_ownership: Option<ResultOwnership>,
-    /// If true, treat the call as a user activation.
+    /// If `true`, treat the call as a user activation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_activation: Option<bool>,
 }
@@ -140,19 +216,30 @@ impl BidiCommand for CallFunction {
     type Returns = EvaluateResult;
 }
 
-/// `script.addPreloadScript`.
+/// [`script.addPreloadScript`][spec] — install a script that runs at
+/// document-start of every navigation in matching contexts.
+///
+/// Preload scripts run in their own (or a named-`sandbox`) isolated
+/// realm. They can take arguments — most commonly a
+/// [`script.ChannelValue`][channel] which the page can post messages
+/// through, surfacing as [`events::Message`].
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-script-addPreloadScript
+/// [channel]: https://w3c.github.io/webdriver-bidi/#type-script-ChannelValue
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AddPreloadScript {
-    /// Function source — runs at document-start of every navigation.
+    /// Function-source string (`(channel) => { … }`).
     pub function_declaration: String,
-    /// Optional list of `LocalValue` arguments to pass.
+    /// Arguments — usually one or more channel values.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub arguments: Vec<serde_json::Value>,
-    /// Optional sandbox name (creates an isolated realm).
+    /// Optional sandbox name (creates an isolated realm shared with
+    /// `script.callFunction(target: Context { sandbox: Some(…) })`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<String>,
-    /// Restrict to specific contexts. Empty / omitted = global.
+    /// Restrict to specific top-level browsing contexts. Empty = every
+    /// context.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub contexts: Vec<BrowsingContextId>,
 }
@@ -169,7 +256,12 @@ pub struct AddPreloadScriptResult {
     pub script: PreloadScriptId,
 }
 
-/// `script.removePreloadScript`.
+/// [`script.removePreloadScript`][spec] — uninstall a preload script.
+///
+/// Already-running scripts in active realms are not affected; only
+/// future navigations stop applying it.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-script-removePreloadScript
 #[derive(Debug, Clone, Serialize)]
 pub struct RemovePreloadScript {
     /// Id returned by [`AddPreloadScript`].
@@ -181,16 +273,20 @@ impl BidiCommand for RemovePreloadScript {
     type Returns = Empty;
 }
 
-/// `script.getRealms`.
+/// [`script.getRealms`][spec] — list active realms, optionally filtered.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-script-getRealms
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetRealms {
     /// Restrict to a single browsing context.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<BrowsingContextId>,
-    /// Restrict to a realm type. See spec for valid strings (`window`,
-    /// `dedicated-worker`, `shared-worker`, `service-worker`, `worker`,
-    /// `paint-worklet`, `audio-worklet`, `worklet`).
+    /// Restrict to a [realm type][spec]: `"window"`, `"dedicated-worker"`,
+    /// `"shared-worker"`, `"service-worker"`, `"worker"`,
+    /// `"paint-worklet"`, `"audio-worklet"`, or `"worklet"`.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-RealmType
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
 }
@@ -203,37 +299,50 @@ impl BidiCommand for GetRealms {
 /// Response for [`GetRealms`].
 #[derive(Debug, Clone, Deserialize)]
 pub struct GetRealmsResult {
-    /// Discovered realms.
+    /// All realms matching the filter (or every realm if unfiltered).
     pub realms: Vec<RealmInfo>,
 }
 
-/// Info for a single realm. Modeled as the spec's discriminated union over
-/// `type`; the rest of the fields vary by type, so non-essential fields are
-/// captured into [`RealmInfo::extra`].
+/// Information about a single realm. Mirrors the spec's
+/// [`script.RealmInfo`][spec] discriminated union.
+///
+/// Type-specific fields (e.g. `sandbox` for window realms, `owners` for
+/// worker realms) are flattened into [`extra`][Self::extra].
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-RealmInfo
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RealmInfo {
     /// Realm id.
     pub realm: RealmId,
-    /// Origin string.
+    /// Origin string (`"https://example.com"`, `"null"`, …).
     pub origin: String,
-    /// Realm type (`"window"`, `"worker"`, …).
+    /// Realm type (`"window"`, `"dedicated-worker"`, …).
     #[serde(rename = "type")]
     pub realm_type: String,
     /// Browsing context for window-type realms.
     #[serde(default)]
     pub context: Option<BrowsingContextId>,
-    /// Other fields (e.g. `sandbox`, `owners`) flattened into a JSON map.
+    /// Other type-specific fields.
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
-/// `script.disown` — drop references to remote objects.
+/// [`script.disown`][spec] — release retained object references.
+///
+/// Only meaningful for evaluations that used
+/// [`ResultOwnership::Root`] — without that, references are released
+/// automatically.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-script-disown
 #[derive(Debug, Clone, Serialize)]
 pub struct Disown {
-    /// Object handles to disown.
+    /// Object handles to disown (the `handle` field on each
+    /// [`script.RemoteValue`][spec]).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-script-RemoteValue
     pub handles: Vec<String>,
-    /// Realm or context to disown in.
+    /// Realm or context where the handles live.
     pub target: Target,
 }
 
@@ -250,7 +359,10 @@ impl BidiCommand for Disown {
 pub(crate) mod events {
     use super::*;
 
-    /// `script.realmCreated`.
+    /// [`script.realmCreated`][spec] — fires when a new realm becomes
+    /// available (page navigation, worker startup, …).
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-script-realmCreated
     #[derive(Debug, Clone, Deserialize)]
     pub struct RealmCreated(pub RealmInfo);
 
@@ -258,7 +370,9 @@ pub(crate) mod events {
         const METHOD: &'static str = "script.realmCreated";
     }
 
-    /// `script.realmDestroyed`.
+    /// [`script.realmDestroyed`][spec] — fires when a realm is torn down.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-script-realmDestroyed
     #[derive(Debug, Clone, Deserialize)]
     pub struct RealmDestroyed {
         /// Realm that was destroyed.
@@ -269,15 +383,27 @@ pub(crate) mod events {
         const METHOD: &'static str = "script.realmDestroyed";
     }
 
-    /// `script.message`. Posted from preload-script-installed channels via
-    /// the function `channel(...)` argument.
+    /// [`script.message`][spec] — a preload-script channel posted a
+    /// message.
+    ///
+    /// Channels are created by passing a
+    /// [`script.ChannelValue`][channel] argument to
+    /// [`AddPreloadScript`]; the script can then post arbitrary
+    /// messages back through it.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#event-script-message
+    /// [channel]: https://w3c.github.io/webdriver-bidi/#type-script-ChannelValue
     #[derive(Debug, Clone, Deserialize)]
     pub struct Message {
         /// Channel id the message was sent on.
         pub channel: ChannelId,
-        /// Payload (`RemoteValue`).
+        /// Payload — a [`script.RemoteValue`][rv] JSON value.
+        ///
+        /// [rv]: https://w3c.github.io/webdriver-bidi/#type-script-RemoteValue
         pub data: serde_json::Value,
-        /// Source realm.
+        /// Source realm — a [`script.Source`][src] JSON value.
+        ///
+        /// [src]: https://w3c.github.io/webdriver-bidi/#type-script-Source
         pub source: serde_json::Value,
     }
 
@@ -286,7 +412,13 @@ pub(crate) mod events {
     }
 }
 
-/// Module facade returned by [`BiDi::script`].
+/// Convenience facade for the `script.*` module.
+///
+/// Returned by [`BiDi::script`](crate::bidi::BiDi::script). The methods
+/// here cover the common forms of each command (no-argument call, no
+/// sandbox, default ownership). For sandboxed evaluation, custom
+/// arguments, retained references, or user-activation gating, build the
+/// command struct directly.
 #[derive(Debug)]
 pub struct ScriptModule<'a> {
     bidi: &'a BiDi,
@@ -299,8 +431,13 @@ impl<'a> ScriptModule<'a> {
         }
     }
 
-    /// `script.evaluate` — convenience: synchronous expression in the active
-    /// realm of `context`.
+    /// Run a JavaScript expression in `context`'s default realm via
+    /// [`script.evaluate`][spec].
+    ///
+    /// Set `await_promise` if the expression resolves to a promise you
+    /// want awaited.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-script-evaluate
     pub async fn evaluate(
         &self,
         context: BrowsingContextId,
@@ -321,8 +458,13 @@ impl<'a> ScriptModule<'a> {
             .await
     }
 
-    /// `script.callFunction` — convenience: call a function declaration in
-    /// `context` with no arguments.
+    /// Call a function in `context`'s default realm with no arguments
+    /// via [`script.callFunction`][spec].
+    ///
+    /// `function_declaration` is a function expression source string —
+    /// see [`CallFunction`].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-script-callFunction
     pub async fn call_function(
         &self,
         context: BrowsingContextId,
@@ -345,7 +487,13 @@ impl<'a> ScriptModule<'a> {
             .await
     }
 
-    /// `script.addPreloadScript`.
+    /// Install a global preload script via
+    /// [`script.addPreloadScript`][spec].
+    ///
+    /// For sandboxed scripts, channel arguments, or per-context scope
+    /// build an [`AddPreloadScript`] directly.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-script-addPreloadScript
     pub async fn add_preload_script(
         &self,
         function_declaration: impl Into<String>,
@@ -360,7 +508,10 @@ impl<'a> ScriptModule<'a> {
             .await
     }
 
-    /// `script.removePreloadScript`.
+    /// Uninstall a preload script via
+    /// [`script.removePreloadScript`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-script-removePreloadScript
     pub async fn remove_preload_script(&self, script: PreloadScriptId) -> Result<(), BidiError> {
         self.bidi
             .send(RemovePreloadScript {
@@ -370,7 +521,12 @@ impl<'a> ScriptModule<'a> {
         Ok(())
     }
 
-    /// `script.getRealms` — all realms.
+    /// List every realm via [`script.getRealms`][spec].
+    ///
+    /// To filter by context or realm type, build a [`GetRealms`] struct
+    /// directly.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-script-getRealms
     pub async fn get_realms(&self) -> Result<GetRealmsResult, BidiError> {
         self.bidi
             .send(GetRealms {

--- a/thirtyfour/src/bidi/modules/session.rs
+++ b/thirtyfour/src/bidi/modules/session.rs
@@ -1,4 +1,16 @@
-//! `session.*` BiDi module — protocol handshake, subscription, status.
+//! `session.*` — protocol handshake, event subscription, status, end.
+//!
+//! The session module is the entry point for every BiDi conversation: it
+//! negotiates the connection, registers interest in events, and tears the
+//! session down. `thirtyfour` opens the session via WebDriver Classic
+//! `New Session` (so [`session.new`][spec-new] is not modelled here), but
+//! every other session-level command is.
+//!
+//! See the [W3C `session` module specification][spec] for the canonical
+//! definitions, types, and remote-end algorithms.
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#module-session
+//! [spec-new]: https://w3c.github.io/webdriver-bidi/#command-session-new
 
 use serde::{Deserialize, Serialize};
 
@@ -7,16 +19,23 @@ use crate::bidi::command::{BidiCommand, Empty};
 use crate::bidi::error::BidiError;
 use crate::bidi::ids::{BrowsingContextId, UserContextId};
 
-/// `session.status`.
+/// [`session.status`][spec] — query whether the driver is ready to accept
+/// a new session.
+///
+/// Once a session is already active most drivers report `ready: false`
+/// with an explanatory message; both fields are always populated. This is
+/// the BiDi analogue of the WebDriver Classic `GET /status` endpoint.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-session-status
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct Status;
 
-/// Response for [`Status`].
+/// Response payload for [`Status`].
 #[derive(Debug, Clone, Deserialize)]
 pub struct StatusResult {
-    /// True when the driver is ready to accept a new session.
+    /// `true` if the driver can create a new session right now.
     pub ready: bool,
-    /// Human-readable readiness message.
+    /// Human-readable readiness explanation. Always populated.
     pub message: String,
 }
 
@@ -25,17 +44,32 @@ impl BidiCommand for Status {
     type Returns = StatusResult;
 }
 
-/// `session.subscribe` — register interest in one or more event names.
+/// [`session.subscribe`][spec] — register interest in one or more events.
+///
+/// Each event name is either a fully qualified event method
+/// (e.g. `"browsingContext.load"`) or a whole module name
+/// (e.g. `"browsingContext"`, which subscribes to every event in that
+/// module). Subscriptions can be scoped to specific browsing contexts or
+/// user contexts; if both `contexts` and `user_contexts` are empty the
+/// subscription is global.
+///
+/// Most callers should prefer the typed
+/// [`BiDi::subscribe::<E>()`](crate::bidi::BiDi::subscribe) helper, which
+/// auto-sends this command for `E::METHOD` and tears the subscription
+/// down via [`Unsubscribe`] when the last stream drops.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-session-subscribe
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct Subscribe {
-    /// Event names like `"browsingContext.load"` or whole modules like
-    /// `"browsingContext"` (subscribes to every event in the module).
+    /// Event method names (e.g. `"browsingContext.load"`) or whole module
+    /// names (e.g. `"browsingContext"`).
     pub events: Vec<String>,
-    /// Optional list of browsing-context ids to scope the subscription.
-    /// Empty / omitted = global.
+    /// Restrict the subscription to specific browsing contexts. Empty =
+    /// any context.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub contexts: Vec<BrowsingContextId>,
-    /// Optional list of user-context ids to scope the subscription.
+    /// Restrict the subscription to specific user contexts. Empty = any
+    /// user context.
     #[serde(rename = "userContexts", skip_serializing_if = "Vec::is_empty")]
     pub user_contexts: Vec<UserContextId>,
 }
@@ -48,24 +82,37 @@ impl BidiCommand for Subscribe {
 /// Response for [`Subscribe`].
 #[derive(Debug, Clone, Deserialize)]
 pub struct SubscribeResult {
-    /// Server-assigned id that can be passed to [`Unsubscribe`] to remove
-    /// just this subscription. Optional — older drivers may not send it.
+    /// Server-assigned subscription id. Pass it to
+    /// [`Unsubscribe::subscriptions`] to revoke this subscription
+    /// individually. The field is optional because older drivers may
+    /// omit it — fall back to unsubscribing by event name in that case.
     #[serde(default)]
     pub subscription: Option<String>,
 }
 
-/// `session.unsubscribe` — remove a previous subscription. Either by event
-/// names or by subscription id.
+/// [`session.unsubscribe`][spec] — drop a previously-installed subscription.
+///
+/// Subscriptions can be removed two ways:
+/// - By **event name(s)** ([`events`][Self::events]) — useful for the
+///   classic "subscribe then later unsubscribe" pattern when you didn't
+///   keep the subscription id.
+/// - By **subscription id** ([`subscriptions`][Self::subscriptions]) —
+///   removes only the specific call previously returned by
+///   [`Subscribe`]. Preferred when multiple subscriptions overlap.
+///
+/// Use [`contexts`][Self::contexts] to scope event-name unsubscribes to a
+/// specific subset of browsing contexts.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-session-unsubscribe
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct Unsubscribe {
-    /// Event names previously passed to [`Subscribe`].
+    /// Event method or module names (mirror of [`Subscribe::events`]).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub events: Vec<String>,
     /// Subscription ids previously returned by [`Subscribe`].
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub subscriptions: Vec<String>,
-    /// Optional list of browsing-context ids that scoped the original
-    /// subscription.
+    /// Browsing contexts scope (only applies to event-name unsubscribes).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub contexts: Vec<BrowsingContextId>,
 }
@@ -75,7 +122,14 @@ impl BidiCommand for Unsubscribe {
     type Returns = Empty;
 }
 
-/// `session.end` — terminates the BiDi session.
+/// [`session.end`][spec] — terminate the BiDi session.
+///
+/// This ends the BiDi conversation but **does not** terminate the
+/// underlying WebDriver Classic session — call
+/// [`WebDriver::quit`](crate::WebDriver::quit) for that. After `end()`
+/// the BiDi WebSocket is closed and the connection cannot be reused.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-session-end
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct End;
 
@@ -84,7 +138,13 @@ impl BidiCommand for End {
     type Returns = Empty;
 }
 
-/// Module facade returned by [`BiDi::session`].
+/// Convenience facade for the `session.*` module.
+///
+/// Returned by [`BiDi::session`](crate::bidi::BiDi::session). Each method
+/// here wraps a single command for the common case; for fine-grained
+/// control (subscription scopes, multi-id unsubscribe, etc.) build the
+/// command struct directly and send it via
+/// [`BiDi::send`](crate::bidi::BiDi::send).
 #[derive(Debug)]
 pub struct SessionModule<'a> {
     bidi: &'a BiDi,
@@ -97,12 +157,22 @@ impl<'a> SessionModule<'a> {
         }
     }
 
-    /// `session.status`.
+    /// Run [`session.status`][spec] and return the result.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-session-status
     pub async fn status(&self) -> Result<StatusResult, BidiError> {
         self.bidi.send(Status).await
     }
 
-    /// `session.subscribe` — convenience over a single event name.
+    /// Subscribe to a single global event by name (e.g. `"browsingContext.load"`).
+    ///
+    /// This sends [`session.subscribe`][spec] with one event name and no
+    /// scope. Prefer [`BiDi::subscribe::<E>()`](crate::bidi::BiDi::subscribe)
+    /// when you also want a typed local stream — it sends the same
+    /// command and reference-counts the subscription so you can call it
+    /// repeatedly without leaking subscriptions on the wire.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-session-subscribe
     pub async fn subscribe(&self, event: impl Into<String>) -> Result<SubscribeResult, BidiError> {
         self.bidi
             .send(Subscribe {
@@ -113,7 +183,10 @@ impl<'a> SessionModule<'a> {
             .await
     }
 
-    /// `session.subscribe` — multi-event variant.
+    /// Subscribe to multiple global events at once.
+    ///
+    /// Single-roundtrip equivalent of calling
+    /// [`subscribe`](Self::subscribe) once per event name.
     pub async fn subscribe_many(
         &self,
         events: impl IntoIterator<Item = String>,
@@ -127,7 +200,12 @@ impl<'a> SessionModule<'a> {
             .await
     }
 
-    /// `session.unsubscribe` by event name(s).
+    /// Unsubscribe by event method names.
+    ///
+    /// Equivalent to sending [`session.unsubscribe`][spec] with the named
+    /// events and no subscription ids or context scope.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-session-unsubscribe
     pub async fn unsubscribe(
         &self,
         events: impl IntoIterator<Item = String>,
@@ -142,7 +220,9 @@ impl<'a> SessionModule<'a> {
         Ok(())
     }
 
-    /// `session.end`.
+    /// End the BiDi session via [`session.end`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-session-end
     pub async fn end(&self) -> Result<(), BidiError> {
         self.bidi.send(End).await?;
         Ok(())

--- a/thirtyfour/src/bidi/modules/storage.rs
+++ b/thirtyfour/src/bidi/modules/storage.rs
@@ -1,7 +1,22 @@
-//! `storage.*` BiDi module — cookies and storage partitions.
+//! `storage.*` — cookies and storage partition addressing.
 //!
-//! Cookies use the crate-wide [`Cookie`](crate::Cookie) and
-//! [`SameSite`](crate::SameSite) types.
+//! BiDi storage commands operate on a [partition][partition-spec] (a
+//! cookie / storage jar). When `partition` is omitted the driver uses
+//! the session's default partition; supply a
+//! [`PartitionDescriptor`](crate::bidi::modules::storage::PartitionDescriptor)
+//! to target a specific user context or origin.
+//!
+//! Cookie values flow through the crate-wide [`Cookie`](crate::Cookie) /
+//! [`SameSite`](crate::SameSite) types — the wire shape uses
+//! [`network.BytesValue`][bytes-spec] for the cookie body, which is
+//! converted to a UTF-8 string when reading and re-encoded when writing.
+//!
+//! See the [W3C `storage` module specification][spec] for the canonical
+//! definitions.
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#module-storage
+//! [partition-spec]: https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey
+//! [bytes-spec]: https://w3c.github.io/webdriver-bidi/#type-network-BytesValue
 
 use serde::{Deserialize, Serialize};
 
@@ -12,10 +27,24 @@ use crate::bidi::command::BidiCommand;
 use crate::bidi::error::BidiError;
 use crate::common::cookie::bidi::{bytes_string, same_site, string_from_bytes_value};
 
-/// `storage.PartitionDescriptor` — opaque addressing for a storage
-/// partition. Construct with `serde_json::json!`, e.g.
-/// `json!({"type":"context","context": id})` or
-/// `json!({"type":"storageKey","userContext":"default","sourceOrigin":"https://x"})`.
+/// Opaque [`storage.PartitionDescriptor`][spec] — addresses one storage
+/// partition.
+///
+/// Build it with `serde_json::json!` in one of the spec's two forms:
+///
+/// ```text
+/// // Pin to a browsing context's partition.
+/// json!({"type":"context","context": "<browsing-context-id>"})
+///
+/// // Pin to an explicit storage key.
+/// json!({
+///     "type":"storageKey",
+///     "userContext": "<user-context-id>",
+///     "sourceOrigin": "https://example.com"
+/// })
+/// ```
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-storage-PartitionDescriptor
 pub type PartitionDescriptor = serde_json::Value;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -91,10 +120,14 @@ impl WirePartialCookie {
 }
 
 /// Filter for [`StorageModule::get_cookies_filtered`] /
-/// [`StorageModule::delete_cookies_filtered`].
+/// [`StorageModule::delete_cookies_filtered`]. Mirrors the spec's
+/// [`storage.CookieFilter`][spec] type.
 ///
-/// Each field, if `Some`, restricts the matched cookies. Fields that share
-/// names with [`Cookie`] match the same wire field on the BiDi side.
+/// Each field, if `Some`, restricts the matched cookies (multiple
+/// fields are AND-combined). Fields that share names with [`Cookie`]
+/// match the same field on the wire.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-storage-CookieFilter
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CookieFilter {
@@ -130,13 +163,24 @@ impl CookieFilter {
     }
 }
 
-/// `storage.getCookies`.
+/// [`storage.getCookies`][spec] — list cookies in a partition,
+/// optionally filtered.
+///
+/// Most callers should use the
+/// [`get_cookies`](StorageModule::get_cookies) /
+/// [`get_cookies_by_name`](StorageModule::get_cookies_by_name) /
+/// [`get_cookies_filtered`](StorageModule::get_cookies_filtered)
+/// facade methods, which handle the [`Cookie`] / wire-format
+/// conversion. Build [`GetCookies`] directly only when you need to
+/// supply a [`PartitionDescriptor`].
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-storage-getCookies
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct GetCookies {
     /// Optional filter — only matching cookies are returned.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<CookieFilter>,
-    /// Optional partition.
+    /// Optional partition. `None` uses the session default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub partition: Option<PartitionDescriptor>,
 }
@@ -158,9 +202,12 @@ pub struct WireGetCookiesResult {
 /// Response for [`StorageModule::get_cookies`].
 #[derive(Debug, Clone)]
 pub struct GetCookiesResult {
-    /// Matching cookies.
+    /// Matching cookies, converted to the crate-wide [`Cookie`] type.
     pub cookies: Vec<Cookie>,
-    /// Resolved partition key (driver-defined shape).
+    /// Resolved [`storage.PartitionKey`][spec] of the partition the
+    /// cookies were read from.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey
     pub partition_key: serde_json::Value,
 }
 
@@ -189,18 +236,31 @@ impl BidiCommand for SetCookie {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetCookieResult {
-    /// Resolved partition key.
+    /// Resolved [`storage.PartitionKey`][spec] the cookie was written to.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey
     #[serde(default)]
     pub partition_key: serde_json::Value,
 }
 
-/// `storage.deleteCookies`.
+/// [`storage.deleteCookies`][spec] — remove every cookie matching a
+/// filter from a partition.
+///
+/// Most callers should use the
+/// [`delete_cookies_by_name`](StorageModule::delete_cookies_by_name) /
+/// [`delete_all_cookies`](StorageModule::delete_all_cookies) /
+/// [`delete_cookies_filtered`](StorageModule::delete_cookies_filtered)
+/// facade methods. Build [`DeleteCookies`] directly only when you need
+/// to supply a [`PartitionDescriptor`].
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-storage-deleteCookies
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct DeleteCookies {
-    /// Filter — every matching cookie is removed.
+    /// Filter — every matching cookie is removed. `None` clears the
+    /// entire partition.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<CookieFilter>,
-    /// Optional partition.
+    /// Optional partition. `None` uses the session default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub partition: Option<PartitionDescriptor>,
 }
@@ -214,12 +274,19 @@ impl BidiCommand for DeleteCookies {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteCookiesResult {
-    /// Resolved partition key.
+    /// Resolved [`storage.PartitionKey`][spec] of the affected partition.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#type-storage-PartitionKey
     #[serde(default)]
     pub partition_key: serde_json::Value,
 }
 
-/// Module facade returned by [`BiDi::storage`].
+/// Convenience facade for the `storage.*` module.
+///
+/// Returned by [`BiDi::storage`](crate::bidi::BiDi::storage). Every
+/// method on this facade targets the session's default storage
+/// partition. To address a specific partition, build the command struct
+/// (e.g. [`GetCookies`]) directly and supply a [`PartitionDescriptor`].
 #[derive(Debug)]
 pub struct StorageModule<'a> {
     bidi: &'a BiDi,
@@ -232,12 +299,15 @@ impl<'a> StorageModule<'a> {
         }
     }
 
-    /// `storage.getCookies` — all cookies in the default partition.
+    /// Return every cookie in the default partition via
+    /// [`storage.getCookies`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-storage-getCookies
     pub async fn get_cookies(&self) -> Result<GetCookiesResult, BidiError> {
         self.get_cookies_filtered(None).await
     }
 
-    /// `storage.getCookies` filtered by name.
+    /// Return cookies whose name matches `name` (default partition).
     pub async fn get_cookies_by_name(
         &self,
         name: impl Into<String>,
@@ -245,7 +315,12 @@ impl<'a> StorageModule<'a> {
         self.get_cookies_filtered(Some(CookieFilter::by_name(name))).await
     }
 
-    /// `storage.getCookies` with an arbitrary [`CookieFilter`].
+    /// Return cookies matching an arbitrary [`CookieFilter`] (default
+    /// partition).
+    ///
+    /// Wraps [`storage.getCookies`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-storage-getCookies
     pub async fn get_cookies_filtered(
         &self,
         filter: Option<CookieFilter>,
@@ -260,10 +335,14 @@ impl<'a> StorageModule<'a> {
         Ok(raw.into())
     }
 
-    /// `storage.setCookie`.
+    /// Set a cookie in the default partition via
+    /// [`storage.setCookie`][spec].
     ///
-    /// `cookie.domain` is required by BiDi; an empty `domain` returns
-    /// `invalid argument` without making a network call.
+    /// `cookie.domain` is required by BiDi — calls without one return
+    /// `invalid argument` locally without making a wire request, since
+    /// the spec rejects them anyway.
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-storage-setCookie
     pub async fn set_cookie(&self, cookie: Cookie) -> Result<SetCookieResult, BidiError> {
         let cookie = WirePartialCookie::from_cookie(cookie)?;
         self.bidi
@@ -274,17 +353,21 @@ impl<'a> StorageModule<'a> {
             .await
     }
 
-    /// `storage.deleteCookies` — by exact name.
+    /// Delete every cookie with name `name` (default partition).
     pub async fn delete_cookies_by_name(&self, name: impl Into<String>) -> Result<(), BidiError> {
         self.delete_cookies_filtered(Some(CookieFilter::by_name(name))).await
     }
 
-    /// `storage.deleteCookies` — every cookie in the default partition.
+    /// Delete every cookie in the default partition.
     pub async fn delete_all_cookies(&self) -> Result<(), BidiError> {
         self.delete_cookies_filtered(None).await
     }
 
-    /// `storage.deleteCookies` with an arbitrary [`CookieFilter`].
+    /// Delete every cookie matching `filter` (default partition).
+    ///
+    /// Wraps [`storage.deleteCookies`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-storage-deleteCookies
     pub async fn delete_cookies_filtered(
         &self,
         filter: Option<CookieFilter>,

--- a/thirtyfour/src/bidi/modules/web_extension.rs
+++ b/thirtyfour/src/bidi/modules/web_extension.rs
@@ -1,0 +1,184 @@
+//! `webExtension.*` — install and uninstall web extensions in the
+//! running browser.
+//!
+//! Driver support is currently Firefox-only (geckodriver implements
+//! both commands; Chromium drivers respond with `unknown error` /
+//! `Method not available`). Some browsers install extensions only
+//! temporarily — they're removed at the next browser shutdown — so
+//! treat the lifetime of the resulting
+//! [`ExtensionId`](crate::bidi::ExtensionId) as scoped to the current
+//! session unless your driver explicitly persists the install.
+//!
+//! Extensions can be supplied three ways: an unpacked directory on the
+//! local filesystem, a packed archive on the local filesystem (`.crx`,
+//! `.xpi`, or plain `.zip`), or base64-encoded archive bytes. See
+//! [`ExtensionData`](crate::bidi::modules::web_extension::ExtensionData).
+//!
+//! See the [W3C `webExtension` module specification][spec] for the
+//! canonical definitions.
+//!
+//! [spec]: https://w3c.github.io/webdriver-bidi/#module-webExtension
+
+use serde::{Deserialize, Serialize};
+
+use crate::bidi::BiDi;
+use crate::bidi::command::{BidiCommand, Empty};
+use crate::bidi::error::BidiError;
+use crate::bidi::ids::ExtensionId;
+
+/// Source of an extension to install. Mirrors the spec's
+/// [`webExtension.ExtensionData`][spec] union.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#type-webExtension-ExtensionData
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ExtensionData {
+    /// Path to an unpacked extension directory on the host filesystem.
+    Path {
+        /// Filesystem path.
+        path: String,
+    },
+    /// Path to a packed archive (`.crx`, `.xpi`, or plain `.zip`) on
+    /// the host filesystem.
+    ArchivePath {
+        /// Filesystem path.
+        path: String,
+    },
+    /// Base64-encoded archive bytes (same format as `archivePath` but
+    /// transmitted inline).
+    Base64 {
+        /// Base64 payload.
+        value: String,
+    },
+}
+
+/// [`webExtension.install`][spec] — install an extension from the given
+/// source.
+///
+/// Returns the assigned [`ExtensionId`], which can be used with
+/// [`Uninstall`] later. Errors:
+///
+/// - `unsupported operation` — driver doesn't implement
+///   `webExtension.install` or doesn't support this `type`.
+/// - `invalid web extension` — bytes weren't a valid extension /
+///   archive, or the path doesn't exist.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-webExtension-install
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Install {
+    /// Where to install the extension from.
+    pub extension_data: ExtensionData,
+}
+
+impl BidiCommand for Install {
+    const METHOD: &'static str = "webExtension.install";
+    type Returns = InstallResult;
+}
+
+/// Response for [`Install`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct InstallResult {
+    /// Server-assigned extension id. Pass to [`Uninstall`] to remove
+    /// the extension later.
+    pub extension: ExtensionId,
+}
+
+/// [`webExtension.uninstall`][spec] — remove a previously-installed
+/// extension.
+///
+/// Returns `no such web extension` if `extension` is unknown.
+///
+/// [spec]: https://w3c.github.io/webdriver-bidi/#command-webExtension-uninstall
+#[derive(Debug, Clone, Serialize)]
+pub struct Uninstall {
+    /// Extension id to remove.
+    pub extension: ExtensionId,
+}
+
+impl BidiCommand for Uninstall {
+    const METHOD: &'static str = "webExtension.uninstall";
+    type Returns = Empty;
+}
+
+/// Convenience facade for the `webExtension.*` module.
+///
+/// Returned by [`BiDi::web_extension`](crate::bidi::BiDi::web_extension).
+/// The three `install_*` shortcuts cover the common cases; for the
+/// generic form pass [`ExtensionData`] to [`install`](Self::install).
+#[derive(Debug)]
+pub struct WebExtensionModule<'a> {
+    bidi: &'a BiDi,
+}
+
+impl<'a> WebExtensionModule<'a> {
+    pub(crate) fn new(bidi: &'a BiDi) -> Self {
+        Self {
+            bidi,
+        }
+    }
+
+    /// Install an extension from any [`ExtensionData`] source via
+    /// [`webExtension.install`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-webExtension-install
+    pub async fn install(&self, extension_data: ExtensionData) -> Result<InstallResult, BidiError> {
+        self.bidi
+            .send(Install {
+                extension_data,
+            })
+            .await
+    }
+
+    /// Install an unpacked extension directory at `path`.
+    ///
+    /// Convenience for [`install`](Self::install) with
+    /// [`ExtensionData::Path`].
+    pub async fn install_path(&self, path: impl Into<String>) -> Result<InstallResult, BidiError> {
+        self.install(ExtensionData::Path {
+            path: path.into(),
+        })
+        .await
+    }
+
+    /// Install a packed extension archive at `path` (`.crx`, `.xpi`, or
+    /// `.zip`).
+    ///
+    /// Convenience for [`install`](Self::install) with
+    /// [`ExtensionData::ArchivePath`].
+    pub async fn install_archive(
+        &self,
+        path: impl Into<String>,
+    ) -> Result<InstallResult, BidiError> {
+        self.install(ExtensionData::ArchivePath {
+            path: path.into(),
+        })
+        .await
+    }
+
+    /// Install a base64-encoded extension archive.
+    ///
+    /// Convenience for [`install`](Self::install) with
+    /// [`ExtensionData::Base64`].
+    pub async fn install_base64(
+        &self,
+        value: impl Into<String>,
+    ) -> Result<InstallResult, BidiError> {
+        self.install(ExtensionData::Base64 {
+            value: value.into(),
+        })
+        .await
+    }
+
+    /// Uninstall an extension via [`webExtension.uninstall`][spec].
+    ///
+    /// [spec]: https://w3c.github.io/webdriver-bidi/#command-webExtension-uninstall
+    pub async fn uninstall(&self, extension: ExtensionId) -> Result<(), BidiError> {
+        self.bidi
+            .send(Uninstall {
+                extension,
+            })
+            .await?;
+        Ok(())
+    }
+}

--- a/thirtyfour/src/bidi/stream.rs
+++ b/thirtyfour/src/bidi/stream.rs
@@ -1,11 +1,21 @@
 //! Event subscription primitives for [`crate::bidi::BiDi`].
 //!
-//! A subscription is a `Stream<Item = E>` filtered to one event method
-//! name. Backed by a `tokio::sync::broadcast` channel that fans out from
-//! the WebSocket reader task to every active subscriber. The stream
-//! holds a refcounted handle into [`crate::bidi::BiDi`]'s subscription
-//! tracking — when the last stream for a given method drops, the wire-level
-//! `session.unsubscribe` is sent automatically.
+//! A subscription is a [`futures::Stream`](futures_util::Stream)
+//! `Item = E` filtered to one event method name. Internally,
+//! [`EventStream`] is a wrapper over a
+//! [`tokio::sync::broadcast::Receiver`] that fans out from the
+//! WebSocket reader task to every active subscriber.
+//!
+//! Each [`EventStream`] also holds a per-method handle into the
+//! transport's subscription refcount: when the last stream for a given
+//! method drops, the wire-level
+//! [`session.unsubscribe`](crate::bidi::modules::session::Unsubscribe)
+//! is sent automatically (best-effort; spawned on the current tokio
+//! runtime).
+//!
+//! Use [`RawEventStream`] (returned by
+//! [`BiDi::subscribe_raw`](crate::bidi::BiDi::subscribe_raw)) for an
+//! untyped firehose with no filtering or deserialisation.
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -20,15 +30,28 @@ use super::transport::ws::BidiTransport;
 
 /// A typed BiDi event stream.
 ///
-/// Constructed via [`crate::bidi::BiDi::subscribe`]. Internally a wrapper
-/// over a `tokio::sync::broadcast::Receiver` that filters by event method
-/// name, then deserialises params into `T`.
+/// Constructed via [`BiDi::subscribe`](crate::bidi::BiDi::subscribe).
+/// The stream yields events whose method name matches `T::METHOD`
+/// (filtering happens locally; subscriptions are still made
+/// per-method on the wire).
 ///
-/// Items where the wire shape can't be deserialised as `T` are skipped
-/// with a `tracing::warn!` — they shouldn't happen unless a vendor-specific
-/// event method name collides or the wire shape has changed upstream, in
-/// which case the user should switch to [`crate::bidi::BiDi::subscribe_raw`]
-/// and parse manually.
+/// # Deserialisation failures
+///
+/// Items whose wire shape can't be deserialised as `T` are skipped
+/// with a `tracing::warn!` to the `thirtyfour::bidi` target. This
+/// shouldn't happen during normal operation — it usually indicates a
+/// driver-vendor extension or a wire-shape change in a newer spec
+/// revision. When it does, switch to
+/// [`BiDi::subscribe_raw`](crate::bidi::BiDi::subscribe_raw) and parse
+/// manually.
+///
+/// # Drop behaviour
+///
+/// Dropping the stream releases its per-method subscription refcount.
+/// When the last [`EventStream`] for `T::METHOD` drops, the framework
+/// spawns a background `session.unsubscribe` on the current tokio
+/// runtime; if no runtime is current, the unsubscribe is skipped (the
+/// subscription will be cleaned up when the BiDi handle drops).
 #[derive(Debug)]
 pub struct EventStream<T> {
     transport: BidiTransport,
@@ -138,8 +161,21 @@ fn warn_parse_failure<T>(method: &str, raw: &RawEvent, err: &serde_json::Error) 
     );
 }
 
-/// All-events stream returned by [`crate::bidi::BiDi::subscribe_raw`].
-/// Yields raw `RawEvent`s without method or shape filtering.
+/// All-events stream returned by
+/// [`BiDi::subscribe_raw`](crate::bidi::BiDi::subscribe_raw).
+///
+/// Yields every event the driver pushes, without filtering by method
+/// or deserialising params. The caller is responsible for sending the
+/// matching [`session.subscribe`](crate::bidi::modules::session::Subscribe)
+/// to start the flow.
+///
+/// Use this when:
+/// - You're debugging an unknown event shape and want to see every
+///   incoming envelope.
+/// - You want a single firehose for many event types without the cost
+///   of per-type subscriptions.
+/// - The event isn't (yet) modelled as a typed [`BidiEvent`] and you'd
+///   prefer raw access over implementing one.
 #[derive(Debug)]
 pub struct RawEventStream {
     rx: Receiver<RawEvent>,

--- a/thirtyfour/tests/bidi_events.rs
+++ b/thirtyfour/tests/bidi_events.rs
@@ -19,8 +19,9 @@ use std::time::Duration;
 
 use futures_util::StreamExt;
 use thirtyfour::bidi::events::{
-    BeforeRequestSent, ContextCreated, ContextDestroyed, DomContentLoaded, Load, LogEntryAdded,
-    NavigationStarted, RealmCreated, ResponseCompleted, ResponseStarted,
+    BeforeRequestSent, ContextCreated, ContextDestroyed, DomContentLoaded, HistoryUpdated, Load,
+    LogEntryAdded, NavigationCommitted, NavigationStarted, RealmCreated, ResponseCompleted,
+    ResponseStarted,
 };
 use thirtyfour::bidi::modules::{browsing_context, log, network};
 use thirtyfour::prelude::*;
@@ -357,6 +358,108 @@ async fn network_intercept_continue_request_unmodified() -> WebDriverResult<()> 
 
         // 5. Cleanup — remove the intercept explicitly via the guard.
         added.remove().await.map_err(bidi_to_wd)?;
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// browsingContext events — history & navigation lifecycle
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_history_updated_event() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        // historyUpdated is optional; some drivers don't emit it. Use the
+        // best-effort subscribe pattern via the session command so we can
+        // bail cleanly if the wire-level subscribe fails.
+        let sub = bidi.session().subscribe("browsingContext.historyUpdated").await;
+        if let Err(e) = sub {
+            if matches!(
+                e.error.as_str(),
+                "unknown command" | "unknown method" | "unsupported operation" | "invalid argument"
+            ) {
+                return driver.quit().await;
+            }
+            return Err(bidi_to_wd(e));
+        }
+        let mut events = bidi.subscribe::<HistoryUpdated>().await.map_err(bidi_to_wd)?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(
+                ctx.clone(),
+                "data:text/html,<html><body>x</body></html>",
+                Some(browsing_context::ReadinessState::Complete),
+            )
+            .await
+            .map_err(bidi_to_wd)?;
+        // Trigger pushState — that's the spec trigger for history updated.
+        bidi.script()
+            .evaluate(ctx.clone(), "history.pushState({}, '', '?upd=1')", false)
+            .await
+            .map_err(bidi_to_wd)?;
+        // Best-effort wait — some drivers don't emit. Use a shorter timeout
+        // and just exit cleanly if nothing arrives.
+        let res = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(evt) = events.next().await
+                    && evt.context == ctx
+                {
+                    return evt;
+                }
+            }
+        })
+        .await;
+        if let Ok(evt) = res {
+            assert!(evt.url.contains("upd=1"));
+        }
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_navigation_committed_event() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let sub = bidi.session().subscribe("browsingContext.navigationCommitted").await;
+        if let Err(e) = sub {
+            if matches!(
+                e.error.as_str(),
+                "unknown command" | "unknown method" | "unsupported operation" | "invalid argument"
+            ) {
+                return driver.quit().await;
+            }
+            return Err(bidi_to_wd(e));
+        }
+        let mut events = bidi.subscribe::<NavigationCommitted>().await.map_err(bidi_to_wd)?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(
+                ctx.clone(),
+                "data:text/html,<html><body>committed</body></html>",
+                Some(browsing_context::ReadinessState::Complete),
+            )
+            .await
+            .map_err(bidi_to_wd)?;
+        let res = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(evt) = events.next().await
+                    && evt.context == ctx
+                {
+                    return evt;
+                }
+            }
+        })
+        .await;
+        if let Ok(evt) = res {
+            assert!(evt.url.starts_with("data:text/html"));
+        }
         driver.quit().await
     })
     .await

--- a/thirtyfour/tests/bidi_typed.rs
+++ b/thirtyfour/tests/bidi_typed.rs
@@ -20,7 +20,9 @@
 use std::future::Future;
 use std::time::Duration;
 
-use thirtyfour::bidi::modules::{browser, browsing_context, network, script};
+use thirtyfour::bidi::modules::{
+    browser, browsing_context, emulation, network, script, web_extension,
+};
 use thirtyfour::prelude::*;
 
 use crate::common::launch_managed_bidi;
@@ -640,6 +642,344 @@ async fn permissions_set_permission_best_effort() -> WebDriverResult<()> {
                     e.error.as_str(),
                     "unknown command" | "unknown method" | "unsupported operation"
                 ) => {}
+            Err(e) => return Err(bidi_to_wd(e)),
+        }
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// browser — client windows, download behavior
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browser_get_client_windows_lists_at_least_one() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let res = bidi.browser().get_client_windows().await;
+        match res {
+            Ok(list) => {
+                assert!(!list.client_windows.is_empty(), "expected at least one client window");
+            }
+            // Some drivers don't yet implement getClientWindows.
+            Err(e)
+                if matches!(
+                    e.error.as_str(),
+                    "unknown command" | "unknown method" | "unsupported operation"
+                ) => {}
+            Err(e) => return Err(bidi_to_wd(e)),
+        }
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browser_set_download_behavior_best_effort() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        // Pass `None` to clear; that's harmless on every driver and only
+        // exercises the wire shape for setDownloadBehavior.
+        let res = bidi.browser().set_download_behavior(None).await;
+        match res {
+            Ok(_) => {}
+            Err(e)
+                if matches!(
+                    e.error.as_str(),
+                    "unknown command" | "unknown method" | "unsupported operation"
+                ) => {}
+            Err(e) => return Err(bidi_to_wd(e)),
+        }
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// browsingContext — locateNodes, print, setBypassCSP
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_locate_nodes_css() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(ctx.clone(), BLANK_HTML, Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        let res = bidi
+            .browsing_context()
+            .locate_nodes(ctx, browsing_context::Locator::css("input"))
+            .await;
+        match res {
+            Ok(found) => {
+                assert!(!found.nodes.is_empty(), "expected to find <input> in BLANK_HTML");
+            }
+            Err(e)
+                if matches!(
+                    e.error.as_str(),
+                    "unknown command" | "unknown method" | "unsupported operation"
+                ) => {}
+            Err(e) => return Err(bidi_to_wd(e)),
+        }
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_print_returns_pdf_b64() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let tree = bidi.browsing_context().get_tree(None).await.map_err(bidi_to_wd)?;
+        let ctx = tree.contexts[0].context.clone();
+        bidi.browsing_context()
+            .navigate(ctx.clone(), BLANK_HTML, Some(browsing_context::ReadinessState::Complete))
+            .await
+            .map_err(bidi_to_wd)?;
+        let res = bidi.browsing_context().print(ctx).await;
+        match res {
+            Ok(out) => {
+                assert!(!out.data.is_empty());
+                // PDFs in base64 always start with "JVBERi" ("%PDF" prefix).
+                assert!(out.data.starts_with("JVBERi"), "unexpected PDF prefix");
+            }
+            Err(e)
+                if matches!(
+                    e.error.as_str(),
+                    "unknown command" | "unknown method" | "unsupported operation"
+                ) => {}
+            Err(e) => return Err(bidi_to_wd(e)),
+        }
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn browsing_context_set_bypass_csp_best_effort() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        // Just exercise the wire shape for both bypass-on and clear.
+        for v in [Some(true), None] {
+            let res = bidi.browsing_context().set_bypass_csp(v).await;
+            match res {
+                Ok(_) => {}
+                Err(e)
+                    if matches!(
+                        e.error.as_str(),
+                        "unknown command" | "unknown method" | "unsupported operation"
+                    ) => {}
+                Err(e) => return Err(bidi_to_wd(e)),
+            }
+        }
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// network — data collectors, extra headers
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn network_data_collector_add_remove_best_effort() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let res =
+            bidi.network().add_data_collector(vec![network::DataType::Response], 64 * 1024).await;
+        match res {
+            Ok(added) => {
+                assert!(!added.collector.as_str().is_empty());
+                bidi.network().remove_data_collector(added.collector).await.map_err(bidi_to_wd)?;
+            }
+            Err(e)
+                if matches!(
+                    e.error.as_str(),
+                    "unknown command" | "unknown method" | "unsupported operation"
+                ) => {}
+            Err(e) => return Err(bidi_to_wd(e)),
+        }
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn network_set_extra_headers_best_effort() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let header = serde_json::json!({
+            "name": "X-Thirtyfour",
+            "value": {"type": "string", "value": "test"}
+        });
+        let res = bidi.network().set_extra_headers(vec![header]).await;
+        match res {
+            Ok(_) => {}
+            Err(e)
+                if matches!(
+                    e.error.as_str(),
+                    "unknown command" | "unknown method" | "unsupported operation"
+                ) => {}
+            Err(e) => return Err(bidi_to_wd(e)),
+        }
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// emulation
+// ---------------------------------------------------------------------------
+//
+// All of `emulation.*` is optional — best-effort accept the spec's
+// documented `unsupported operation` reply.
+
+async fn emulation_skip_ok(res: Result<(), thirtyfour::bidi::BidiError>) -> WebDriverResult<()> {
+    match res {
+        Ok(_) => Ok(()),
+        Err(e)
+            if matches!(
+                e.error.as_str(),
+                "unknown command" | "unknown method" | "unsupported operation" | "invalid argument"
+            ) =>
+        {
+            Ok(())
+        }
+        Err(e) => Err(bidi_to_wd(e)),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn emulation_set_geolocation_override_best_effort() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let res = bidi
+            .emulation()
+            .set_geolocation_override(Some(emulation::GeolocationCoordinates {
+                latitude: -33.8688,
+                longitude: 151.2093,
+                accuracy: Some(50.0),
+                altitude: None,
+                altitude_accuracy: None,
+                heading: None,
+                speed: None,
+            }))
+            .await;
+        emulation_skip_ok(res).await?;
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn emulation_set_locale_override_best_effort() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let res = bidi.emulation().set_locale_override(Some("en-AU".into())).await;
+        emulation_skip_ok(res).await?;
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn emulation_set_timezone_override_best_effort() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let res = bidi.emulation().set_timezone_override(Some("Australia/Sydney".into())).await;
+        emulation_skip_ok(res).await?;
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn emulation_set_user_agent_override_best_effort() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let res = bidi.emulation().set_user_agent_override(Some("ThirtyFourTest/1.0".into())).await;
+        emulation_skip_ok(res).await?;
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn emulation_set_scripting_enabled_best_effort() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let res = bidi.emulation().set_scripting_enabled(Some(false)).await;
+        emulation_skip_ok(res).await?;
+        // Always try to clear the override so the rest of the session has
+        // JS — driver's response to the clear can also be unsupported.
+        let _ = bidi.emulation().set_scripting_enabled(None).await;
+        driver.quit().await
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn emulation_set_touch_override_best_effort() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let res = bidi.emulation().set_touch_override(Some(5)).await;
+        emulation_skip_ok(res).await?;
+        driver.quit().await
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// webExtension
+// ---------------------------------------------------------------------------
+//
+// Only Firefox implements webExtension at the moment, and a real install
+// needs a packaged extension. Just hit `install` with a bogus path and
+// expect a typed error of one of the documented codes.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn web_extension_install_invalid_path_returns_typed_error() -> WebDriverResult<()> {
+    with_timeout(async {
+        let driver = launch_managed_bidi().await?;
+        let bidi = driver.bidi().await?;
+        let res = bidi
+            .web_extension()
+            .install(web_extension::ExtensionData::Path {
+                path: "/nonexistent/path/to/extension".into(),
+            })
+            .await;
+        match res {
+            // Firefox: error("invalid web extension")
+            // Chrome: error("unknown error") with "Method not available." message
+            // Other: error("unknown command"/"unsupported operation")
+            Err(e)
+                if matches!(
+                    e.error.as_str(),
+                    "invalid web extension"
+                        | "invalid argument"
+                        | "unknown command"
+                        | "unknown method"
+                        | "unknown error"
+                        | "unsupported operation"
+                ) => {}
+            Ok(_) => panic!("expected an error from install with bogus path"),
             Err(e) => return Err(bidi_to_wd(e)),
         }
         driver.quit().await


### PR DESCRIPTION
## Summary

- **100% W3C BiDi spec coverage.** Adds the two missing modules (`emulation`, `webExtension`) and the missing commands/events in the existing ones (browser client-windows + downloads, browsingContext print/locateNodes/setBypassCSP, network data-collectors + extra-headers, browsingContext download/history/navigation events, input.fileDialogOpened).
- **Spec-grounded rustdoc on every public item.** Each module, command, event, struct, field, and facade method has docs that summarise the spec section in plain English and deep-link to the relevant `#command-…` / `#event-…` / `#type-…` anchor at https://w3c.github.io/webdriver-bidi/.
- **mdbook updates** to overview.md (module table, new emulation example, comparison-table copy) and events.md (full re-export list of typed events).
- **Integration tests** for every new typed command and the new events, gated behind `manager-tests,bidi`. Driver-dependent commands accept `unsupported operation` / `unknown command` so the suite stays cross-browser.

## What's new in code

**New modules**
- `emulation` — 11 commands covering geolocation, locale, timezone, screen settings, screen orientation, user-agent, scripting-enabled, scrollbar, forced-colors theme, network conditions, touch overrides.
- `web_extension` — `install` (path / archive / base64) and `uninstall`.

**New commands in existing modules**
- `browser`: `getClientWindows`, `setClientWindowState`, `setDownloadBehavior`.
- `browsingContext`: `locateNodes`, `print`, `setBypassCSP`.
- `network`: `addDataCollector`, `removeDataCollector`, `getData`, `disownData`, `setExtraHeaders`.

**New events**
- `browsingContext`: `historyUpdated`, `downloadWillBegin`, `downloadEnd`, `navigationAborted`, `navigationCommitted`, `navigationFailed`.
- `input`: `fileDialogOpened`.

**New typed ids**: `ClientWindowId`, `CollectorId`, `ExtensionId`.

## Notes for reviewers

- The W3C BiDi spec doesn't define `permissions` or `bluetooth` modules — `permissions` is a separate W3C Permissions extension spec and was already implemented before this PR; bluetooth is a separate Web Bluetooth extension spec and is intentionally not included here. The rustdoc on `permissions/mod.rs` now calls this out.
- `setScriptingEnabled` and `setBypassCSP` use a `Option<bool>` field with a custom `serialize_with` because the wire shape only accepts `false`/`null` (resp. `true`/`null`). `Some(true)` (resp. `Some(false)`) is silently dropped — see the doc comments for the rationale.
- For commands with both `contexts` and `userContexts` scoping, the facade methods always send the unscoped form. Users who need scoping build the command struct directly and send via `BiDi::send`. This pattern is documented on each facade.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets` — zero warnings
- [x] `cargo doc --no-deps --all-features` — zero broken intra-doc links
- [x] `cargo test -p thirtyfour --lib` — 78/78 pass
- [x] `cargo test -p thirtyfour --doc` — 122/122 pass
- [x] `cargo test -p thirtyfour --features manager-tests,bidi --test bidi_typed -- --test-threads=1` — 40/40 pass against managed chromedriver
- [x] `cargo test -p thirtyfour --features manager-tests,bidi --test bidi_events -- --test-threads=1` — 14/14 pass against managed chromedriver
- [x] `mdbook build` in `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)