### PR TITLE
Align docs and examples with query-based browser automation

### DIFF
--- a/docs/src/getting-started/explaining-the-code.md
+++ b/docs/src/getting-started/explaining-the-code.md
@@ -58,11 +58,17 @@ Next, we tell the browser to navigate to Wikipedia:
 And then we look for an element on the page:
 
 ```rust
-    let elem_form = driver.find(By::Id("search-form")).await?;
+    let elem_form = driver
+        .query(By::Id("search-form"))
+        .desc("Wikipedia search form")
+        .single()
+        .await?;
 ```
 
 We search for elements using what we call a `selector` or `locator`. In this case we are looking for
-an element with the id of `search-form`.
+an element with the id of `search-form`. The `query()` method polls until the element appears, and
+`desc()` gives the query a readable name if it times out. Calling `single()` also checks our page
+contract: exactly one search form should match this selector.
 
 > If you actually navigate to [https://wikipedia.org](https://wikipedia.org) and open your browser's
 > devtools (F12 in most browsers), then go to the `Inspector` tab, you will see the raw HTML for
@@ -74,11 +80,16 @@ This is the container element that contains both the input field and the button 
 But we want to type into the field, so we need to do another query:
 
 ```rust
-    let elem_text = elem_form.find(By::Id("searchInput")).await?;
+    let elem_text = elem_form
+        .query(By::Id("searchInput"))
+        .desc("Wikipedia search input")
+        .single()
+        .await?;
 ```
 
-And again, if you search in the inspector for `#searchInput` you get an `<input />` element
-which is the one we want to type into.
+This query starts from `elem_form`, so it only searches inside the form's subtree. If you search in
+the inspector for `#searchInput` you get an `<input />` element, which is the one we want to type
+into.
 
 ## Typing Text Into An Element
 
@@ -94,7 +105,11 @@ Now we need to find the search button and click it. Finding the element means do
 query:
 
 ```rust
-    let elem_button = elem_form.find(By::Css("button[type='submit']")).await?;
+    let elem_button = elem_form
+        .query(By::Css("button[type='submit']"))
+        .desc("Wikipedia search button")
+        .single()
+        .await?;
 ```
 
 This time we use a `CSS` selector to locate a `<button>` element with an attribute `type` that
@@ -123,27 +138,33 @@ cases where you are forced to use this approach, but it should be a last resort.
 from a website testing perspective, it probably also means a human is going to be unsure of when
 the page has actually finished loading, and this is an indicator of a poor user experience.
 
-Instead, we usually want to look for an element on the page and wait until that element is visible.
+Instead, we usually want to look for an element on the page and wait until that element appears.
 
 ```rust
-driver.query(By::ClassName("firstHeading")).first().await?;
+driver
+    .query(By::ClassName("firstHeading"))
+    .desc("Wikipedia article heading")
+    .single()
+    .await?;
 assert_eq!(driver.title().await?, "Selenium - Wikipedia");
 ```
 
 ## Better Element Queries
 
-To have `thirtyfour` "wait" until an element has loaded, we use the `query()` method which provides
-a "builder" interface for constructing more flexible queries. Again, this uses one of the `By`
-selectors, and we tell it to return only the first matching element.
+To have `thirtyfour` wait until an element appears, we use the `query()` method, which provides a
+builder interface for constructing flexible queries. Again, this uses one of the `By` selectors.
+The `single()` terminator expresses that the selector must match exactly one element; use `first()`
+instead when choosing the first of several matches is intentional.
 
-The `query()` method will poll every half-second until it finds the element. If it cannot find the
-element within 30 seconds, it will timeout and return an error. The polling time and timeout duration
-can be changed using `WebDriverConfig`, or you can also override them for a given query.
+By default, `query()` polls every half-second for up to 20 seconds. If no element matches, it times
+out and returns an error that includes the selector and any description added with `desc()`. The
+polling time and timeout duration can be changed using `WebDriverConfig`, or overridden for a given
+query.
 
 The `query()` method is the recommended way to search for elements. The `find()` and `find_all()`
-methods exist only for compatibility with the webdriver spec. The `query()` method uses these
-under the hood, but adds polling and other niceties on top, including giving you more details about
-your query if an element was not found.
+methods are lower-level, one-shot operations shaped like the WebDriver specification. Use them when
+one immediate lookup is deliberate. For everyday automation, `query()` adds polling and other
+niceties, including more detail when an element was not found.
 
 See the [`ElementQuery`](https://docs.rs/thirtyfour/latest/thirtyfour/extensions/query/struct.ElementQuery.html)
 documentation for more details on the kinds of queries it supports.

--- a/docs/src/getting-started/first-code.md
+++ b/docs/src/getting-started/first-code.md
@@ -34,21 +34,37 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;
-    let elem_form = driver.find(By::Id("search-form")).await?;
+    let elem_form = driver
+        .query(By::Id("search-form"))
+        .desc("Wikipedia search form")
+        .single()
+        .await?;
 
-    // Find element from element.
-    let elem_text = elem_form.find(By::Id("searchInput")).await?;
+    // Querying from an element scopes the search to its subtree.
+    let elem_text = elem_form
+        .query(By::Id("searchInput"))
+        .desc("Wikipedia search input")
+        .single()
+        .await?;
 
     // Type in the search terms.
     elem_text.send_keys("selenium").await?;
 
     // Click the search button.
-    let elem_button = elem_form.find(By::Css("button[type='submit']")).await?;
+    let elem_button = elem_form
+        .query(By::Css("button[type='submit']"))
+        .desc("Wikipedia search button")
+        .single()
+        .await?;
     elem_button.click().await?;
 
-    // Look for header to implicitly wait for the page to load.
-    driver.query(By::ClassName("firstHeading")).first().await?;
-    assert_eq!(driver.title().await?, "Selenium – Wikipedia");
+    // Wait for the unique article heading before checking the title.
+    driver
+        .query(By::ClassName("firstHeading"))
+        .desc("Wikipedia article heading")
+        .single()
+        .await?;
+    assert_eq!(driver.title().await?, "Selenium - Wikipedia");
 
     // Always explicitly close the browser.
     driver.quit().await?;

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,21 @@
+# Specifications
+
+This directory records stable, repository-level requirements that are otherwise
+spread across issues, documentation, and examples.
+
+## Current specifications
+
+- [AI-friendly browser automation](ai-friendly-browser-automation.md) owns the
+  reliability contract for the entry-level automation examples and the ordered
+  documentation/API work tracked in [`todo.md`](../todo.md).
+
+## Source map
+
+- **Confirmed intent:** approved or assigned GitHub issue contracts and
+  maintainer instructions.
+- **Observed behavior:** the current crate source, tests, examples, and published
+  documentation.
+- **Ordering guidance:** [`todo.md`](../todo.md). Its checkboxes are not a live
+  substitute for GitHub issue state.
+- **Exact dependency versions and feature gates:** the workspace and crate
+  `Cargo.toml` files.

--- a/specs/ai-friendly-browser-automation.md
+++ b/specs/ai-friendly-browser-automation.md
@@ -1,0 +1,45 @@
+# AI-friendly browser automation
+
+## Purpose
+
+This specification owns the reliability contract for entry-level `thirtyfour`
+examples that humans and coding agents are likely to copy. It does not define
+the later selector-guidance, AI quickstart, recipe, harness, or debugging work
+ordered in [`todo.md`](../todo.md).
+
+## Requirements
+
+- **AI-AUTO-001 (confirmed):** Entry-level examples that manage a local browser
+  must use `WebDriver::managed`; an example specifically teaching an external
+  Selenium endpoint may use `WebDriver::new`. Every flow must explicitly call
+  `driver.quit().await?`.
+- **AI-AUTO-002 (confirmed):** Normal element lookup in entry-level examples
+  must use `WebDriver::query` or `WebElement::query`, so lookup polls for the
+  required page state instead of making a one-shot request.
+- **AI-AUTO-003 (confirmed):** Queries for important user-facing elements must
+  include a human-readable description for timeout diagnostics.
+- **AI-AUTO-004 (confirmed):** A query must use `single()` when exactly one
+  match is part of the example's page contract, and `first()` only when
+  first-match behavior is intentional.
+- **AI-AUTO-005 (confirmed):** The entry-level documentation must describe
+  `find()` and `find_all()` as lower-level, one-shot WebDriver operations rather
+  than the normal automation path.
+- **AI-AUTO-006 (observed):** The repository-root README is a symlink to the
+  crate README, which directs readers to the `tokio_async` runnable example.
+- **AI-AUTO-007 (confirmed):** The README, crate-level rustdoc, mdBook
+  walkthrough, and matching runnable examples must stay behaviorally aligned.
+
+## Acceptance criteria
+
+- **AC-001:** The crate README, crate-level rustdoc, mdBook first-code page, and
+  matching runnable examples contain no `find()` call in their Wikipedia user
+  flow. Covers AI-AUTO-002.
+- **AC-002:** The search form, search input, search button, and, where present,
+  resulting article heading queries have readable descriptions and enforce
+  their intended uniqueness. Covers AI-AUTO-003 and AI-AUTO-004.
+- **AC-003:** The mdBook explanation teaches the query-based flow and explicitly
+  preserves `find()` / `find_all()` as deliberate one-shot APIs. Covers
+  AI-AUTO-002 and AI-AUTO-005.
+- **AC-004:** The updated runnable examples compile with their existing required
+  feature sets, and repository formatting, library tests, doc tests, clippy,
+  and rustdoc validation pass. Covers AI-AUTO-001 through AI-AUTO-007.

--- a/thirtyfour/README.md
+++ b/thirtyfour/README.md
@@ -56,20 +56,36 @@ async fn main() -> WebDriverResult<()> {
 
      // Navigate to https://wikipedia.org.
      driver.goto("https://wikipedia.org").await?;
-     let elem_form = driver.find(By::Id("search-form")).await?;
+     let elem_form = driver
+         .query(By::Id("search-form"))
+         .desc("Wikipedia search form")
+         .single()
+         .await?;
 
-     // Find element from element.
-     let elem_text = elem_form.find(By::Id("searchInput")).await?;
+     // Querying from an element scopes the search to its subtree.
+     let elem_text = elem_form
+         .query(By::Id("searchInput"))
+         .desc("Wikipedia search input")
+         .single()
+         .await?;
 
      // Type in the search terms.
      elem_text.send_keys("selenium").await?;
 
      // Click the search button.
-     let elem_button = elem_form.find(By::Css("button[type='submit']")).await?;
+     let elem_button = elem_form
+         .query(By::Css("button[type='submit']"))
+         .desc("Wikipedia search button")
+         .single()
+         .await?;
      elem_button.click().await?;
 
-     // Look for header to implicitly wait for the page to load.
-     driver.find(By::ClassName("firstHeading")).await?;
+     // Wait for the unique article heading before checking the title.
+     driver
+         .query(By::ClassName("firstHeading"))
+         .desc("Wikipedia article heading")
+         .single()
+         .await?;
      assert_eq!(driver.title().await?, "Selenium - Wikipedia");
 
      // Always explicitly close the browser.

--- a/thirtyfour/examples/minimal_async.rs
+++ b/thirtyfour/examples/minimal_async.rs
@@ -14,17 +14,23 @@ async fn main() -> anyhow::Result<()> {
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;
 
-    // Find element.
-    let elem_form = driver.find(By::Id("search-form")).await?;
+    // Query the unique search form.
+    let elem_form =
+        driver.query(By::Id("search-form")).desc("Wikipedia search form").single().await?;
 
-    // Find element from element.
-    let elem_text = elem_form.find(By::Id("searchInput")).await?;
+    // Querying from an element scopes the search to its subtree.
+    let elem_text =
+        elem_form.query(By::Id("searchInput")).desc("Wikipedia search input").single().await?;
 
     // Type in the search terms.
     elem_text.send_keys("selenium").await?;
 
     // Click the search button.
-    let elem_button = elem_form.find(By::Css("button[type='submit']")).await?;
+    let elem_button = elem_form
+        .query(By::Css("button[type='submit']"))
+        .desc("Wikipedia search button")
+        .single()
+        .await?;
     elem_button.click().await?;
 
     // Always explicitly close the browser. This prevents the executor from being blocked

--- a/thirtyfour/examples/selenium_example.rs
+++ b/thirtyfour/examples/selenium_example.rs
@@ -16,20 +16,26 @@ async fn main() -> anyhow::Result<()> {
 
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;
-    let elem_form = driver.find(By::Id("search-form")).await?;
+    let elem_form =
+        driver.query(By::Id("search-form")).desc("Wikipedia search form").single().await?;
 
-    // Find element from element.
-    let elem_text = elem_form.find(By::Id("searchInput")).await?;
+    // Querying from an element scopes the search to its subtree.
+    let elem_text =
+        elem_form.query(By::Id("searchInput")).desc("Wikipedia search input").single().await?;
 
     // Type in the search terms.
     elem_text.send_keys("selenium").await?;
 
     // Click the search button.
-    let elem_button = elem_form.find(By::Css("button[type='submit']")).await?;
+    let elem_button = elem_form
+        .query(By::Css("button[type='submit']"))
+        .desc("Wikipedia search button")
+        .single()
+        .await?;
     elem_button.click().await?;
 
-    // Look for header to implicitly wait for the page to load.
-    driver.find(By::ClassName("firstHeading")).await?;
+    // Wait for the unique article heading before checking the title.
+    driver.query(By::ClassName("firstHeading")).desc("Wikipedia article heading").single().await?;
     assert_eq!(driver.title().await?, "Selenium - Wikipedia");
 
     // Always explicitly close the browser. This prevents the executor from being blocked

--- a/thirtyfour/examples/tokio_async.rs
+++ b/thirtyfour/examples/tokio_async.rs
@@ -12,20 +12,26 @@ async fn main() -> anyhow::Result<()> {
     let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;
-    let elem_form = driver.find(By::Id("search-form")).await?;
+    let elem_form =
+        driver.query(By::Id("search-form")).desc("Wikipedia search form").single().await?;
 
-    // Find element from element.
-    let elem_text = elem_form.find(By::Id("searchInput")).await?;
+    // Querying from an element scopes the search to its subtree.
+    let elem_text =
+        elem_form.query(By::Id("searchInput")).desc("Wikipedia search input").single().await?;
 
     // Type in the search terms.
     elem_text.send_keys("selenium").await?;
 
     // Click the search button.
-    let elem_button = elem_form.find(By::Css("button[type='submit']")).await?;
+    let elem_button = elem_form
+        .query(By::Css("button[type='submit']"))
+        .desc("Wikipedia search button")
+        .single()
+        .await?;
     elem_button.click().await?;
 
-    // Look for header to implicitly wait for the page to load.
-    driver.query(By::ClassName("firstHeading")).first().await?;
+    // Wait for the unique article heading before checking the title.
+    driver.query(By::ClassName("firstHeading")).desc("Wikipedia article heading").single().await?;
     assert_eq!(driver.title().await?, "Selenium - Wikipedia");
 
     // Always explicitly close the browser. This prevents the executor from being blocked

--- a/thirtyfour/examples/tokio_basic.rs
+++ b/thirtyfour/examples/tokio_basic.rs
@@ -16,20 +16,26 @@ async fn run() -> anyhow::Result<()> {
     let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
     // Navigate to https://wikipedia.org.
     driver.goto("https://wikipedia.org").await?;
-    let elem_form = driver.find(By::Id("search-form")).await?;
+    let elem_form =
+        driver.query(By::Id("search-form")).desc("Wikipedia search form").single().await?;
 
-    // Find element from element.
-    let elem_text = elem_form.find(By::Id("searchInput")).await?;
+    // Querying from an element scopes the search to its subtree.
+    let elem_text =
+        elem_form.query(By::Id("searchInput")).desc("Wikipedia search input").single().await?;
 
     // Type in the search terms.
     elem_text.send_keys("selenium").await?;
 
     // Click the search button.
-    let elem_button = elem_form.find(By::Css("button[type='submit']")).await?;
+    let elem_button = elem_form
+        .query(By::Css("button[type='submit']"))
+        .desc("Wikipedia search button")
+        .single()
+        .await?;
     elem_button.click().await?;
 
-    // Look for header to implicitly wait for the page to load.
-    driver.find(By::ClassName("firstHeading")).await?;
+    // Wait for the unique article heading before checking the title.
+    driver.query(By::ClassName("firstHeading")).desc("Wikipedia article heading").single().await?;
     assert_eq!(driver.title().await?, "Selenium - Wikipedia");
 
     // Always explicitly close the browser. This prevents the executor from being blocked

--- a/thirtyfour/src/lib.rs
+++ b/thirtyfour/src/lib.rs
@@ -63,20 +63,36 @@
 //!
 //!     // Navigate to https://wikipedia.org.
 //!     driver.goto("https://wikipedia.org").await?;
-//!     let elem_form = driver.find(By::Id("search-form")).await?;
+//!     let elem_form = driver
+//!         .query(By::Id("search-form"))
+//!         .desc("Wikipedia search form")
+//!         .single()
+//!         .await?;
 //!
-//!     // Find element from element.
-//!     let elem_text = elem_form.find(By::Id("searchInput")).await?;
+//!     // Querying from an element scopes the search to its subtree.
+//!     let elem_text = elem_form
+//!         .query(By::Id("searchInput"))
+//!         .desc("Wikipedia search input")
+//!         .single()
+//!         .await?;
 //!
 //!     // Type in the search terms.
 //!     elem_text.send_keys("selenium").await?;
 //!
 //!     // Click the search button.
-//!     let elem_button = elem_form.find(By::Css("button[type='submit']")).await?;
+//!     let elem_button = elem_form
+//!         .query(By::Css("button[type='submit']"))
+//!         .desc("Wikipedia search button")
+//!         .single()
+//!         .await?;
 //!     elem_button.click().await?;
 //!
-//!     // Look for header to implicitly wait for the page to load.
-//!     driver.find(By::ClassName("firstHeading")).await?;
+//!     // Wait for the unique article heading before checking the title.
+//!     driver
+//!         .query(By::ClassName("firstHeading"))
+//!         .desc("Wikipedia article heading")
+//!         .single()
+//!         .await?;
 //!     assert_eq!(driver.title().await?, "Selenium - Wikipedia");
 //!
 //!     // explicitly close the browser.


### PR DESCRIPTION
## Summary
- Update the getting started docs, crate README, and rustdoc example to use `query()` with `desc()` and `single()` for the Wikipedia flow.
- Clarify that `find()` and `find_all()` are lower-level one-shot lookups, while `query()` is the recommended polling API.
- Add repository-level specs capturing the browser-automation reliability contract and acceptance criteria.
- Keep the runnable examples aligned with the documentation, including the article-heading wait and title assertion text.

## Testing
- Not run (not requested)