### PR TITLE
ffix(cdp): replace dropped recv() future in EventStream::poll_next with BroadcastStream

### DIFF
--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -103,6 +103,7 @@ zip = { version = "8", default-features = false, features = [
 ], optional = true }
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
+tokio-stream = { version = "0.1.18", features = ["sync"], default-features = false }
 
 [dev-dependencies]
 anyhow = "1"

--- a/thirtyfour/src/bidi/stream.rs
+++ b/thirtyfour/src/bidi/stream.rs
@@ -21,8 +21,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures_util::Stream;
-use tokio::sync::broadcast::error::TryRecvError;
-use tokio::sync::broadcast::{Receiver, error::RecvError};
+use tokio::sync::broadcast::Receiver;
+use tokio_stream::wrappers::BroadcastStream;
 
 use super::BidiEvent;
 use super::command::RawEvent;
@@ -55,7 +55,7 @@ use super::transport::ws::BidiTransport;
 #[derive(Debug)]
 pub struct EventStream<T> {
     transport: BidiTransport,
-    rx: Receiver<RawEvent>,
+    rx: BroadcastStream<RawEvent>,
     method: &'static str,
     _marker: std::marker::PhantomData<fn() -> T>,
 }
@@ -68,7 +68,7 @@ impl<T> EventStream<T> {
     ) -> Self {
         Self {
             transport,
-            rx,
+            rx: BroadcastStream::new(rx),
             method,
             _marker: std::marker::PhantomData,
         }
@@ -101,44 +101,22 @@ impl<T: BidiEvent> Stream for EventStream<T> {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
+
         loop {
-            match this.rx.try_recv() {
-                Ok(raw) => {
+            match Pin::new(&mut this.rx).poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(Some(Err(_lagged))) => continue,
+                Poll::Ready(Some(Ok(raw))) => {
                     if this.matches(&raw) {
                         match serde_json::from_value::<T>(raw.params.clone()) {
                             Ok(parsed) => return Poll::Ready(Some(parsed)),
                             Err(e) => warn_parse_failure::<T>(this.method, &raw, &e),
                         }
                     }
+                    // didn't match, poll again
                 }
-                Err(TryRecvError::Empty) => break,
-                Err(TryRecvError::Lagged(_)) => continue,
-                Err(TryRecvError::Closed) => return Poll::Ready(None),
             }
-        }
-
-        let polled = {
-            let recv = this.rx.recv();
-            tokio::pin!(recv);
-            recv.poll(cx)
-        };
-        match polled {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Ok(raw)) => {
-                if this.matches(&raw) {
-                    match serde_json::from_value::<T>(raw.params.clone()) {
-                        Ok(parsed) => return Poll::Ready(Some(parsed)),
-                        Err(e) => warn_parse_failure::<T>(this.method, &raw, &e),
-                    }
-                }
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Poll::Ready(Err(RecvError::Lagged(_))) => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Poll::Ready(Err(RecvError::Closed)) => Poll::Ready(None),
         }
     }
 }
@@ -178,13 +156,13 @@ fn warn_parse_failure<T>(method: &str, raw: &RawEvent, err: &serde_json::Error) 
 ///   prefer raw access over implementing one.
 #[derive(Debug)]
 pub struct RawEventStream {
-    rx: Receiver<RawEvent>,
+    rx: BroadcastStream<RawEvent>,
 }
 
 impl RawEventStream {
     pub(crate) fn new(rx: Receiver<RawEvent>) -> Self {
         Self {
-            rx,
+            rx: BroadcastStream::new(rx),
         }
     }
 }
@@ -195,26 +173,12 @@ impl Stream for RawEventStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         loop {
-            match this.rx.try_recv() {
-                Ok(raw) => return Poll::Ready(Some(raw)),
-                Err(TryRecvError::Empty) => break,
-                Err(TryRecvError::Lagged(_)) => continue,
-                Err(TryRecvError::Closed) => return Poll::Ready(None),
+            match Pin::new(&mut this.rx).poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(Some(Err(_lagged))) => continue,
+                Poll::Ready(Some(Ok(raw))) => return Poll::Ready(Some(raw)),
             }
-        }
-        let polled = {
-            let recv = this.rx.recv();
-            tokio::pin!(recv);
-            recv.poll(cx)
-        };
-        match polled {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Ok(raw)) => Poll::Ready(Some(raw)),
-            Poll::Ready(Err(RecvError::Lagged(_))) => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Poll::Ready(Err(RecvError::Closed)) => Poll::Ready(None),
         }
     }
 }

--- a/thirtyfour/src/cdp/stream.rs
+++ b/thirtyfour/src/cdp/stream.rs
@@ -9,8 +9,7 @@ use std::task::{Context, Poll};
 
 use futures_util::Stream;
 use serde::de::DeserializeOwned;
-use tokio::sync::broadcast::error::TryRecvError;
-use tokio::sync::broadcast::{Receiver, error::RecvError};
+use tokio::sync::broadcast::Receiver;
 use tokio_stream::wrappers::BroadcastStream;
 
 use super::CdpEvent;
@@ -108,14 +107,14 @@ fn warn_parse_failure<T>(method: &str, raw: &RawEvent, err: &serde_json::Error) 
 /// [`CdpSession::subscribe_all`]: crate::cdp::CdpSession::subscribe_all
 #[derive(Debug)]
 pub struct RawEventStream {
-    rx: Receiver<RawEvent>,
+    rx: BroadcastStream<RawEvent>,
     session: Option<SessionId>,
 }
 
 impl RawEventStream {
     pub(crate) fn new(rx: Receiver<RawEvent>, session: Option<SessionId>) -> Self {
         Self {
-            rx,
+            rx: BroadcastStream::new(rx),
             session,
         }
     }
@@ -127,36 +126,17 @@ impl Stream for RawEventStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         loop {
-            match this.rx.try_recv() {
-                Ok(raw) => {
+            match Pin::new(&mut this.rx).poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(Some(Err(_lagged))) => continue,
+                Poll::Ready(Some(Ok(raw))) => {
                     if raw.session_id == this.session {
                         return Poll::Ready(Some(raw));
                     }
+                    // didn't match, poll again
                 }
-                Err(TryRecvError::Empty) => break,
-                Err(TryRecvError::Lagged(_)) => continue,
-                Err(TryRecvError::Closed) => return Poll::Ready(None),
             }
-        }
-        let polled = {
-            let recv = this.rx.recv();
-            tokio::pin!(recv);
-            recv.poll(cx)
-        };
-        match polled {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Ok(raw)) => {
-                if raw.session_id == this.session {
-                    return Poll::Ready(Some(raw));
-                }
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Poll::Ready(Err(RecvError::Lagged(_))) => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Poll::Ready(Err(RecvError::Closed)) => Poll::Ready(None),
         }
     }
 }

--- a/thirtyfour/src/cdp/stream.rs
+++ b/thirtyfour/src/cdp/stream.rs
@@ -11,6 +11,7 @@ use futures_util::Stream;
 use serde::de::DeserializeOwned;
 use tokio::sync::broadcast::error::TryRecvError;
 use tokio::sync::broadcast::{Receiver, error::RecvError};
+use tokio_stream::wrappers::BroadcastStream;
 
 use super::CdpEvent;
 use super::SessionId;
@@ -33,7 +34,7 @@ use super::command::RawEvent;
 /// [`CdpSession::subscribe_all`]: crate::cdp::CdpSession::subscribe_all
 #[derive(Debug)]
 pub struct EventStream<T> {
-    rx: Receiver<RawEvent>,
+    rx: BroadcastStream<RawEvent>,
     session: Option<SessionId>,
     method: &'static str,
     _marker: std::marker::PhantomData<fn() -> T>,
@@ -46,7 +47,7 @@ impl<T> EventStream<T> {
         method: &'static str,
     ) -> Self {
         Self {
-            rx,
+            rx: BroadcastStream::new(rx),
             session,
             method,
             _marker: std::marker::PhantomData,
@@ -63,47 +64,22 @@ impl<T: CdpEvent> Stream for EventStream<T> {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
-        // Drain any already-buffered events synchronously first; only park on
-        // the channel if there's nothing pending.
+
         loop {
-            match this.rx.try_recv() {
-                Ok(raw) => {
+            match Pin::new(&mut this.rx).poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(Some(Err(_lagged))) => continue,
+                Poll::Ready(Some(Ok(raw))) => {
                     if this.matches(&raw) {
                         match serde_json::from_value::<T>(raw.params.clone()) {
                             Ok(parsed) => return Poll::Ready(Some(parsed)),
                             Err(e) => warn_parse_failure::<T>(this.method, &raw, &e),
                         }
                     }
+                    // didn't match, poll again
                 }
-                Err(TryRecvError::Empty) => break,
-                Err(TryRecvError::Lagged(_)) => continue,
-                Err(TryRecvError::Closed) => return Poll::Ready(None),
             }
-        }
-
-        // Nothing buffered — park on the channel for the next event.
-        let polled = {
-            let recv = this.rx.recv();
-            tokio::pin!(recv);
-            recv.poll(cx)
-        };
-        match polled {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(Ok(raw)) => {
-                if this.matches(&raw) {
-                    match serde_json::from_value::<T>(raw.params.clone()) {
-                        Ok(parsed) => return Poll::Ready(Some(parsed)),
-                        Err(e) => warn_parse_failure::<T>(this.method, &raw, &e),
-                    }
-                }
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Poll::Ready(Err(RecvError::Lagged(_))) => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-            Poll::Ready(Err(RecvError::Closed)) => Poll::Ready(None),
         }
     }
 }

--- a/thirtyfour/src/cdp/stream.rs
+++ b/thirtyfour/src/cdp/stream.rs
@@ -153,6 +153,7 @@ mod tests {
     use futures_util::StreamExt;
     use serde::Deserialize;
     use serde_json::json;
+    use std::time::Duration;
     use tokio::sync::broadcast;
 
     #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -216,5 +217,73 @@ mod tests {
         let evt = stream.next().await.unwrap();
         assert_eq!(evt.method, "X.b");
         assert_eq!(evt.params["k"], 1);
+    }
+
+    /// Verify that a typed stream receives events delivered *after* the
+    /// stream has been polled and parked.
+    ///
+    /// The bug being regression-tested: `poll_next` created a fresh
+    /// `broadcast::Receiver::recv()` future on each call, polled it, and
+    /// then dropped it on `Poll::Pending`. Dropping the future unregistered
+    /// the waker from the broadcast channel, so any events arriving after
+    /// that point never woke the parked task. The test spawns a background
+    /// task that polls the stream, yields to let it park, sends an event,
+    /// and asserts the event is received within a timeout.
+    #[tokio::test]
+    async fn typed_stream_receives_event_sent_after_poll_pending() {
+        let (tx, _) = broadcast::channel::<RawEvent>(16);
+        let mut stream = EventStream::<Hello>::new(tx.subscribe(), None, Hello::METHOD);
+
+        let (result_tx, mut result_rx) = tokio::sync::oneshot::channel::<Option<Hello>>();
+        tokio::spawn(async move {
+            let evt = stream.next().await;
+            let _ = result_tx.send(evt);
+        });
+
+        // Yield repeatedly to let the spawned task run, reach its first
+        // `poll_next` call, get `Poll::Pending`, and park itself.
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        // Send the event after the stream has parked.
+        tx.send(raw("Test.hello", None, json!({"text": "after-poll"}))).unwrap();
+
+        let evt = tokio::time::timeout(Duration::from_secs(5), &mut result_rx)
+            .await
+            .expect("timed out. Stream never received the event")
+            .expect("oneshot cancelled")
+            .expect("expected Some event");
+
+        assert_eq!(evt.text, "after-poll");
+    }
+
+    /// Same as [`typed_stream_receives_event_sent_after_poll_pending`] but
+    /// for the untyped [`RawEventStream`].
+    #[tokio::test]
+    async fn raw_stream_receives_event_sent_after_poll_pending() {
+        let (tx, _) = broadcast::channel::<RawEvent>(16);
+        let mut stream = RawEventStream::new(tx.subscribe(), None);
+
+        let (result_tx, mut result_rx) = tokio::sync::oneshot::channel::<Option<RawEvent>>();
+        tokio::spawn(async move {
+            let evt = stream.next().await;
+            let _ = result_tx.send(evt);
+        });
+
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        tx.send(raw("Test.hello", None, json!({"text": "after-poll"}))).unwrap();
+
+        let evt = tokio::time::timeout(Duration::from_secs(5), &mut result_rx)
+            .await
+            .expect("timed out. Stream never received the event")
+            .expect("oneshot cancelled")
+            .expect("expected Some event");
+
+        assert_eq!(evt.method, "Test.hello");
+        assert_eq!(evt.params["text"], "after-poll");
     }
 }

--- a/thirtyfour/tests/cdp_events.rs
+++ b/thirtyfour/tests/cdp_events.rs
@@ -18,8 +18,9 @@ use std::time::Duration;
 
 use futures_util::StreamExt;
 use thirtyfour::ChromeCapabilities;
-use thirtyfour::cdp::CdpSession;
+use thirtyfour::cdp::domains::fetch::RequestPaused;
 use thirtyfour::cdp::domains::{fetch, log, network, page, runtime, target};
+use thirtyfour::cdp::{CdpSession, EventStream};
 use thirtyfour::prelude::*;
 
 use crate::common::launch_managed_chrome;
@@ -319,6 +320,61 @@ async fn fetch_request_paused_then_continue() -> WebDriverResult<()> {
         // is that we received the paused event.
         let driver = nav.await.expect("nav join");
         let _ = driver;
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fetch_background_listener_receives_paused_event() -> WebDriverResult<()> {
+    // Regression test: events delivered after a stream has parked must
+    // still wake the consumer. The listener runs in a background task
+    // (mirroring the pattern from #321) to ensure the waker
+    // registration survives across poll boundaries.
+    with_timeout(async {
+        let url = spawn_local_http("<html><body>background listener</body></html>").await?;
+        let (driver, session) = open_session().await?;
+        session.send(fetch::Enable::default()).await.expect("Fetch.enable");
+
+        // Subscribe and move the stream into a background listener task.
+        let mut events: EventStream<RequestPaused> = session.subscribe::<RequestPaused>().await?;
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            while let Some(event) = events.next().await {
+                if tx.send(event).is_err() {
+                    break;
+                }
+            }
+        });
+
+        // Navigate and wait for the background listener to receive the
+        // `RequestPaused` event.
+        let nav = {
+            let url = url.clone();
+            tokio::spawn(async move { driver.goto(&url).await })
+        };
+
+        let event = tokio::time::timeout(EVENT_TIMEOUT, rx.recv())
+            .await
+            .expect("background listener never received the event")
+            .expect("channel closed");
+
+        assert!(!event.request_id.as_str().is_empty());
+
+        // Let the request through so navigation completes.
+        session
+            .send(fetch::ContinueRequest {
+                request_id: event.request_id,
+                url: None,
+                method: None,
+                post_data: None,
+                headers: None,
+            })
+            .await
+            .expect("Fetch.continueRequest");
+
+        let _driver = nav.await.expect("nav join");
         Ok(())
     })
     .await


### PR DESCRIPTION
# What I was trying to do

So I recently encountered some bug where I have the following code:

```rust
        let cdp = driver.cdp();
        let session = cdp.connect().await?;
        let mut requests = session.subscribe::<fetch::RequestPaused>().await?;
        session
            .send::<fetch::Enable>(fetch::Enable {
                patterns: Some(vec![fetch::RequestPattern {
                    url_pattern: Some(String::from("*")),
                    resource_type: Some(thirtyfour::cdp::domains::network::ResourceType::Image),
                    request_stage: Some(fetch::RequestStage::Request),
                }]),
                handle_auth_requests: None,
            })
            .await?;

        let handle = tokio::spawn(async move {
            let _cdp = cdp;
            let session = session;
            tokio::task::yield_now().await;
            while let Some(event) = requests.next().await {
                println!("→ {} {:?}", event.request_id, event.request);
                // TODO - my very fancy whitelist that only allows specific known urls and blocks the rest.

                session
                    .send::<fetch::ContinueRequest>(fetch::ContinueRequest {
                        request_id: event.request_id,
                        url: None,
                        method: None,
                        post_data: None,
                        headers: None,
                    })
                    .await?;
            }

            Ok(())
        });
        // ensure that the listener task is aborted when this goes out of scope to avoid leaking of tasks.
        let _guard = TaskGuard { handle };

        debug!("Navigating to bing.com");
        driver
            .goto("https://www.bing.com/")
            .await
            .context("Failed to open bing")?;
```

The goal of that code is to register a fetch filter, navigate to bing.com and do some image filtering. It has multiple use cases like for example saving bandwidth by selectively blocking images,  but that is besides the point. 

# The problem.

- `driver.goto` just blocks and never moves forward until it **times out** 
-  no console logs indicating things are getting filtered, our code does not receive any messages from chrome. 
- I tried several things thinking maybe my setup has issues but it smelt like a deadlock of some kind.

```bash
ChromeDriver 148.0.7778.96 (8625e066febc721e015ea99842da12901eb7ed73-refs/branch-heads/7778@{#1904})

Chromium 148.0.7778.96 built on Debian GNU/Linux 13 (trixie)
```
 

 I started debugging with mitmproxy and I could see chrome is indeed replying with `Fetch.RequestPaused` in the websocket, I went up through thirtyfour source code and saw that [`dispatch`](https://github.com/stevepryde/thirtyfour/blob/77c02c4bd1ea41a54d28c2f0e03213bd84abf6ff/thirtyfour/src/cdp/transport/ws.rs#L207) is receiving the web socket request and sending it to `self.events` but that is the last known location of the request. 
 
 It never reaches my:
 
 ```rust
while let Some(event) = requests.next().await {}

```


The message seemed to have disappeared. After 3 hours of of scratching my head and looking at [tokio console](https://github.com/tokio-rs/console) I finally discovered the problem is at how [`EventStream::poll_next`](https://github.com/stevepryde/thirtyfour/blame/77c02c4bd1ea41a54d28c2f0e03213bd84abf6ff/thirtyfour/src/cdp/stream.rs#L64).

What I discovered is that poll_next is being called once and never polled again. If it is never polled again then the message hangs in the broadcast Receiver and never replied to which means the browser just hangs at waiting for the filter response. From the perspective of `dispatch`, `self.events.send()` succeeded with `Ok(1)` indicating someone received the message.  

I confirmed that this was exactly the issue by simply temporarily making `EventStream rx` public and calling `.recv()` myself which just worked without issues. Indicating the channel is indeed accepting messages.

## Root cause.
```
let polled = {
    let recv = this.rx.recv();
    tokio::pin!(recv);
    recv.poll(cx)
};
```
This creates a brand-new `recv()` future, polls it once, and then drops it when `poll_next` returns `Poll::Pending`. A `broadcast::Receiver::recv()` future registers its waker with the channel only while it is alive. Once dropped, the registration is gone. When the broadcast channel subsequently delivers a message and tries to wake a receiver, there is nobody registered , the task parks forever and the message is never consumed. That is my understanding. It also changes behavior in different scenarios, that is the reason why the tests never caught it originally. 

Tokio just stops driving the `poll_next` completely. `requests.next().await` just never receives any activity.

## Solutions.

I tried several stuff such as adding:

```rust
    recv_fut: Option<Pin<Box<dyn Future<Output = Result<RawEvent, RecvError>> + Send>>>,
```
But that was just dirty complex and needed `unsafe` keyword to move things around. It was just generally disgusting and did not work cleanly.  

```rust
    // Reuse or create the recv future so the waker stays registered
    let fut = this.recv_fut.get_or_insert_with(|| {
        // SAFETY: we are re-borrowing rx here; the future must not outlive self
        // We use unsafe to get a raw pointer to rx to avoid the borrow conflict
        let rx = &mut this.rx as *mut Receiver<RawEvent>;
        Box::pin(async move { unsafe { &mut *rx }.recv().await })
    });
```

After a bit of research, I found a well known library specifically designed to do whatever `poll_next` was trying to do. 
It is [tokio-stream](https://crates.io/crates/tokio-stream). It has [BroadcastStream](https://docs.rs/tokio-stream/latest/tokio_stream/wrappers/struct.BroadcastStream.html) wrappers that greatly simplify this particular specific use case.

```rust
use tokio_stream::wrappers::BroadcastStream;

pub struct EventStream<T> {
    rx: BroadcastStream<RawEvent>,
    session: Option<SessionId>,
    method: &'static str,
    _marker: std::marker::PhantomData<T>,
}
```

```rust
fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
    let this = self.get_mut();
    
    loop {
        match Pin::new(&mut this.rx).poll_next(cx) {
            Poll::Pending => return Poll::Pending,
            Poll::Ready(None) => return Poll::Ready(None),
            Poll::Ready(Some(Err(_lagged))) => continue,
            Poll::Ready(Some(Ok(raw))) => {
                if this.matches(&raw) {
                    match serde_json::from_value::<T>(raw.params.clone()) {
                        Ok(parsed) => return Poll::Ready(Some(parsed)),
                        Err(e) => warn_parse_failure::<T>(this.method, &raw, &e),
                    }
                }
                // didn't match, poll again
            }
        }
    }
}
```

So I used that and all the weirdness stopped. So I think using the library wrappers is relatively simpler to maintain since it abstracts away the chore of maintaining a stream rather than introducing unsafe code or Arc Mutexes just to ensure that the poll internals are not dropped and neutering it.


Hope this helps

