### PR TITLE
Document explicit interaction safety patterns

### DIFF
--- a/docs/src/features/waiting.md
+++ b/docs/src/features/waiting.md
@@ -15,6 +15,84 @@ button.wait_until().not_displayed().await?;
 `ElementWaiter` that polls the element until either a predicate
 matches or the timeout elapses.
 
+## Keep Interactions Explicit
+
+For a fresh target, put readiness on a described query, choose cardinality,
+perform the action, and then query for the user-visible outcome:
+
+```rust,no_run
+use thirtyfour::prelude::*;
+
+async fn save_settings(driver: &WebDriver) -> WebDriverResult<()> {
+    let save = driver
+        .query(By::Testid("settings-save"))
+        .and_clickable()
+        .desc("settings save button")
+        .single()
+        .await?;
+
+    save.click().await?;
+
+    driver
+        .query(By::Testid("settings-saved"))
+        .and_displayed()
+        .with_text("Settings saved")
+        .desc("settings saved confirmation")
+        .single()
+        .await?;
+    Ok(())
+}
+```
+
+For an element you already resolved and intentionally want to keep, wait on
+that element before acting:
+
+```rust,no_run
+# use thirtyfour::prelude::*;
+# async fn submit(save: WebElement) -> WebDriverResult<()> {
+save.wait_until().clickable().await?;
+save.click().await?;
+# Ok(())
+# }
+```
+
+Text entry has application-specific replacement semantics, so make the choice
+to clear or append visible in the code:
+
+```rust,no_run
+use thirtyfour::prelude::*;
+
+async fn replace_email(driver: &WebDriver) -> WebDriverResult<()> {
+    let email = driver
+        .query(By::Testid("account-email"))
+        .and_displayed()
+        .and_enabled()
+        .desc("account email input")
+        .single()
+        .await?;
+
+    email.clear().await?;
+    email.send_keys("ada@example.test").await?;
+    Ok(())
+}
+```
+
+Here, “clickable” means displayed and enabled. It cannot guarantee that an
+overlay will not intercept the click, that the DOM will not replace the
+element, or that page state will not change between the readiness check and the
+action. A held element can become stale; re-query when re-rendering is expected,
+or keep the selector in an [`ElementResolver`](./components.md#elementresolver-methods)
+inside a Component.
+
+Selector-only helpers such as `driver.click(selector)` or
+`clear_and_type(selector, text)` would hide cardinality, descriptions, timeout,
+clearing, stale-element handling, and the expected outcome. A builder exposing
+those choices would duplicate `ElementQuery` without providing a stronger
+safety guarantee, so this design adds no new generic interaction API. Retrying
+clicks automatically can also repeat a non-idempotent action. Put repeated
+application behavior in a Component intent method such as `save_settings()` or
+`submit_credentials()`, where those choices and the outcome are known.
+
 ## Built-In Predicates
 
 State predicates polled directly via WebDriver:

--- a/specs/ai-friendly-browser-automation.md
+++ b/specs/ai-friendly-browser-automation.md
@@ -5,8 +5,9 @@
 This specification owns the reliability contract for entry-level `thirtyfour`
 examples, selector guidance, the AI/LLM quickstart, task-oriented recipes, and
 translation guidance, and coding-agent guidance that humans and agents are
-likely to copy. It also defines the browser-test runner and portable failure
-artifacts; it does not define the later page-snapshot work ordered in
+likely to copy. It also defines the browser-test runner, portable failure
+artifacts, and the interaction-helper design boundary; it does not define the
+later page-snapshot work ordered in
 [`todo.md`](../todo.md).
 
 ## Requirements
@@ -150,6 +151,20 @@ artifacts; it does not define the later page-snapshot work ordered in
 - **AI-ART-004 (confirmed):** Documentation must warn that bounded artifacts
   can still contain secrets or personal data and require application-specific
   disabling or redaction before external upload.
+- **AI-INT-001 (confirmed):** The canonical interaction flow must remain an
+  explicit sequence of described query, deliberate cardinality, readiness,
+  action, and user-visible outcome.
+- **AI-INT-002 (confirmed):** Fresh targets use query readiness filters, while
+  intentionally held targets use `wait_until()`. Documentation must define
+  clickable as displayed plus enabled rather than a complete interactability
+  guarantee.
+- **AI-INT-003 (confirmed):** This design adds no generic click-and-type API.
+  Selector-only helpers would hide cardinality, diagnostics, timeout, clearing,
+  stale-element, retry, or outcome semantics, while a builder exposing those
+  choices would duplicate `ElementQuery` without a stronger safety guarantee.
+- **AI-INT-004 (confirmed):** Reusable interaction abstractions belong in
+  application-specific Component intent methods, where their semantics and
+  expected outcome are known.
 
 ## Acceptance criteria
 
@@ -229,3 +244,10 @@ artifacts; it does not define the later page-snapshot work ordered in
   attachment before a test body, capture before runner cleanup, browser and
   manager limitations, portable-protocol scope, and privacy guidance. Covers
   AI-ART-003 and AI-ART-004.
+- **AC-025:** Waiting documentation contains copyable click and text-entry
+  patterns and explains both fresh-query and held-element readiness paths.
+  Covers AI-INT-001 and AI-INT-002.
+- **AC-026:** Waiting documentation names interactability, stale-element,
+  clearing, retry, and outcome limitations and records the no-new-generic-API
+  decision. Existing quickstart and recipe flows remain explicit. Covers
+  AI-INT-003 and AI-INT-004.

--- a/todo.md
+++ b/todo.md
@@ -38,7 +38,7 @@ flows and examples.
 - [x] [#338 Consider exporting common component ergonomics from the prelude](https://github.com/stevepryde/thirtyfour/issues/338)
 - [x] [#334 Add a managed test harness helper that guarantees browser cleanup](https://github.com/stevepryde/thirtyfour/issues/334)
 - [x] [#335 Add first-class failure artifact helpers for browser tests](https://github.com/stevepryde/thirtyfour/issues/335)
-- [ ] [#337 Explore high-level safe interaction helpers built on query and waits](https://github.com/stevepryde/thirtyfour/issues/337)
+- [x] [#337 Explore high-level safe interaction helpers built on query and waits](https://github.com/stevepryde/thirtyfour/issues/337)
 
 ## 5. Advanced AI/Debugging Capability
 


### PR DESCRIPTION
## Summary

- document the explicit readiness → action → user-visible outcome pattern
- distinguish fresh query filters from waits on an intentionally held element
- make clear that “clickable” means displayed and enabled, not a complete interactability guarantee
- record the design decision not to add a generic click/type API
- direct repeated application behavior to Component intent methods

## Decision

This issue is resolved as a docs-only design decision. Selector-only convenience calls would hide cardinality, diagnostics, timeouts, clearing, stale-element handling, retries, and expected outcomes. A builder exposing those choices would duplicate `ElementQuery` without adding a stronger safety guarantee.

Automatic click retries are also unsafe for potentially non-idempotent actions.

## Validation

- all three new Rust examples compile in a temporary integration target
- `cargo test -p thirtyfour --lib` (95 passed)
- `cargo test -p thirtyfour --doc` (124 passed, 10 ignored)
- `cargo clippy --all-features --all-targets`
- `cargo doc --no-deps --all-features`
- `mdbook build docs`
- `cargo fmt --check`
- `git diff --check`

Stacked on #355.

Closes #337