### PR TITLE
Support partial link selectors in components

### DIFF
--- a/docs/src/features/components.md
+++ b/docs/src/features/components.md
@@ -64,15 +64,45 @@ A few things are happening here:
 - Each `#[by(...)]` field is an `ElementResolver`. It doesn't query
   anything until you call `.resolve()`, and it caches the result so
   subsequent calls don't hit WebDriver again.
-- Resolvers always search relative to `base`, so a `SearchForm` can
-  only ever find elements inside its own `<form>`. That scoping is one
-  of the big wins over scattered `driver.query(...)` calls — you can't
-  accidentally match elements from a different form on the page.
+- Resolver queries start from `base`, so components normally stay scoped
+  to their own subtree. XPath is the exception: an expression beginning
+  with `//` is document-rooted. Use `.//` when an XPath resolver must stay
+  inside the component.
+
+## Component Shape And Generated API
+
+`Component` can only be derived for a struct with named fields. The struct
+must contain exactly one base `WebElement`:
+
+```rust
+#[derive(Debug, Clone, Component)]
+pub struct Dialog {
+    #[base]
+    root: WebElement,
+}
+```
+
+A field named `base` is detected automatically. Use `#[base]` when the
+field has another name. Do not use both forms in the same struct; the
+derive rejects multiple base fields. The base field type must be
+`WebElement` (either imported or written as `thirtyfour::WebElement`).
+
+For each component, the derive generates:
+
+- `pub fn new(base: WebElement) -> Self`;
+- `From<WebElement>`, which delegates to `new`;
+- the `Component` trait implementation, including `base_element()`.
+
+Fields with `#[by(...)]` become element resolvers. Other fields are
+initialised with `Default::default()`, so each such field type must implement
+`Default`. A `#[cfg(...)]` attribute on a field is preserved in the generated
+constructor, allowing feature- or target-specific resolver and state fields.
 
 ## The `#[by(...)]` Attribute
 
-Every resolver field needs a `#[by(...)]` attribute. The first part
-picks the selector:
+Every resolver field needs one `#[by(...)]` attribute. Use either exactly
+one selector or one custom resolver. Selector and `description` values must
+be string literals.
 
 | Attribute                | Selector used          |
 | ------------------------ | ---------------------- |
@@ -86,27 +116,60 @@ picks the selector:
 | `partial_link = "..."`   | `By::PartialLinkText`  |
 | `testid = "..."`         | `By::Testid`           |
 
-Pair the selector with extra options, comma-separated. Which options
-apply depends on whether the resolver is single or multi (the macro
-infers that from the field type — `ElementResolver<T>` is single,
-`ElementResolver<Vec<T>>` is multi):
+All selectors start a query from the component's base element. For XPath,
+remember that `//div` searches from the document root while `.//div` searches
+within the base element.
 
-| Option                     | Applies to | Effect                                                    |
-| -------------------------- | ---------- | --------------------------------------------------------- |
-| `single`                   | single     | Match exactly one element. Errors if 0 or 2+. Default.    |
-| `first`                    | single     | Match the first element instead.                          |
-| `not_empty`                | multi      | Match at least one element. Errors if empty. Default.     |
-| `allow_empty`              | multi      | Match zero or more elements. Empty Vec is OK.             |
-| `description = "..."`      | both       | Attach a label that shows up in timeout error messages.   |
-| `wait(timeout_ms = N, interval_ms = N)` | both | Override the poll cadence for this field.            |
-| `nowait`                   | both       | Try once without polling.                                 |
-| `ignore_errors`            | both       | Forward `ignore_errors` to the underlying query.          |
-| `multi`                    | multi      | Force multi-resolver behaviour. Only needed for custom type aliases. |
-| `custom = my_resolver_fn`  | both       | Use a custom resolver function (see [Custom Resolvers](#custom-resolvers)). Mutually exclusive with the other options. |
+### Resolver Types And Cardinality
+
+Built-in selector resolvers can return `WebElement`, a nested `Component`, or
+a `Vec` of either. The macro infers single- versus multi-element behaviour from
+the field type:
+
+| Field type                        | Inferred mode | Default cardinality |
+| --------------------------------- | ------------- | ------------------- |
+| `ElementResolver<T>`              | single        | exactly one         |
+| `ElementResolver<Vec<T>>`         | multi         | one or more         |
+| `ElementResolverSingle`           | single        | exactly one         |
+| `ElementResolverMulti`            | multi         | one or more         |
+| user-defined resolver type alias   | single        | use `multi` to force multi mode |
+
+Here, `T` is either `WebElement` or a type implementing `Component + Clone`.
+Nested components are constructed from each matched `WebElement` through
+their generated `From<WebElement>` implementation.
+
+`ElementResolver<Vec<T>>` is detected through the normal `ElementResolver`,
+`components::ElementResolver`, and `thirtyfour::components::ElementResolver`
+paths. If a type alias hides the `Vec`, add the `multi` option. The convenience
+alias `ElementResolverMulti` is also detected when used directly.
+
+### Query Options
+
+Pair a selector with options, separated by commas:
+
+| Option                                      | Applies to | Effect |
+| ------------------------------------------- | ---------- | ------ |
+| `single`                                    | single     | Require exactly one match. This is the default. |
+| `first`                                     | single     | Return the first match instead of requiring uniqueness. |
+| `not_empty`                                 | multi      | Require one or more matches. This is the default. |
+| `allow_empty`                               | multi      | Return all matches, including an empty `Vec`. |
+| `multi`                                     | multi      | Force multi mode when a type alias hides `Vec<T>`. |
+| `description = "..."`                       | both       | Include a human-readable label in query errors. |
+| `ignore_errors`                             | both       | Ignore query errors while polling and keep trying until the timeout. |
+| `wait(timeout_ms = N, interval_ms = N)`     | both       | Override both the polling timeout and interval. Both arguments are required. |
+| `nowait`                                    | both       | Poll once instead of waiting. |
+
+The default mode uses the query system's default polling configuration.
+`single` and `first` are mutually exclusive, as are `not_empty` and
+`allow_empty`, and `wait(...)` and `nowait`. Single-only options cannot be
+used for a multi resolver, and multi-only options cannot be used for a single
+resolver. The derive also rejects repeated options and multiple selectors.
 
 Examples:
 
 ```rust
+type LinkListResolver = ElementResolver<Vec<WebElement>>;
+
 // Use the first match if there are several.
 #[by(id = "search-input", first)]
 input: ElementResolver<WebElement>,
@@ -119,6 +182,10 @@ items: ElementResolver<Vec<WebElement>>,
 #[by(css = ".loading-spinner", description = "loading spinner",
      wait(timeout_ms = 60_000, interval_ms = 1_000))]
 spinner: ElementResolver<WebElement>,
+
+// A custom alias that contains ElementResolver<Vec<WebElement>>.
+#[by(partial_link = "Guide", multi, allow_empty)]
+guide_links: LinkListResolver,
 ```
 
 ## ElementResolver Methods
@@ -224,7 +291,7 @@ Fields without a `#[by(...)]` attribute are initialised via
 extra boilerplate:
 
 ```rust
-#[derive(Debug, Clone, Component, Default)]
+#[derive(Debug, Clone, Component)]
 pub struct LoginForm {
     base: WebElement,
     #[by(id = "username")]
@@ -257,10 +324,30 @@ pub struct Header {
 }
 ```
 
-A custom resolver receives the component's base element and returns a
-`WebDriverResult<T>` matching the field's type. `custom = ...` is
-mutually exclusive with the selector and modifier options — the
-function is doing all of that work itself.
+A custom resolver receives the component's base element by value and returns
+a `WebDriverResult<T>` matching the field's `ElementResolver<T>` type. Pass a
+function path or another compatible expression, not a quoted string:
+
+```rust
+// Assume Row is another Component.
+async fn resolve_rows(base: WebElement) -> WebDriverResult<Vec<Row>> {
+    let elements = base.query(By::Css("tbody > tr")).all_from_selector().await?;
+    Ok(elements.into_iter().map(Row::from).collect())
+}
+
+#[derive(Debug, Clone, Component)]
+pub struct Table {
+    base: WebElement,
+    #[by(custom = resolve_rows)]
+    rows: ElementResolver<Vec<Row>>,
+}
+```
+
+The resolver function owns the complete lookup policy, including cardinality,
+polling, filtering, and error handling. Therefore `custom = ...` cannot be
+combined with a selector or any other `#[by(...)]` option. Single and `Vec`
+field types are still inferred normally; do not add `multi` to a custom
+resolver.
 
 ## When To Reach For A Component
 

--- a/docs/src/features/components.md
+++ b/docs/src/features/components.md
@@ -74,16 +74,17 @@ A few things are happening here:
 Every resolver field needs a `#[by(...)]` attribute. The first part
 picks the selector:
 
-| Attribute            | Selector used    |
-| -------------------- | ---------------- |
-| `id = "..."`         | `By::Id`         |
-| `css = "..."`        | `By::Css`        |
-| `xpath = "..."`      | `By::XPath`      |
-| `tag = "..."`        | `By::Tag`        |
-| `class = "..."`      | `By::ClassName`  |
-| `name = "..."`       | `By::Name`       |
-| `link = "..."`       | `By::LinkText`   |
-| `testid = "..."`     | `By::Testid`     |
+| Attribute                | Selector used          |
+| ------------------------ | ---------------------- |
+| `id = "..."`             | `By::Id`               |
+| `css = "..."`            | `By::Css`              |
+| `xpath = "..."`          | `By::XPath`            |
+| `tag = "..."`            | `By::Tag`              |
+| `class = "..."`          | `By::ClassName`        |
+| `name = "..."`           | `By::Name`             |
+| `link = "..."`           | `By::LinkText`         |
+| `partial_link = "..."`   | `By::PartialLinkText`  |
+| `testid = "..."`         | `By::Testid`           |
 
 Pair the selector with extra options, comma-separated. Which options
 apply depends on whether the resolver is single or multi (the macro

--- a/thirtyfour-macros/Cargo.toml
+++ b/thirtyfour-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thirtyfour-macros"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = """
 Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI testing.

--- a/thirtyfour-macros/README.md
+++ b/thirtyfour-macros/README.md
@@ -9,7 +9,7 @@ For more information, see the [crate documentation](https://docs.rs/thirtyfour-m
 
 ## Minimum Supported Rust Version
 
-The MSRV for `thirtyfour-macros` is 1.57.
+The MSRV for `thirtyfour-macros` is 1.88.
 
 ## LICENSE
 
@@ -19,4 +19,3 @@ You can choose either license if you use this work.
 See the NOTICE file for more details.
 
 `SPDX-License-Identifier: MIT OR Apache-2.0`
-

--- a/thirtyfour-macros/src/component.rs
+++ b/thirtyfour-macros/src/component.rs
@@ -264,6 +264,7 @@ enum ByToken {
     Id(Literal),
     Tag(Literal),
     LinkText(Literal),
+    PartialLinkText(Literal),
     Css(Literal),
     XPath(Literal),
     Name(Literal),
@@ -292,6 +293,7 @@ impl ByToken {
             ByToken::Id(_)
             | ByToken::Tag(_)
             | ByToken::LinkText(_)
+            | ByToken::PartialLinkText(_)
             | ByToken::Css(_)
             | ByToken::XPath(_)
             | ByToken::Name(_)
@@ -438,6 +440,13 @@ impl TryFrom<Meta> for ByToken {
                         lit: Lit::Str(v),
                         ..
                     }),
+                ) if k.is_ident("partial_link") => Ok(ByToken::PartialLinkText(v.token())),
+                (
+                    k,
+                    Expr::Lit(ExprLit {
+                        lit: Lit::Str(v),
+                        ..
+                    }),
                 ) if k.is_ident("css") => Ok(ByToken::Css(v.token())),
                 (
                     k,
@@ -530,6 +539,7 @@ impl ByTokens {
                 ByToken::Id(id) => ret.push(quote! { By::Id(#id) }),
                 ByToken::Tag(tag) => ret.push(quote! { By::Tag(#tag) }),
                 ByToken::LinkText(text) => ret.push(quote! { By::LinkText(#text) }),
+                ByToken::PartialLinkText(text) => ret.push(quote! { By::PartialLinkText(#text) }),
                 ByToken::Css(css) => ret.push(quote! { By::Css(#css) }),
                 ByToken::XPath(xpath) => ret.push(quote! { By::XPath(#xpath) }),
                 ByToken::Name(name) => ret.push(quote! { By::Name(#name) }),
@@ -685,6 +695,7 @@ impl ToTokens for DebugByTokens {
                 ByToken::Id(lit)
                 | ByToken::Tag(lit)
                 | ByToken::LinkText(lit)
+                | ByToken::PartialLinkText(lit)
                 | ByToken::Css(lit)
                 | ByToken::XPath(lit)
                 | ByToken::Name(lit)
@@ -1007,5 +1018,31 @@ fn fix_type(mut ty: syn::Path) -> TokenStream {
         None => {
             quote! {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+    use syn::parse_quote;
+
+    #[test]
+    fn partial_link_selector_expands_to_by_partial_link_text() {
+        let input = parse_quote! {
+            struct LinkComponent {
+                base: ::thirtyfour::WebElement,
+                #[by(partial_link = "guide")]
+                link: ::thirtyfour::components::ElementResolver<::thirtyfour::WebElement>,
+            }
+        };
+
+        let expanded = expand_component_derive(input).to_string();
+        let expected = quote! { By::PartialLinkText("guide") }.to_string();
+
+        assert!(
+            expanded.contains(&expected),
+            "expected expansion to contain `{expected}`, got `{expanded}`"
+        );
     }
 }

--- a/thirtyfour-macros/src/lib.rs
+++ b/thirtyfour-macros/src/lib.rs
@@ -18,116 +18,108 @@ macro_rules! bail {
 
 pub(crate) use bail;
 
-/// Derive macro for a wrapped `Component`.
+/// Derive macro for a wrapped [`Component`].
 ///
-/// A `Component` contains a base [`WebElement`] from which all element queries will be performed.
+/// A component owns a base [`WebElement`]. Its [`ElementResolver`] fields lazily query from that
+/// element and cache their results. Queries normally stay within the base element's subtree;
+/// XPath expressions beginning with `//` are document-rooted, so use `.//` for a relative XPath.
 ///
-/// All elements in the component are descendents of the base element (or at least the
-/// starting point for an element query, since XPath queries can access parent nodes).
+/// ## Supported structs and generated API
 ///
-/// Components perform element lookups via [`ElementResolver`]s, which lazily perform an
-/// element query to resolve a [`WebElement`], and then cache the result for later access.
+/// The derive supports non-generic structs with named fields. Exactly one field must be the base
+/// `WebElement`. A field named `base` is detected automatically; use `#[base]` to give it another
+/// name. Multiple base fields, tuple structs, enums, and unions are not supported.
 ///
-/// See the [`ElementResolver`] documentation for more details.
+/// The derive generates:
 ///
-/// ## Attributes
+/// - `pub fn new(base: WebElement) -> Self`;
+/// - `From<WebElement>`;
+/// - the [`Component`] implementation and its `base_element()` method.
 ///
-/// ### `#[base]`
-/// By default, the base element should be named `base` and be of type `WebElement`.
-/// You can optionally use the `#[base]` attribute if you wish to name the base element
-/// something other than `base`.
-/// If you use this attribute, you cannot also have another
-/// element named `base`.
+/// A field without `#[by(...)]` is initialized with `Default::default()`. Its type must therefore
+/// implement `Default`. A field-level `#[cfg(...)]` is preserved in the generated constructor.
 ///
-/// ### `#[by(..)]`
-/// Components use the `#[by(..)]` attribute to specify all the details of the query.
+/// ## Selectors
 ///
-/// The only required attribute is the selector attribute, which can be one of the following:
-/// - `id = "..."`: Select element by id.
-/// - `tag = "..."`: Select element by tag name.
-/// - `link = "..."`: Select element by link text.
-/// - `partial_link = "..."`: Select element by partial link text.
-/// - `css = "..."`: Select element by CSS.
-/// - `xpath = "..."`: Select element by XPath.
-/// - `name = "..."`: Select element by name.
-/// - `class = "..."`: Select element by class name.
-/// - `testid = "..."`: Select element by `data-testid`.
+/// A normal resolver requires exactly one selector with a string-literal value:
 ///
-/// Optional attributes available within `#[by(..)]` include:
-/// - `single`: (default, single element only) Return `NoSuchElement` if the number of elements
-///   found is != 1.
-/// - `first`: (single element only) Select the first element that matches the query.
-///   By default, a query will return `NoSuchElement` if multiple elements match.
-///   This default is designed to catch instances where a query is not specific enough.
-/// - `not_empty`: (default, multi elements only) Return `NoSuchElement` if no elements were found.
-/// - `allow_empty`: (multi elements only) Return an empty Vec if no elements were found.
-///   By default a multi-element query will return `NoSuchElement` if no
-///   elements were found.
-/// - `description = "..."`: Set the element description to be displayed in `NoSuchElement` errors.
-/// - `allow_errors`: Ignore errors such as stale elements while polling.
-/// - `wait(timeout_ms = 10000, interval_ms=500)`: Override the default polling options.
-/// - `nowait`: Turn off polling for this element query.
-/// - `custom = "my_resolve_fn"`: Use the specified function to resolve the element or component.
-///   **NOTE**: The `custom` attribute cannot be specified with any other
-///   attribute.
+/// | Attribute | Generated selector |
+/// | --- | --- |
+/// | `id = "..."` | `By::Id` |
+/// | `tag = "..."` | `By::Tag` |
+/// | `link = "..."` | `By::LinkText` |
+/// | `partial_link = "..."` | `By::PartialLinkText` |
+/// | `css = "..."` | `By::Css` |
+/// | `xpath = "..."` | `By::XPath` |
+/// | `name = "..."` | `By::Name` |
+/// | `class = "..."` | `By::ClassName` |
+/// | `testid = "..."` | `By::Testid` |
 ///
-/// See [`ElementQueryOptions`] for more details on how each option is used.
+/// ## Resolver type and cardinality
 ///
-/// ### Custom resolver functions
+/// `ElementResolver<T>` and `ElementResolverSingle` use single mode, which requires exactly one
+/// match by default. `ElementResolver<Vec<T>>` and the unqualified `ElementResolverMulti` alias
+/// use multi mode, which requires at least one match by default. Here `T` may be `WebElement` or
+/// a nested type that implements `Component + Clone`.
 ///
-/// When using `custom = "my_resolve_fn"`, your function signature should look something like this:
+/// The `Vec` is detected for `ElementResolver`, `components::ElementResolver`, and
+/// `thirtyfour::components::ElementResolver` paths. If a user-defined type alias hides the `Vec`,
+/// add `multi` to force multi mode.
+///
+/// ## Query options
+///
+/// Selector resolvers accept these comma-separated options:
+///
+/// | Option | Mode | Behavior |
+/// | --- | --- | --- |
+/// | `single` | single | Require exactly one match. This is the default. |
+/// | `first` | single | Return the first match instead of requiring uniqueness. |
+/// | `not_empty` | multi | Require one or more matches. This is the default. |
+/// | `allow_empty` | multi | Return all matches, including an empty `Vec`. |
+/// | `multi` | multi | Force multi mode when a type alias hides `Vec<T>`. |
+/// | `description = "..."` | both | Add a human-readable label to query errors. |
+/// | `ignore_errors` | both | Ignore query errors while polling and keep trying. |
+/// | `wait(timeout_ms = N, interval_ms = N)` | both | Override the polling timeout and interval; both arguments are required. |
+/// | `nowait` | both | Poll once without waiting. |
+///
+/// The derive rejects repeated options and incompatible combinations. In particular, `single`
+/// and `first`, `not_empty` and `allow_empty`, and `wait(...)` and `nowait` are mutually
+/// exclusive. Single-only and multi-only options must match the inferred resolver mode.
+///
+/// ## Custom resolvers
+///
+/// Use `custom = expression` instead of a selector to supply a compatible [`ElementQueryFn`]. A
+/// custom resolver receives the base `WebElement` by value and returns `WebDriverResult<T>`, where
+/// `T` matches the field's `ElementResolver<T>` type. Pass a function path or another expression,
+/// not a quoted string. `custom` cannot be combined with a selector or any other option.
+///
+/// ## Example
 ///
 /// ```ignore
-/// async fn my_resolve_fn(elem: &WebElement) -> WebDriverResult<T>
-/// ```
-///
-/// where the `T` is the same as type `T` in `ElementResolver<T>`.
-/// Also see the example below.
-///
-/// ## Example:
-/// ```ignore
-/// /// This component shows how to nest components inside others.
-/// #[derive(Debug, Clone, Component)]
-/// pub struct CheckboxSectionComponent {
-///     base: WebElement,
-///     #[by(tag = "label", allow_empty)]
-///     boxes: ElementResolver<Vec<CheckboxComponent>>,
-///     // Other fields will be initialised using `Default::default()`.
-///     my_field: bool,
+/// async fn resolve_button(base: WebElement) -> WebDriverResult<WebElement> {
+///     base.query(By::ClassName("run-button")).and_displayed().first().await
 /// }
 ///
-/// /// This component shows how to wrap a simple web component.
 /// #[derive(Debug, Clone, Component)]
-/// pub struct CheckboxComponent {
-///     base: WebElement,
+/// pub struct FormComponent {
+///     #[base]
+///     root: WebElement,
 ///     #[by(css = "input[type='checkbox']", first)]
-///     input: ElementResolver<WebElement>,
-///     #[by(name = "text-label", description = "text label")]
-///     label: ElementResolver<WebElement>
-///     #[by(custom = "my_custom_resolve_fn")]
-///     button: ElementResolver<WebElement>
-/// }
-///
-/// /// Use this function signature for your custom resolvers.
-/// async fn my_custom_resolve_fn(elem: &WebElement) -> WebDriverResult<WebElement> {
-///     // Do something with elem.
-///     elem.query(By::ClassName("my-class")).and_displayed().first().await
-/// }
-///
-/// impl CheckboxComponent {
-///     /// Return true if the checkbox is ticked.
-///     pub async fn is_ticked(&self) -> WebDriverResult<bool> {
-///         // Equivalent to: let elem = self.input.resolve_present().await?;
-///         let elem = resolve_present!(self.input);
-///         let prop = elem.prop("checked").await?;
-///         Ok(prop.unwrap_or_default() == "true")
-///     }
+///     checkbox: ElementResolver<WebElement>,
+///     #[by(partial_link = "Help", description = "help link")]
+///     help: ElementResolver<WebElement>,
+///     #[by(tag = "label", allow_empty)]
+///     labels: ElementResolver<Vec<WebElement>>,
+///     #[by(custom = resolve_button)]
+///     button: ElementResolver<WebElement>,
+///     attempts: u32,
 /// }
 /// ```
+///
+/// [`Component`]: https://docs.rs/thirtyfour/latest/thirtyfour/components/trait.Component.html
+/// [`ElementQueryFn`]: https://docs.rs/thirtyfour/latest/thirtyfour/common/types/trait.ElementQueryFn.html
+/// [`ElementResolver`]: https://docs.rs/thirtyfour/latest/thirtyfour/components/struct.ElementResolver.html
 /// [`WebElement`]: https://docs.rs/thirtyfour/latest/thirtyfour/struct.WebElement.html
-/// [`ElementResolver`]: https://docs.rs/thirtyfour/0.31.0-alpha.1/thirtyfour/components/struct.ElementResolver.html
-/// [`ElementQueryOptions`]: https://docs.rs/thirtyfour/0.31.0-alpha.1/thirtyfour/extensions/query/struct.ElementQueryOptions.html
-/// [`ElementQueryFn<T>`]: https://docs.rs/thirtyfour/0.31.0-alpha.1/thirtyfour/common/types/type.ElementQueryFn.html
 #[proc_macro_derive(Component, attributes(base, by))]
 pub fn derive_component_fn(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/thirtyfour-macros/src/lib.rs
+++ b/thirtyfour-macros/src/lib.rs
@@ -46,10 +46,12 @@ pub(crate) use bail;
 /// - `id = "..."`: Select element by id.
 /// - `tag = "..."`: Select element by tag name.
 /// - `link = "..."`: Select element by link text.
+/// - `partial_link = "..."`: Select element by partial link text.
 /// - `css = "..."`: Select element by CSS.
 /// - `xpath = "..."`: Select element by XPath.
 /// - `name = "..."`: Select element by name.
 /// - `class = "..."`: Select element by class name.
+/// - `testid = "..."`: Select element by `data-testid`.
 ///
 /// Optional attributes available within `#[by(..)]` include:
 /// - `single`: (default, single element only) Return `NoSuchElement` if the number of elements

--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -70,7 +70,7 @@ serde = { version = "1.0.210", features = ["derive", "rc"] }
 serde_json = { version = "1.0.132", features = ["preserve_order"] }
 serde_repr = "0.1.19"
 stringmatch = "0.4"
-thirtyfour-macros = { path = "../thirtyfour-macros", version = "0.2.0", optional = true }
+thirtyfour-macros = { path = "../thirtyfour-macros", version = "0.3.0", optional = true }
 thiserror = "2.0.12"
 tokio = { version = "1.30", features = [
     "rt",

--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thirtyfour"
-version = "0.37.2"
+version = "0.37.3"
 edition = "2024"
 description = """
 Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI testing.

--- a/thirtyfour/tests/components.rs
+++ b/thirtyfour/tests/components.rs
@@ -49,6 +49,37 @@ mod feature_component {
         }
     }
 
+    #[allow(dead_code)]
+    #[derive(Debug, Clone, Component)]
+    struct EveryBySelectorComponent {
+        base: WebElement,
+        #[by(id = "id")]
+        by_id: ElementResolver<WebElement>,
+        #[by(xpath = ".//a")]
+        by_xpath: ElementResolver<WebElement>,
+        #[by(link = "exact")]
+        by_link_text: ElementResolver<WebElement>,
+        #[by(partial_link = "partial")]
+        by_partial_link_text: ElementResolver<WebElement>,
+        #[by(name = "name")]
+        by_name: ElementResolver<WebElement>,
+        #[by(tag = "a")]
+        by_tag: ElementResolver<WebElement>,
+        #[by(class = "class")]
+        by_class_name: ElementResolver<WebElement>,
+        #[by(css = "a[href]")]
+        by_css: ElementResolver<WebElement>,
+        #[by(testid = "test-id")]
+        by_testid: ElementResolver<WebElement>,
+    }
+
+    #[test]
+    fn component_derive_supports_every_by_selector() {
+        fn assert_component<T: thirtyfour::components::Component>() {}
+
+        assert_component::<EveryBySelectorComponent>();
+    }
+
     #[rstest]
     fn basic_component(test_harness: TestHarness) -> WebDriverResult<()> {
         let c = test_harness.driver();


### PR DESCRIPTION
## Summary

- add `#[by(partial_link = "...")]` support to the `Component` derive macro
- map the new attribute to `By::PartialLinkText`
- add expansion-level regression coverage and a downstream compile matrix for all nine public `By` selectors
- expand the mdBook guide and derive rustdoc into a complete reference for supported component shapes, generated APIs, selectors, cardinality inference, query options, custom resolvers, defaults, `#[cfg]` fields, and XPath scoping
- correct stale documentation for `testid`, `ignore_errors`, and custom resolver syntax/signatures
- bump `thirtyfour-macros` from 0.2.0 to 0.3.0 and update `thirtyfour`'s dependency requirement
- bump `thirtyfour` from 0.37.2 to the compatible patch release 0.37.3
- align the macro README with the workspace's Rust 1.88 MSRV

## Root cause

The public `By` API exposes nine selector constructors, but the component derive parser and emitter only handled eight. `By::PartialLinkText` had no corresponding `#[by(...)]` attribute. The component documentation also described only part of the macro contract and contained stale custom-resolver and option examples.

The published macro crate remains at 0.2.0, so both the previously added `testid` support and this PR's `partial_link` support require a new macro release. The selector additions are additive, but the macro crate's MSRV has risen from the published 1.57 contract to 1.88. Using 0.3.0 keeps that toolchain-breaking change out of the existing `^0.2.0` compatibility line. `thirtyfour` 0.37.2 already requires Rust 1.88, so the parent crate can ship these additive changes as patch release 0.37.3.

## Release order

Publish `thirtyfour-macros` 0.3.0 first, then publish `thirtyfour` 0.37.3. Cargo cannot package the latter against crates.io until the new macro version is available.

## Validation

- `cargo package -p thirtyfour-macros --allow-dirty` (packaged and verified 0.3.0)
- `cargo +1.88 check -p thirtyfour-macros`
- `cargo +1.88 check -p thirtyfour --all-features`
- `cargo fmt`
- `mdbook build docs`
- `cargo test -p thirtyfour-macros`
- `cargo test -p thirtyfour --lib` (78 passed)
- `cargo test -p thirtyfour --doc` (123 passed, 10 ignored)
- `cargo clippy --all-features --all-targets`
- `cargo doc --no-deps --all-features`
- `git diff --check`