### PR TITLE
Bump thirtyfour version to 0.37.2

### DIFF
--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thirtyfour"
-version = "0.37.1"
+version = "0.37.2"
 edition = "2024"
 description = """
 Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI testing.


### PR DESCRIPTION
Patch version bump for the thirtyfour crate (0.37.1 → 0.37.2) ahead of a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)