### PR TITLE
Document the component prelude decision

### DIFF
--- a/specs/ai-friendly-browser-automation.md
+++ b/specs/ai-friendly-browser-automation.md
@@ -104,6 +104,17 @@ in [`todo.md`](../todo.md).
 - **AI-TRANS-004 (confirmed):** The guide must link to the canonical query,
   waiting, Component, manager, manual WebDriver, and reliable-test guidance and
   be discoverable from the mdBook navigation and AI quickstart.
+- **AI-COMP-001 (confirmed):** When the `component` feature is enabled, the
+  prelude must export the `Component` derive/trait name and `ElementResolver`
+  so the recommended `use thirtyfour::prelude::*;` import supports the common
+  Component path.
+- **AI-COMP-002 (confirmed):** The `resolve!` and `resolve_present!` helper
+  macros must remain explicit crate-root imports. They are optional shorthand,
+  and adding generic macro names to the wildcard prelude would introduce
+  unnecessary collision risk.
+- **AI-COMP-003 (confirmed):** Component rustdoc, mdBook guidance, examples,
+  and tests must use the preferred import style and describe its `component`
+  feature gate consistently.
 
 ## Acceptance criteria
 
@@ -161,3 +172,8 @@ in [`todo.md`](../todo.md).
   table of common nonexistent APIs. Covers AI-TRANS-003.
 - **AC-019:** The mdBook summary and AI quickstart link to the translation
   guide, which links onward to each deeper guide in AI-TRANS-004.
+- **AC-020:** With default features, Component examples compile with
+  `thirtyfour::prelude::*` supplying `Component` and `ElementResolver`, while
+  resolver macros use explicit root imports. Crate rustdoc, mdBook Component
+  guidance, the playground example, and Component integration tests show the
+  same import contract. Covers AI-COMP-001 through AI-COMP-003.

--- a/todo.md
+++ b/todo.md
@@ -35,7 +35,7 @@ people or agents coming from other browser automation ecosystems.
 These can be designed more confidently once the docs clarify the preferred user
 flows and examples.
 
-- [ ] [#338 Consider exporting common component ergonomics from the prelude](https://github.com/stevepryde/thirtyfour/issues/338)
+- [x] [#338 Consider exporting common component ergonomics from the prelude](https://github.com/stevepryde/thirtyfour/issues/338)
 - [ ] [#334 Add a managed test harness helper that guarantees browser cleanup](https://github.com/stevepryde/thirtyfour/issues/334)
 - [ ] [#335 Add first-class failure artifact helpers for browser tests](https://github.com/stevepryde/thirtyfour/issues/335)
 - [ ] [#337 Explore high-level safe interaction helpers built on query and waits](https://github.com/stevepryde/thirtyfour/issues/337)


### PR DESCRIPTION
## Summary

- record the component prelude contract in the canonical AI automation spec
- document why `Component` and `ElementResolver` are feature-gated prelude exports while resolver macros remain explicit root imports
- reconcile the roadmap checkbox with the implementation already merged in #341

The API implementation for this issue shipped in #341. This focused follow-up avoids duplicating that API and makes the repository source of truth match the current tree.

Closes #338.

## Stack

- Base: #351

## Validation

- `cargo fmt --check`
- `cargo clippy --all-features --all-targets`
- `cargo doc --no-deps --all-features`
- `cargo test -p thirtyfour --lib`
- `cargo check -p thirtyfour --all-features --example playground`
- `cargo check -p thirtyfour --no-default-features`
- `mdbook build docs`
- `git diff --check`