### PR TITLE
Document reliable AI-generated test rules

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
 - [Installation](./getting-started/installation.md)
 - [Your First Browser Automation Code](./getting-started/first-code.md)
 - [Explaining The Code](./getting-started/explaining-the-code.md)
+- [Reliable AI-Generated Tests](./getting-started/reliable-tests.md)
 - [Feature Flags](./getting-started/feature-flags.md)
 # Feature Documentation
 - [Element Queries](./features/queries.md)

--- a/docs/src/getting-started/first-code.md
+++ b/docs/src/getting-started/first-code.md
@@ -117,3 +117,8 @@ Make sure Firefox is installed, and re-run:
 If everything worked correctly, you should have seen the Wikipedia page open up on Firefox this time.
 
 Congratulations! You successfully automated a web browser.
+
+Before building a larger suite, copy the short
+[Reliable AI-Generated Tests](./reliable-tests.md) checklist into your coding-agent
+instructions or project guidance. It captures the reliability rules used by this
+example and links to the deeper documentation for each one.

--- a/docs/src/getting-started/reliable-tests.md
+++ b/docs/src/getting-started/reliable-tests.md
@@ -1,0 +1,55 @@
+# Reliable AI-Generated Tests
+
+Use this checklist when asking a coding agent to write or review `thirtyfour`
+automation. It is intentionally short enough to paste into project-level agent
+instructions:
+
+```text
+- Use WebDriver::managed for local browsers; use WebDriver::new or builder only
+  when connecting to a remote Selenium or Grid endpoint.
+- Use query() for normal lookup. Use find() only for an intentional one-shot lookup.
+- End unique queries with single(), and add desc(...) to important queries.
+- Prefer By::Testid or another stable app-owned selector. Avoid generated classes,
+  DOM-position chains, and XPath when stable CSS can express the target.
+- Never use a fixed sleep for page readiness. Wait with query() or wait_until().
+- Scope queries through a container element; use Components for repeated UI areas.
+- Explicitly call driver.quit().await? when the session is finished.
+- Do not share one WebDriver session across independent concurrent flows. A shared
+  WebDriverManager may launch separate sessions for parallel tests.
+- Keep CDP and BiDi code isolated from portable WebDriver flows. Gate optional
+  cdp-events and bidi APIs with their Cargo features, and opt BiDi sessions in.
+```
+
+## Why These Rules
+
+- [`WebDriver::managed`](../features/manager.md) downloads, launches, and
+  lifetime-manages a local driver. Use the normal constructor or
+  [`WebDriver::builder`](../appendix/manual-webdriver.md) when an external
+  Selenium service owns that lifecycle. Explicit `quit()` reports shutdown
+  errors and does not rely on asynchronous cleanup during `Drop`.
+- [Element queries](../features/queries.md) poll for page state and provide
+  filters, descriptions, and cardinality checks. See the guidance for
+  [stable selectors](../features/queries.md#choosing-stable-selectors),
+  [choosing `single()` or `first()`](../features/queries.md#picking-an-element),
+  [describing important queries](../features/queries.md#better-error-messages),
+  and [intentional one-shot lookup](../features/queries.md#a-note-on-find--find_all).
+- [Element waits](../features/waiting.md) express the state an existing element
+  must reach. A fixed sleep only guesses how long the page needs; a query or wait
+  completes as soon as the required state exists and produces a useful timeout
+  when it does not.
+- Element-scoped queries prevent unrelated matches. For recurring UI areas,
+  [Components](../features/components.md) keep selectors private and expose
+  user-intent methods while their resolvers handle polling and stale elements.
+- A cloned `WebDriver` controls the same browser session, so independent flows
+  can race over tabs, navigation, and browser state. The
+  [manager's shared configuration](../features/manager.md#sharing-one-manager-across-sessions)
+  can instead launch a separate session for each test or worker.
+- CDP is Chromium-specific, while BiDi is the cross-browser W3C protocol. Keep
+  either behind a small boundary so the rest of the automation remains portable,
+  and follow the [feature flag](./feature-flags.md) and
+  [BiDi opt-in](../bidi/overview.md#enabling-bidi) requirements. The `cdp` feature
+  is enabled by default; `cdp-events` and `bidi` are opt-in.
+
+Treat these as review rules, not merely generation hints: generated code should
+not be accepted until its selectors, waits, cleanup, concurrency, and feature
+gates satisfy the same checklist.

--- a/specs/ai-friendly-browser-automation.md
+++ b/specs/ai-friendly-browser-automation.md
@@ -3,9 +3,9 @@
 ## Purpose
 
 This specification owns the reliability contract for entry-level `thirtyfour`
-examples and selector guidance that humans and coding agents are likely to
-copy. It does not define the later AI quickstart, recipe, harness, or debugging
-work ordered in [`todo.md`](../todo.md).
+examples, selector guidance, and coding-agent guidance that humans and agents
+are likely to copy. It does not define the later AI quickstart, recipe, harness,
+or debugging work ordered in [`todo.md`](../todo.md).
 
 ## Requirements
 
@@ -42,6 +42,17 @@ work ordered in [`todo.md`](../todo.md).
   selectors the real page exposes rather than pretending app-owned test hooks
   exist. The surrounding guidance must distinguish this constraint from the
   preferred practice for applications the reader controls.
+- **AI-STYLE-001 (confirmed):** The mdBook must provide one concise checklist
+  of reliability rules suitable for pasting into coding-agent instructions.
+- **AI-STYLE-002 (confirmed):** The checklist must cover session setup and
+  cleanup, query semantics and diagnostics, stable selectors, readiness waits,
+  query scoping and components, session concurrency, and protocol-specific
+  isolation and feature gates.
+- **AI-STYLE-003 (confirmed):** Every major checklist rule must link to the
+  deeper documentation that defines its behavior and must not claim that a
+  planned API, such as the managed test harness, already exists.
+- **AI-STYLE-004 (confirmed):** The checklist must be linked directly from the
+  getting-started learning path.
 
 ## Acceptance criteria
 
@@ -66,3 +77,8 @@ work ordered in [`todo.md`](../todo.md).
   AI-SEL-003.
 - **AC-007:** The component documentation contains a concrete `testid` resolver
   example. Covers AI-SEL-001.
+- **AC-008:** A standalone mdBook page contains a copyable checklist covering
+  all AI-STYLE-002 topics without duplicating the deeper guides. Covers
+  AI-STYLE-001 through AI-STYLE-003.
+- **AC-009:** The mdBook summary and first-code page link to the checklist.
+  Covers AI-STYLE-004.


### PR DESCRIPTION
## Summary

- add a concise, copyable checklist for reliable AI-generated `thirtyfour` tests
- link each major rule to the existing manager, query, waiting, component, and protocol guidance
- add the checklist to the getting-started navigation and first-code learning path
- record the checklist requirements and acceptance criteria in the AI-friendly automation spec

## Why

The crate already provides the primitives needed for reliable automation, but their usage rules were distributed across several documentation pages. This gives humans and coding agents one concrete review contract without duplicating the deeper guides or advertising future APIs.

Fixes #339.

## Validation

- `cargo fmt --check`
- `cargo test -p thirtyfour --lib`
- `cargo test -p thirtyfour --doc`
- `cargo clippy --all-features --all-targets`
- `cargo doc --no-deps --all-features`
- `mdbook build docs`
- `git diff --check`
- verified generated mdBook HTML and deep-link anchors