### PR TITLE
Suppress driver console window on Windows by default

### DIFF
--- a/thirtyfour/src/manager/manager.rs
+++ b/thirtyfour/src/manager/manager.rs
@@ -86,6 +86,9 @@ pub(crate) struct ResolvedConfig {
     pub offline: bool,
     pub mirror: Mirror,
     pub stdio: StdioMode,
+    /// Windows only: give the driver process its own console window instead
+    /// of suppressing it with `CREATE_NO_WINDOW`.
+    pub show_console_window: bool,
     /// Per-browser driver-binary overrides. When a browser appears here,
     /// `ensure_driver` skips download/cache and spawns the supplied binary
     /// directly.
@@ -102,6 +105,7 @@ impl std::fmt::Debug for ResolvedConfig {
             .field("ready_timeout", &self.ready_timeout)
             .field("offline", &self.offline)
             .field("stdio", &self.stdio)
+            .field("show_console_window", &self.show_console_window)
             .field("driver_paths", &self.driver_paths)
             .finish_non_exhaustive()
     }
@@ -166,6 +170,7 @@ pub struct WebDriverManagerBuilder {
     pub(crate) offline: Option<bool>,
     pub(crate) mirror: Option<Mirror>,
     pub(crate) stdio: Option<StdioMode>,
+    pub(crate) show_console_window: Option<bool>,
     /// Per-browser driver-binary overrides registered via
     /// [`WebDriverManagerBuilder::driver_binary`].
     pub(crate) driver_paths: HashMap<BrowserKind, PathBuf>,
@@ -187,6 +192,7 @@ impl std::fmt::Debug for WebDriverManagerBuilder {
             .field("ready_timeout", &self.ready_timeout)
             .field("offline", &self.offline)
             .field("stdio", &self.stdio)
+            .field("show_console_window", &self.show_console_window)
             .field("driver_paths", &self.driver_paths)
             .field("status_subscribers", &self.status_subscribers.len())
             .field("log_subscribers", &self.log_subscribers.len())
@@ -205,6 +211,7 @@ impl Clone for WebDriverManagerBuilder {
             offline: self.offline,
             mirror: self.mirror.clone(),
             stdio: self.stdio,
+            show_console_window: self.show_console_window,
             driver_paths: self.driver_paths.clone(),
             status_subscribers: self.status_subscribers.iter().map(Arc::clone).collect(),
             log_subscribers: self.log_subscribers.iter().map(Arc::clone).collect(),
@@ -310,6 +317,21 @@ impl WebDriverManagerBuilder {
         self
     }
 
+    /// Windows only: give the driver process its own console window.
+    ///
+    /// By default the driver is spawned with the `CREATE_NO_WINDOW` creation
+    /// flag so that no console window flashes up — this matters for GUI apps
+    /// built with `#![windows_subsystem = "windows"]`, where the console
+    /// subprocess would otherwise pop open a visible console. Driver output
+    /// is unaffected either way: stdout/stderr are still delivered according
+    /// to [`WebDriverManagerBuilder::stdio`].
+    ///
+    /// No-op on non-Windows platforms.
+    pub fn show_console_window(mut self, yes: bool) -> Self {
+        self.show_console_window = Some(yes);
+        self
+    }
+
     /// Use an already-installed driver binary at `path` for the given
     /// browser instead of resolving and downloading one. Skips the
     /// version-resolution and download/cache flow entirely; the binary is
@@ -373,6 +395,7 @@ impl WebDriverManagerBuilder {
             offline: self.offline.unwrap_or(false),
             mirror: self.mirror.unwrap_or_default(),
             stdio: self.stdio.unwrap_or_default(),
+            show_console_window: self.show_console_window.unwrap_or(false),
             driver_paths: self.driver_paths,
         };
         let emitter = Emitter::new();
@@ -612,6 +635,7 @@ impl WebDriverManager {
                 host: self.cfg.host,
                 ready_timeout: self.cfg.ready_timeout,
                 stdio: self.cfg.stdio,
+                show_console_window: self.cfg.show_console_window,
             },
             SpawnContext {
                 driver_id: self.mint_driver_id(),

--- a/thirtyfour/src/manager/process.rs
+++ b/thirtyfour/src/manager/process.rs
@@ -43,6 +43,10 @@ pub(crate) struct SpawnConfig {
     pub host: IpAddr,
     pub ready_timeout: Duration,
     pub stdio: StdioMode,
+    /// Windows only: skip `CREATE_NO_WINDOW` so the driver gets its own
+    /// console window. Only read on Windows.
+    #[cfg_attr(not(windows), allow(dead_code))]
+    pub show_console_window: bool,
 }
 
 impl Default for SpawnConfig {
@@ -51,6 +55,7 @@ impl Default for SpawnConfig {
             host: IpAddr::V4(Ipv4Addr::LOCALHOST),
             ready_timeout: Duration::from_secs(30),
             stdio: StdioMode::default(),
+            show_console_window: false,
         }
     }
 }
@@ -173,6 +178,17 @@ async fn spawn_at_port(
     cmd.stderr(cfg.stdio.to_stdio());
     cmd.stdin(Stdio::null());
     cmd.kill_on_drop(true);
+
+    // On Windows a console subprocess pops up its own console window whenever
+    // the parent has none (GUI apps built with `windows_subsystem =
+    // "windows"`). Suppress it with CREATE_NO_WINDOW unless the user opted in
+    // via `show_console_window`. Explicitly-set stdio handles still work under
+    // CREATE_NO_WINDOW, so every `StdioMode` behaves the same either way.
+    #[cfg(windows)]
+    if !cfg.show_console_window {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
 
     // chromedriver / msedgedriver bind only to loopback by default; pass
     // --allowed-ips when the user has configured a non-loopback host.


### PR DESCRIPTION
## Summary
- On Windows, `WebDriver::managed` now spawns the driver process (chromedriver / geckodriver / msedgedriver) with the `CREATE_NO_WINDOW` creation flag, so no console window pops up when the parent is a GUI app built with `#![windows_subsystem = "windows"]`
- Adds `WebDriverManagerBuilder::show_console_window(bool)` to opt back into the old behaviour (default: hidden)
- Driver output is unaffected either way: explicitly-set stdio handles still work under `CREATE_NO_WINDOW`, so all `StdioMode` variants (`Tracing`, `Inherit`, `Null`) behave the same

## Notes
- `CREATE_NO_WINDOW` only suppresses window *creation*; with `StdioMode::Inherit` in a console app, output still goes to the parent's console as before
- Verified with `cargo check -p thirtyfour --target x86_64-pc-windows-msvc` (with the `manager` feature) plus the usual fmt/clippy/doc/test checks on the host — runtime behaviour on a real Windows desktop still worth a manual sanity check
- Uses tokio's inherent `Command::creation_flags`, no new dependencies

Fixes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)