### PR TITLE
Export component helpers from the prelude and update docs

### DIFF
--- a/docs/src/features/components.md
+++ b/docs/src/features/components.md
@@ -28,7 +28,6 @@ Wrap it in a Component:
 
 ```rust
 use thirtyfour::prelude::*;
-use thirtyfour::components::ElementResolver;
 
 #[derive(Debug, Clone, Component)]
 pub struct SearchForm {
@@ -136,12 +135,15 @@ Every resolver field exposes the same handful of methods:
 Two macros wrap the most common calls:
 
 ```rust
+use thirtyfour::{resolve, resolve_present};
+
 let elem = resolve!(self.input);            // self.input.resolve().await?
 let elem = resolve_present!(self.input);    // self.input.resolve_present().await?
 ```
 
 The macros are useful for chained method calls without scattering
-`.await?` around:
+`.await?` around. They are exported from the crate root instead of the
+prelude so broad macro names do not get glob-imported accidentally:
 
 ```rust
 resolve!(self.submit).click().await?;
@@ -283,3 +285,8 @@ For the full list of methods and attribute combinations, see:
   the `Component` trait, `ElementResolver`, and helper wrappers.
 - [`thirtyfour_macros::Component`](https://docs.rs/thirtyfour-macros/latest/thirtyfour_macros/derive.Component.html) —
   the derive macro and every supported attribute.
+
+With the default `component` feature enabled, `use thirtyfour::prelude::*;`
+imports the `Component` derive macro and `ElementResolver`. Import
+`resolve!` and `resolve_present!` explicitly from `thirtyfour` when you
+want the shorthand macros.

--- a/docs/src/getting-started/feature-flags.md
+++ b/docs/src/getting-started/feature-flags.md
@@ -2,7 +2,9 @@
 
 - `rustls-tls`: (Default) Use rustls to provide TLS support (via reqwest).
 - `native-tls`: Use native TLS (via reqwest).
-- `component`: (Default) Enable the `Component` derive macro (via thirtyfour_macros).
+- `component`: (Default) Enable the `Component` derive macro (via
+  thirtyfour_macros) and export `Component` / `ElementResolver` from the
+  prelude.
 - `manager`: (Default) Automatic webdriver download and process management;
   see [WebDriver Manager](../features/manager.md). Disable this if you'd
   rather manage the webdriver yourself — see

--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -184,4 +184,4 @@ required-features = ["manager"]
 [[example]]
 name = "playground"
 path = "examples/components/playground.rs"
-required-features = ["manager"]
+required-features = ["manager", "component"]

--- a/thirtyfour/README.md
+++ b/thirtyfour/README.md
@@ -31,7 +31,9 @@ Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI 
 
 - `rustls-tls`: (Default) Use rustls to provide TLS support (via reqwest).
 - `native-tls`: Use native TLS (via reqwest).
-- `component`: (Default) Enable the `Component` derive macro (via thirtyfour_macros).
+- `component`: (Default) Enable the `Component` derive macro (via
+  thirtyfour_macros) and export `Component` / `ElementResolver` from the
+  prelude.
 - `cdp`: (Default) Typed Chrome DevTools Protocol commands.
 - `cdp-events`: WebSocket-backed CDP event subscription.
 - `bidi`: WebDriver BiDi (W3C) — typed commands and event subscription

--- a/thirtyfour/examples/components/playground.rs
+++ b/thirtyfour/examples/components/playground.rs
@@ -7,13 +7,7 @@
 
 use std::time::Duration;
 
-use thirtyfour::{
-    components::{Component, ElementResolver},
-    prelude::*,
-    resolve,
-    stringmatch::StringMatchable,
-    support::sleep,
-};
+use thirtyfour::{prelude::*, resolve, stringmatch::StringMatchable, support::sleep};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/thirtyfour/src/lib.rs
+++ b/thirtyfour/src/lib.rs
@@ -34,7 +34,9 @@
 //!
 //! * `rustls-tls`: (Default) Use rustls to provide TLS support (via reqwest).
 //! * `native-tls`: Use native TLS (via reqwest).
-//! * `component`: (Default) Enable the `Component` derive macro (via thirtyfour-macros).
+//! * `component`: (Default) Enable the `Component` derive macro
+//!   (via thirtyfour-macros) and export [`prelude::Component`] /
+//!   [`prelude::ElementResolver`] from [`prelude`].
 //! * `cdp`: (Default) Typed Chrome DevTools Protocol commands via
 //!   [`WebDriver::cdp`] / [`WebElement::cdp_remote_object_id`] /
 //!   [`WebElement::cdp_backend_node_id`].
@@ -115,6 +117,8 @@
 //!
 //! Components allow you to wrap a web component using smart element resolvers that can
 //! automatically re-query stale elements, and much more.
+//! The default `component` feature makes [`prelude::Component`] and
+//! [`prelude::ElementResolver`] available from [`prelude`].
 //!
 //! ```ignore
 //! #[derive(Debug, Clone, Component)]
@@ -187,6 +191,8 @@ pub use web_element::WebElement;
 pub mod prelude {
     pub use crate::WebDriver;
     pub use crate::WebElement;
+    #[cfg(feature = "component")]
+    pub use crate::components::{Component, ElementResolver};
     pub use crate::error::{WebDriverError, WebDriverResult};
     pub use crate::extensions::query::{ElementPoller, ElementQueryable, ElementWaitable};
     pub use crate::session::scriptret::ScriptRet;

--- a/thirtyfour/tests/components.rs
+++ b/thirtyfour/tests/components.rs
@@ -6,7 +6,6 @@ mod feature_component {
     use assert_matches::assert_matches;
     use rstest::rstest;
     use std::time::Instant;
-    use thirtyfour::components::{Component, ElementResolver};
     use thirtyfour::error::WebDriverErrorInner;
     use thirtyfour::extensions::query::ElementQueryOptions;
     use thirtyfour::support::block_on;


### PR DESCRIPTION
## Summary
- Re-export `Component` and `ElementResolver` from `thirtyfour::prelude` when the default `component` feature is enabled.
- Update docs and examples to import the `resolve!` and `resolve_present!` macros explicitly from the crate root.
- Require the `component` feature for the component playground example so it only builds with the needed APIs.

## Testing
- Not run (not requested)
- Adjusted the component test imports to match the new prelude surface