### PR TITLE
Prevent concurrent GitHub Pages deployments in mdbook workflow

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -4,6 +4,13 @@ on:
     branches:
       - main
 
+# Allow only one concurrent Pages deployment. Don't cancel in-progress runs:
+# let the active deployment finish, but supersede any queued run so rapid
+# merges to main can't race each other in the deploy-pages step.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The **Deploy MdBook** workflow [failed on main](https://github.com/stevepryde/thirtyfour/actions/runs/28741666336) with:

```
Error: Deployment failed, try again later.
```

from `actions/deploy-pages@v4`, right after two merges to main landed a few minutes apart (each triggering its own Pages deployment). This is the known failure mode when Pages deployments race each other.

## Fix

Add the standard `pages` concurrency group used by GitHub's official Pages starter workflows, with `cancel-in-progress: false` so an active deployment is allowed to finish while queued runs are superseded. Rapid merges to main can no longer collide in the deploy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)