### PR TITLE
docs: add AI/LLM browser automation quickstart

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
 # Getting Started
 - [Installation](./getting-started/installation.md)
 - [Your First Browser Automation Code](./getting-started/first-code.md)
+- [AI/LLM Quickstart](./getting-started/ai-quickstart.md)
 - [Explaining The Code](./getting-started/explaining-the-code.md)
 - [Reliable AI-Generated Tests](./getting-started/reliable-tests.md)
 - [Feature Flags](./getting-started/feature-flags.md)

--- a/docs/src/getting-started/ai-quickstart.md
+++ b/docs/src/getting-started/ai-quickstart.md
@@ -1,0 +1,112 @@
+# AI/LLM Quickstart
+
+Use this page as the compact source of truth when asking an AI coding tool to
+write `thirtyfour` automation. It keeps the reliable defaults in one place and
+links to the deeper documentation when a task needs more detail.
+
+## Minimal Setup
+
+```toml
+[dependencies]
+thirtyfour = "THIRTYFOUR_CRATE_VERSION"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+The default `thirtyfour` features include the local
+[`WebDriver::managed`](../features/manager.md) setup used below. Use
+[`WebDriver::new` or `WebDriver::builder`](../appendix/manual-webdriver.md)
+instead when a remote Selenium or Grid service owns the driver process.
+Install Chrome before running the test; the manager downloads a matching
+`chromedriver` automatically on first use.
+
+## Starter Test
+
+This example is marked `no_run` because `example.test` represents your
+application and cannot be exercised as written.
+
+```rust,no_run
+use thirtyfour::prelude::*;
+
+#[tokio::test]
+async fn saves_profile_settings() -> WebDriverResult<()> {
+    let mut caps = DesiredCapabilities::chrome();
+    caps.set_headless()?;
+    let driver = WebDriver::managed(caps).await?;
+
+    // Keep the test result so quit() is attempted even when an assertion or
+    // browser command fails.
+    let test_result: WebDriverResult<()> = async {
+        driver.goto("https://example.test/settings").await?;
+
+        let form = driver
+            .query(By::Testid("profile-settings"))
+            .desc("profile settings form")
+            .single()
+            .await?;
+
+        form.query(By::Testid("display-name"))
+            .desc("display name input")
+            .single()
+            .await?
+            .send_keys("Ada")
+            .await?;
+
+        let save_button = form
+            .query(By::Testid("save-profile"))
+            .desc("save profile button")
+            .single()
+            .await?;
+        save_button.wait_until().clickable().await?;
+        save_button.click().await?;
+
+        // Assert the user-visible outcome. This query polls until the saved
+        // state appears, so it replaces a brittle fixed sleep.
+        driver
+            .query(By::Testid("settings-status"))
+            .with_text("Saved")
+            .and_displayed()
+            .desc("saved settings status")
+            .single()
+            .await?;
+
+        Ok(())
+    }
+    .await;
+
+    let quit_result = driver.quit().await;
+    test_result?;
+    quit_result
+}
+```
+
+## Rules For Generated Automation
+
+- Prefer app-owned `By::Testid` selectors, then stable semantic CSS. Match
+  visible text when the copy is the behavior under test; use XPath only when
+  CSS cannot reasonably express the target.
+- Use `query()` for normal lookup, `.single()` when uniqueness is a page
+  contract, and `.desc(...)` on important user-facing elements.
+- Never use a fixed sleep for readiness. Poll for the required state with
+  `query()` or use `wait_until()` on an element you already have.
+- Scope queries through a container or Component, and assert a user-visible
+  outcome rather than only checking that a click returned successfully.
+- Explicitly quit every session. Do not run independent concurrent flows
+  through clones of the same `WebDriver`.
+
+The copyable [Reliable AI-Generated Tests](./reliable-tests.md) checklist is the
+review gate for generated code. Apply it before accepting a test.
+
+## Deeper Documentation
+
+- [Element Queries](../features/queries.md) — stable selectors, descriptions,
+  filters, scoping, cardinality, and intentional one-shot `find()` calls.
+- [Waiting For Element Changes](../features/waiting.md) — state waits for an
+  element that has already been located.
+- [Components](../features/components.md) — reusable UI areas with private
+  selectors and resilient element resolution.
+- [WebDriver Manager](../features/manager.md) — local driver downloads,
+  process lifetime, configuration, and separate sessions.
+- [Chrome DevTools Protocol](../cdp/overview.md) — Chromium-only typed commands
+  and optional event support.
+- [WebDriver BiDi](../bidi/overview.md) — cross-browser bidirectional commands
+  and events, with feature and capability opt-in.

--- a/specs/ai-friendly-browser-automation.md
+++ b/specs/ai-friendly-browser-automation.md
@@ -3,16 +3,17 @@
 ## Purpose
 
 This specification owns the reliability contract for entry-level `thirtyfour`
-examples, selector guidance, and coding-agent guidance that humans and agents
-are likely to copy. It does not define the later AI quickstart, recipe, harness,
-or debugging work ordered in [`todo.md`](../todo.md).
+examples, selector guidance, the AI/LLM quickstart, and coding-agent guidance
+that humans and agents are likely to copy. It does not define the later recipe,
+harness, or debugging work ordered in [`todo.md`](../todo.md).
 
 ## Requirements
 
 - **AI-AUTO-001 (confirmed):** Entry-level examples that manage a local browser
   must use `WebDriver::managed`; an example specifically teaching an external
-  Selenium endpoint may use `WebDriver::new`. Every flow must explicitly call
-  `driver.quit().await?`.
+  Selenium endpoint may use `WebDriver::new`. Every flow must explicitly await
+  `driver.quit()` and propagate its error when no earlier flow error takes
+  precedence.
 - **AI-AUTO-002 (confirmed):** Normal element lookup in entry-level examples
   must use `WebDriver::query` or `WebElement::query`, so lookup polls for the
   required page state instead of making a one-shot request.
@@ -53,6 +54,19 @@ or debugging work ordered in [`todo.md`](../todo.md).
   planned API, such as the managed test harness, already exists.
 - **AI-STYLE-004 (confirmed):** The checklist must be linked directly from the
   getting-started learning path.
+- **AI-QS-001 (confirmed):** The mdBook must provide one compact AI/LLM
+  quickstart with minimal dependencies and a starter test using
+  `WebDriver::managed`, `query()`, readable descriptions, explicit readiness
+  conditions, a user-visible outcome, and explicit session cleanup.
+- **AI-QS-002 (confirmed):** The starter test must prefer app-owned test IDs,
+  scoped queries, and a cleanup shape that still attempts `quit()` after the
+  test body fails. A sample URL that is not runnable must be marked `no_run`.
+- **AI-QS-003 (confirmed):** The quickstart must give direct selector,
+  readiness, scoping, outcome, cleanup, and concurrency rules, while linking
+  to the canonical reliability checklist rather than duplicating it.
+- **AI-QS-004 (confirmed):** The quickstart must link to the query, waiting,
+  component, manager, CDP, and BiDi guides and be part of the mdBook
+  getting-started navigation.
 
 ## Acceptance criteria
 
@@ -82,3 +96,13 @@ or debugging work ordered in [`todo.md`](../todo.md).
   AI-STYLE-001 through AI-STYLE-003.
 - **AC-009:** The mdBook summary and first-code page link to the checklist.
   Covers AI-STYLE-004.
+- **AC-010:** A standalone AI/LLM quickstart contains the minimal dependency
+  block and compile-checked or `no_run` starter test required by AI-QS-001 and
+  AI-QS-002.
+- **AC-011:** The starter test waits for an interactable control, asserts a
+  user-visible result without a fixed sleep, and attempts explicit cleanup on
+  both success and failure. Covers AI-QS-001 and AI-QS-002.
+- **AC-012:** The quickstart contains concise prescriptive rules and links to
+  the canonical review checklist plus every deeper guide named by AI-QS-004.
+- **AC-013:** The mdBook summary links the quickstart from Getting Started.
+  Covers AI-QS-004.


### PR DESCRIPTION
## Summary

- add a compact AI/LLM quickstart to the mdBook getting-started path
- provide minimal dependencies and a compile-validated `no_run` starter test with stable selectors, explicit waits, visible outcomes, and failure-safe cleanup
- link the canonical reliability checklist and deeper query, wait, component, manager, CDP, and BiDi guides
- extend the AI-friendly browser automation spec with the quickstart contract and acceptance criteria

## Validation

- `cargo fmt --check`
- `cargo test -p thirtyfour --lib`
- `cargo test -p thirtyfour --doc`
- `cargo clippy --all-features --all-targets`
- `cargo doc --no-deps --all-features`
- `mdbook build docs`
- isolated `cargo test --no-run` against the exact documented dependencies and starter-test API shape
- `git diff --check`

Closes #330