### PR TITLE
Document stable selector guidance

### DIFF
--- a/docs/src/features/components.md
+++ b/docs/src/features/components.md
@@ -20,7 +20,7 @@ Suppose your page contains a search form:
 ```html
 <form id="search-form">
     <input type="text" id="search-input" />
-    <button type="submit">Search</button>
+    <button type="submit" data-testid="search-submit">Search</button>
 </form>
 ```
 
@@ -34,7 +34,7 @@ pub struct SearchForm {
     base: WebElement,                              // The <form> itself.
     #[by(id = "search-input")]
     input: ElementResolver<WebElement>,            // The <input>.
-    #[by(css = "button[type='submit']")]
+    #[by(testid = "search-submit", description = "search submit button")]
     submit: ElementResolver<WebElement>,           // The <button>.
 }
 

--- a/docs/src/features/queries.md
+++ b/docs/src/features/queries.md
@@ -49,8 +49,53 @@ Pass any of these `By` variants to `query()`:
 | `By::PartialLinkText("...")` | `<a>` whose visible text contains the string |
 | `By::Testid("...")`   | Element with `data-testid="..."`         |
 
-`By::Css` and `By::XPath` are the most expressive; the others are
-convenience wrappers and most are implemented as CSS under the hood.
+`By::Css` can express compound CSS selectors, while `By::XPath` covers
+relationships CSS cannot represent. The other variants are convenient,
+purpose-specific selectors, and most are implemented as CSS under the hood.
+
+## Choosing Stable Selectors
+
+Use selectors in this order when the application gives you the choice:
+
+1. **App-owned test IDs.** Add a stable `data-testid` to important controls and
+   select it with `By::Testid`. This keeps tests independent of styling and
+   displayed copy.
+2. **Stable semantic CSS.** When no test ID exists, target durable attributes
+   and element roles, such as `button[type='submit']`, rather than generated
+   classes or a long chain of DOM positions.
+3. **Visible text when the copy is the behavior.** Text matching is useful for
+   verifying an error message, heading, or labeled action. It is brittle as a
+   default element identity because copy changes, localization, and duplicate
+   labels can break an otherwise-correct flow.
+4. **XPath only when CSS cannot express the target.** XPath is useful for
+   relationships or document structures CSS cannot select, but is usually
+   harder to read and easier to couple to the current DOM.
+
+For an app-owned test hook:
+
+```rust
+let save_button = driver
+    .query(By::Testid("settings-save"))
+    .desc("settings save button")
+    .single()
+    .await?;
+```
+
+Use a strong selector before a text filter when the visible wording also
+matters:
+
+```rust
+let status = driver
+    .query(By::Testid("settings-status"))
+    .with_text("Saved")
+    .desc("saved settings status")
+    .single()
+    .await?;
+```
+
+`By::Testid` targets the conventional `data-testid` attribute. Teams that use
+another app-owned attribute can express it with CSS, for example
+`By::Css("[data-qa='settings-save']")`.
 
 ## Picking An Element
 
@@ -122,7 +167,7 @@ for partial / case-insensitive / word-boundary matches:
 use thirtyfour::stringmatch::StringMatchable;
 
 let btn = driver
-    .query(By::Tag("button"))
+    .query(By::Testid("account-submit"))
     .with_text("Submit".match_partial().case_insensitive())
     .first()
     .await?;
@@ -143,8 +188,9 @@ Available filter families (each has a `with_*` and a `without_*` form):
   `.with_css_properties(...)`
 
 Each filter triggers an extra WebDriver round trip per poll iteration,
-so prefer narrowing the initial `By` selector when you can. CSS and
-XPath are usually the right tool for complex matches.
+so prefer narrowing the initial `By` selector when you can. Start with an
+app-owned test ID or stable CSS selector, add filters only for behavior the
+test needs to verify, and reserve XPath for targets CSS cannot express.
 
 ## Custom Predicates
 

--- a/docs/src/getting-started/explaining-the-code.md
+++ b/docs/src/getting-started/explaining-the-code.md
@@ -70,6 +70,28 @@ an element with the id of `search-form`. The `query()` method polls until the el
 `desc()` gives the query a readable name if it times out. Calling `single()` also checks our page
 contract: exactly one search form should match this selector.
 
+### Choosing A Stable Selector
+
+When you control the application under test, add stable `data-testid` hooks to
+important controls and prefer `By::Testid`:
+
+```rust
+let save_button = driver
+    .query(By::Testid("settings-save"))
+    .desc("settings save button")
+    .single()
+    .await?;
+```
+
+If there is no app-owned test ID, use a stable semantic CSS selector next.
+Match visible text when the wording itself is part of the behavior you need to
+verify, not as the default identity of a control: copy changes, localization,
+and duplicate labels can otherwise break the test. Use XPath only when CSS
+cannot reasonably express the target.
+
+Wikipedia does not provide test IDs for this flow, so the walkthrough uses the
+stable selectors that the real third-party page exposes.
+
 > If you actually navigate to [https://wikipedia.org](https://wikipedia.org) and open your browser's
 > devtools (F12 in most browsers), then go to the `Inspector` tab, you will see the raw HTML for
 > the page. In the search box at the top of the inspector, if you type `#search-form`

--- a/docs/src/getting-started/first-code.md
+++ b/docs/src/getting-started/first-code.md
@@ -73,6 +73,22 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 }
 ```
 
+> **Selector note:** Wikipedia is a third-party site, so this example uses the
+> stable IDs, element types, and classes that the real page exposes. In an app
+> you control, add stable `data-testid` hooks to important controls and prefer
+> `By::Testid`:
+>
+> ```rust
+> let save_button = driver
+>     .query(By::Testid("settings-save"))
+>     .desc("settings save button")
+>     .single()
+>     .await?;
+> ```
+>
+> See [Element Queries](../features/queries.md#choosing-stable-selectors) for
+> the selector priority and guidance on text matching and XPath.
+
 Make sure Chrome is installed, then run:
 
     cargo run

--- a/specs/ai-friendly-browser-automation.md
+++ b/specs/ai-friendly-browser-automation.md
@@ -3,9 +3,9 @@
 ## Purpose
 
 This specification owns the reliability contract for entry-level `thirtyfour`
-examples that humans and coding agents are likely to copy. It does not define
-the later selector-guidance, AI quickstart, recipe, harness, or debugging work
-ordered in [`todo.md`](../todo.md).
+examples and selector guidance that humans and coding agents are likely to
+copy. It does not define the later AI quickstart, recipe, harness, or debugging
+work ordered in [`todo.md`](../todo.md).
 
 ## Requirements
 
@@ -28,6 +28,20 @@ ordered in [`todo.md`](../todo.md).
   crate README, which directs readers to the `tokio_async` runnable example.
 - **AI-AUTO-007 (confirmed):** The README, crate-level rustdoc, mdBook
   walkthrough, and matching runnable examples must stay behaviorally aligned.
+- **AI-SEL-001 (confirmed):** Documentation must prefer stable, app-owned
+  `data-testid` hooks through `By::Testid` when the application under test can
+  provide them.
+- **AI-SEL-002 (confirmed):** Selector guidance must recommend stable semantic
+  CSS selectors when no test ID exists, and XPath only when CSS cannot
+  reasonably express the target.
+- **AI-SEL-003 (confirmed):** Visible-text matching is appropriate when the
+  displayed copy is part of the behavior under test. It must not be presented
+  as the default way to identify controls because copy, localization, and
+  duplicate labels can make it brittle.
+- **AI-SEL-004 (confirmed):** Examples against third-party sites must use
+  selectors the real page exposes rather than pretending app-owned test hooks
+  exist. The surrounding guidance must distinguish this constraint from the
+  preferred practice for applications the reader controls.
 
 ## Acceptance criteria
 
@@ -43,3 +57,12 @@ ordered in [`todo.md`](../todo.md).
 - **AC-004:** The updated runnable examples compile with their existing required
   feature sets, and repository formatting, library tests, doc tests, clippy,
   and rustdoc validation pass. Covers AI-AUTO-001 through AI-AUTO-007.
+- **AC-005:** The README, crate-level rustdoc, and getting-started path show
+  `By::Testid` and explain the stable-selector priority without making the live
+  Wikipedia flow inaccurate. Covers AI-SEL-001, AI-SEL-002, and AI-SEL-004.
+- **AC-006:** The query documentation explains when text matching is meaningful
+  versus brittle, shows the CSS escape hatch for custom test attributes, and
+  reserves XPath for targets CSS cannot express. Covers AI-SEL-002 and
+  AI-SEL-003.
+- **AC-007:** The component documentation contains a concrete `testid` resolver
+  example. Covers AI-SEL-001.

--- a/thirtyfour/README.md
+++ b/thirtyfour/README.md
@@ -13,7 +13,7 @@ Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI 
 - All W3C WebDriver and WebElement methods supported
 - Create new browser session directly via WebDriver (e.g. chromedriver)
 - Create new browser session via Selenium Standalone or Grid
-- Find elements (via all common selectors e.g. Id, Class, CSS, Tag, XPath)
+- Find elements (via all common selectors e.g. Testid, Id, Class, CSS, Tag, XPath)
 - Send keys to elements, including key-combinations
 - Execute Javascript
 - Action Chains
@@ -94,6 +94,27 @@ async fn main() -> WebDriverResult<()> {
      Ok(())
 }
 ```
+
+### Prefer stable selectors
+
+When you control the application under test, give important elements stable
+`data-testid` hooks and select them with `By::Testid`:
+
+```rust
+let save_button = driver
+    .query(By::Testid("settings-save"))
+    .desc("settings save button")
+    .single()
+    .await?;
+```
+
+Prefer app-owned test IDs first, then stable semantic CSS selectors. Match
+visible text when the copy itself is part of the behavior you are testing, and
+use XPath only when CSS cannot reasonably express the target. The Wikipedia
+example above uses the stable selectors that third-party page actually exposes.
+
+See the [Element Queries](https://stevepryde.github.io/thirtyfour/features/queries.html)
+chapter for the full selector guidance.
 
 ## Minimum Supported Rust Version
 

--- a/thirtyfour/src/lib.rs
+++ b/thirtyfour/src/lib.rs
@@ -129,6 +129,28 @@
 //! [`WebElement::wait_until`]: extensions::query::ElementWaitable::wait_until
 //! [`query`]: extensions::query
 //!
+//! ### Prefer stable selectors
+//!
+//! When you control the application under test, give important elements stable
+//! `data-testid` hooks and select them with [`By::Testid`]:
+//!
+//! ```no_run
+//! # use thirtyfour::prelude::*;
+//! # async fn example(driver: &WebDriver) -> WebDriverResult<()> {
+//! let save_button = driver
+//!     .query(By::Testid("settings-save"))
+//!     .desc("settings save button")
+//!     .single()
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Prefer app-owned test IDs first, then stable semantic CSS selectors. Match
+//! visible text when the copy itself is part of the behavior under test, and
+//! use XPath only when CSS cannot reasonably express the target. Examples
+//! against third-party sites must use the stable selectors those sites expose.
+//!
 //! ### Components
 //!
 //! Components allow you to wrap a web component using smart element resolvers that can


### PR DESCRIPTION
## Summary

- make `By::Testid` prominent in the README, crate rustdoc, and getting-started documentation
- document a stable-selector priority for app-owned test IDs, semantic CSS, visible text, and XPath
- add a component example using a `testid` resolver
- extend the AI-friendly browser automation specification with the selector contract

## Why

The entry-level documentation listed `By::Testid` but did not teach readers or AI tools to prefer stable, app-owned selectors. This made generated automation more likely to depend on styling, copy, or brittle DOM structure.

The live Wikipedia walkthrough keeps the selectors the third-party page actually exposes; the surrounding guidance distinguishes that constraint from applications readers control.

Closes #336.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p thirtyfour --lib`
- `cargo test -p thirtyfour --doc`
- `cargo clippy --all-features --all-targets`
- `cargo doc --no-deps --all-features`
- `mdbook build docs`
- independent Dream Team review with no actionable findings
