### PR TITLE
Add resolved element interaction helpers

### DIFF
--- a/docs/src/features/components.md
+++ b/docs/src/features/components.md
@@ -200,6 +200,41 @@ Every resolver field exposes the same handful of methods:
 | `.invalidate()`              | Drop the cache without querying. The next `.resolve()` will run the query again.     |
 | `.validate().await?`         | Return the cached value if it's still in the DOM, or `None`.                         |
 
+An `ElementResolver<WebElement>` also provides common element operations
+directly. Each method calls `resolve_present()` first, then forwards to the
+resolved `WebElement`:
+
+| Method                              | Returns                         | Behaviour                                             |
+| ----------------------------------- | ------------------------------- | ----------------------------------------------------- |
+| `.click().await?`                   | `()`                            | Resolve a present element and click it.                |
+| `.click_when_ready().await?`        | `()`                            | Resolve, wait until displayed and enabled, then click. |
+| `.clear().await?`                   | `()`                            | Resolve and clear the element's contents.              |
+| `.send_keys(value).await?`          | `()`                            | Resolve and send keys to the element.                  |
+| `.text().await?`                    | `String`                        | Resolve and return its rendered text.                  |
+| `.value().await?`                   | `Option<String>`                | Resolve and return its `value` property.               |
+
+The resolver receiver makes the re-resolution behavior part of the API, so the
+methods deliberately use the same names as `WebElement`:
+
+```rust
+self.email.clear().await?;
+self.email.send_keys("ada@example.test").await?;
+self.submit.click_when_ready().await?;
+```
+
+These helpers validate and potentially re-query once before the operation.
+They do not retry the operation if the page changes afterward or wait for an
+application outcome.
+They are available only on `ElementResolver<WebElement>`, not resolvers of a
+Component, `Vec`, or another custom type. Each call validates independently. If
+two operations must target exactly the same node, resolve once instead:
+
+```rust
+let email = self.email.resolve_present().await?;
+email.clear().await?;
+email.send_keys("ada@example.test").await?;
+```
+
 Two macros wrap the most common calls:
 
 ```rust

--- a/docs/src/features/queries.md
+++ b/docs/src/features/queries.md
@@ -111,8 +111,9 @@ the one that matches what you actually need:
 | `.all_from_selector_required().await?`  | Same, but errors if empty.                             |
 | `.any().await?`                         | Elements from every branch combined, possibly empty.   |
 | `.any_required().await?`                | Same, but errors if empty.                             |
-| `.exists().await?`                      | `bool` — does it exist?                                |
-| `.not_exists().await?`                  | `bool` — does it stay absent for the timeout?          |
+| `.exists().await?`                      | Waits for a match; returns `false` on timeout.          |
+| `.not_exists().await?`                  | Waits for no matches; returns `false` on timeout.       |
+| `.wait_until_gone().await?`             | Waits for no matches; timeout is an error.              |
 
 `.any()` and `.all_from_selector()` differ when you've used `.or()`:
 `.any()` runs every branch and returns the union of matches;
@@ -228,7 +229,30 @@ immediately):
 
 ```rust
 let exists = driver.query(By::Id("maybe")).nowait().exists().await?;
+let absent = driver.query(By::Id("maybe")).nowait().not_exists().await?;
 ```
+
+Each branch is attempted at most once with `.nowait()`. `exists()` may stop at
+the first matching branch; `not_exists()` must check every branch because all
+of them must be absent. Without `.nowait()`, `not_exists()` polls until the
+query has no matches and returns `false` if matches remain when polling ends.
+
+When disappearance is required rather than optional, use the error-returning
+form:
+
+```rust
+driver
+    .query(By::Testid("saving-indicator"))
+    .desc("saving indicator")
+    .wait_until_gone()
+    .await?;
+```
+
+“Gone” means no element currently matches any branch after that branch's
+filters in the query's source context. A replacement node that still matches
+keeps the query waiting. This returns immediately when the query is already
+absent and returns a `WebDriverError::Timeout` if any branch still matches at
+the deadline.
 
 The default poller is 20 seconds with 500ms intervals. To change it for
 the whole `WebDriver`, supply a custom `WebDriverConfig` — see

--- a/docs/src/features/waiting.md
+++ b/docs/src/features/waiting.md
@@ -1,9 +1,10 @@
 # Waiting For Element Changes
 
-`ElementQuery` waits for an element to *appear*. `ElementWaiter` waits
-for an element you already have to reach a particular state — visible,
-clickable, gone, with certain text, etc. Reach for it whenever you've
-clicked something and need the page to settle before you continue.
+`ElementQuery` repeatedly evaluates selectors and filters, including when you
+need all matching elements to disappear. `ElementWaiter` watches an element you
+already have until it reaches a particular state — visible, clickable, stale,
+with certain text, and so on. Reach for it whenever you've clicked something
+and need the held element to change before you continue.
 
 ```rust
 let button = driver.query(By::Css(".save")).single().await?;
@@ -50,11 +51,15 @@ that element before acting:
 ```rust,no_run
 # use thirtyfour::prelude::*;
 # async fn submit(save: WebElement) -> WebDriverResult<()> {
-save.wait_until().clickable().await?;
-save.click().await?;
+save.click_when_ready().await?;
 # Ok(())
 # }
 ```
+
+`click_when_ready()` is the common two-step sequence
+`wait_until().clickable().await?` followed by `click().await`. Keeping the
+readiness helper on a resolved object preserves the selector and cardinality
+choices made when that object was found.
 
 Text entry has application-specific replacement semantics, so make the choice
 to clear or append visible in the code:
@@ -84,13 +89,17 @@ action. A held element can become stale; re-query when re-rendering is expected,
 or keep the selector in an [`ElementResolver`](./components.md#elementresolver-methods)
 inside a Component.
 
-Selector-only helpers such as `driver.click(selector)` or
+Selector-taking helpers such as `driver.click(selector)` or
 `clear_and_type(selector, text)` would hide cardinality, descriptions, timeout,
 clearing, stale-element handling, and the expected outcome. A builder exposing
 those choices would duplicate `ElementQuery` without providing a stronger
-safety guarantee, so this design adds no new generic interaction API. Retrying
-clicks automatically can also repeat a non-idempotent action. Put repeated
-application behavior in a Component intent method such as `save_settings()` or
+safety guarantee, so there is no selector-taking generic interaction API.
+Resolved objects can still provide concise helpers for unambiguous common
+sequences: `WebElement::click_when_ready()` and the same-named
+`ElementResolver<WebElement>` methods keep their resolution behavior explicit
+in the receiver type. Retrying clicks automatically can repeat a non-idempotent
+action, so these helpers do not retry the click itself. Put repeated application
+behavior in a Component intent method such as `save_settings()` or
 `submit_credentials()`, where those choices and the outcome are known.
 
 ## Built-In Predicates
@@ -109,9 +118,9 @@ State predicates polled directly via WebDriver:
 | `.not_clickable().await?`   | hidden or disabled                           |
 | `.stale().await?`           | detached from the DOM                        |
 
-`.stale()` is especially useful right after a click — it lets you wait
-for the element you just acted on to disappear before assuming the
-next page is loaded.
+`.stale()` is especially useful right after a click: it waits for the concrete
+remote element you acted on to detach. It does not prove that navigation or the
+next page has finished loading.
 
 ## Text, Class, Attribute, Property Waits
 
@@ -209,13 +218,22 @@ for `ElementQuery::with_filter()`.
 - **Looking for an element on the page?** Use [`ElementQuery`](./queries.md).
 - **Already have an element and waiting for it to change?** Use
   `ElementWaiter` (this chapter).
-- **Waiting for an element to disappear?** Either works.
-  `query(...).not_exists()` polls until the selector returns nothing;
-  `elem.wait_until().stale()` polls until *that specific element* is
-  detached.
+- **Waiting for an element to disappear?** Use
+  `query(...).wait_until_gone()` when no element may match the complete query;
+  use `elem.wait_until().stale()` when *that specific resolved element* must be
+  detached. Use `not_exists()` when you want the same query polling as a
+  boolean instead of a timeout error.
+
+The distinction matters during re-rendering. `stale()` succeeds when its one
+remote element ID detaches, even if a replacement matches the old selector.
+`wait_until_gone()` re-runs every selector and filter and keeps waiting while a
+replacement matches. Neither wait implies that a navigation or the next page
+has completed.
 
 ## API Reference
 
-For the full method list, see
+For the full method lists, see
+[`ElementQuery`](https://docs.rs/thirtyfour/latest/thirtyfour/extensions/query/struct.ElementQuery.html)
+and
 [`ElementWaiter`](https://docs.rs/thirtyfour/latest/thirtyfour/extensions/query/struct.ElementWaiter.html)
 on docs.rs.

--- a/docs/src/getting-started/ai-quickstart.md
+++ b/docs/src/getting-started/ai-quickstart.md
@@ -55,8 +55,7 @@ async fn saves_profile_settings() -> Result<(), BrowserTestError> {
             .desc("save profile button")
             .single()
             .await?;
-        save_button.wait_until().clickable().await?;
-        save_button.click().await?;
+        save_button.click_when_ready().await?;
 
         // Assert the user-visible outcome. This query polls until the saved
         // state appears, so it replaces a brittle fixed sleep.

--- a/docs/src/tools/selenium-playwright.md
+++ b/docs/src/tools/selenium-playwright.md
@@ -249,7 +249,7 @@ These names are common translation mistakes, especially in generated code:
 | `page.locator(...)` / `driver.locator(...)` | `driver.query(...)` or `element.query(...)` |
 | `get_by_role`, `get_by_label`, `get_by_text` | `By::Testid`, stable semantic CSS, or a strong selector plus a text filter |
 | `expect(locator).to_be_visible()` | Query with `and_displayed()` or call `element.wait_until().displayed()` |
-| `locator.click()` with hidden auto-waiting | Query with `and_clickable()`, or wait explicitly before `WebElement::click()` |
+| `locator.click()` with hidden auto-waiting | Query with `and_clickable()`, or call `WebElement::click_when_ready()` on a deliberately held element |
 | `browser.new_context()` | A separate `WebDriver` session, or deliberate cookie/storage cleanup |
 | Selenium `WebDriverWait` / `ExpectedConditions` types | `query()` filters and `wait_until()` predicates |
 | Selenium `ActionChains` spelling | `driver.action_chain()` and the `ActionChain` API |

--- a/specs/ai-friendly-browser-automation.md
+++ b/specs/ai-friendly-browser-automation.md
@@ -158,13 +158,22 @@ later page-snapshot work ordered in
   intentionally held targets use `wait_until()`. Documentation must define
   clickable as displayed plus enabled rather than a complete interactability
   guarantee.
-- **AI-INT-003 (confirmed):** This design adds no generic click-and-type API.
-  Selector-only helpers would hide cardinality, diagnostics, timeout, clearing,
-  stale-element, retry, or outcome semantics, while a builder exposing those
-  choices would duplicate `ElementQuery` without a stronger safety guarantee.
+- **AI-INT-003 (confirmed):** This design adds no selector-taking generic
+  click-and-type API. Selector-only helpers would hide cardinality,
+  diagnostics, timeout, clearing, stale-element, retry, or outcome semantics,
+  while a builder exposing those choices would duplicate `ElementQuery`
+  without a stronger safety guarantee. Narrow helpers on an already-resolved
+  `WebElement` or `ElementResolver<WebElement>` may compose common operations
+  without retrying the operation or waiting for its outcome.
 - **AI-INT-004 (confirmed):** Reusable interaction abstractions belong in
   application-specific Component intent methods, where their semantics and
   expected outcome are known.
+- **AI-INT-005 (confirmed):** Query absence is evaluated from current matches
+  across every selector branch and its filters, without retaining historical
+  matches. `not_exists()` returns a boolean when polling ends, while
+  `wait_until_gone()` returns a timeout error if matches remain. `nowait()`
+  performs one poll. Query absence is distinct from `stale()`, which watches
+  one concrete resolved element.
 
 ## Acceptance criteria
 
@@ -248,6 +257,12 @@ later page-snapshot work ordered in
   patterns and explains both fresh-query and held-element readiness paths.
   Covers AI-INT-001 and AI-INT-002.
 - **AC-026:** Waiting documentation names interactability, stale-element,
-  clearing, retry, and outcome limitations and records the no-new-generic-API
-  decision. Existing quickstart and recipe flows remain explicit. Covers
-  AI-INT-003 and AI-INT-004.
+  clearing, retry, and outcome limitations and records the
+  no-selector-taking-generic-API decision. Narrow held-element and resolver
+  helpers document that they do not retry operations or wait for outcomes.
+  Existing quickstart and recipe flows remain explicit. Covers AI-INT-003 and
+  AI-INT-004.
+- **AC-027:** Query absence tests cover a match disappearing between polls,
+  every `.or()` branch, branch filters, one-shot `nowait()`, boolean timeout,
+  and erroring timeout behavior. Query and waiting documentation distinguish
+  full-query absence from concrete-element staleness. Covers AI-INT-005.

--- a/thirtyfour/src/components/wrapper/resolver.rs
+++ b/thirtyfour/src/components/wrapper/resolver.rs
@@ -8,7 +8,7 @@ use crate::components::Component;
 use crate::error::WebDriverResult;
 use crate::extensions::query::ElementQueryOptions;
 use crate::prelude::ElementQueryable;
-use crate::{By, DynElementQueryFn, ElementQueryFn, WebElement};
+use crate::{By, DynElementQueryFn, ElementQueryFn, TypingData, WebElement};
 
 /// Type alias for `ElementResolver<WebElement>`, for convenience.
 pub type ElementResolverSingle = ElementResolver<WebElement>;
@@ -156,6 +156,44 @@ impl<T: Resolve + Clone + 'static> ElementResolver<T> {
 }
 
 impl ElementResolver<WebElement> {
+    /// Resolve a present element and call [`WebElement::click()`] on it.
+    ///
+    /// This validates the cached element and re-runs the resolver first if it is stale.
+    pub async fn click(&self) -> WebDriverResult<()> {
+        self.resolve_present().await?.click().await
+    }
+
+    /// Resolve a present element and call [`WebElement::click_when_ready()`] on it.
+    ///
+    /// The click can still fail if, for example, the element becomes stale or another element
+    /// intercepts the click after the readiness check. This does not retry the click or wait for
+    /// an application outcome.
+    pub async fn click_when_ready(&self) -> WebDriverResult<()> {
+        self.resolve_present().await?.click_when_ready().await
+    }
+
+    /// Resolve a present element and call [`WebElement::clear()`] on it.
+    pub async fn clear(&self) -> WebDriverResult<()> {
+        self.resolve_present().await?.clear().await
+    }
+
+    /// Resolve a present element and forward the specified [`TypingData`] to
+    /// [`WebElement::send_keys()`].
+    pub async fn send_keys(&self, key: impl Into<TypingData>) -> WebDriverResult<()> {
+        self.resolve_present().await?.send_keys(key).await
+    }
+
+    /// Resolve a present element and return [`WebElement::text()`].
+    pub async fn text(&self) -> WebDriverResult<String> {
+        self.resolve_present().await?.text().await
+    }
+
+    /// Resolve a present element and return its optional `value` property from
+    /// [`WebElement::value()`].
+    pub async fn value(&self) -> WebDriverResult<Option<String>> {
+        self.resolve_present().await?.value().await
+    }
+
     /// Create a new element resolver that must return a single element.
     pub fn new_single(base_element: WebElement, by: By) -> Self {
         let resolver = move |elem: WebElement| {

--- a/thirtyfour/src/extensions/query/element_query.rs
+++ b/thirtyfour/src/extensions/query/element_query.rs
@@ -339,10 +339,35 @@ impl ElementQuery {
         Ok(!elements.is_empty())
     }
 
-    /// Return true if no element matches any selector (including filters), otherwise false.
+    /// Poll until no element currently matches any selector branch after its filters, returning
+    /// whether the condition was met before the configured poller ended.
+    ///
+    /// With [`ElementQuery::nowait()`], every selector is checked exactly once and the result is
+    /// returned immediately.
     pub async fn not_exists(&self) -> WebDriverResult<bool> {
         let elements = self.run_poller(false, true).await?;
         Ok(elements.is_empty())
+    }
+
+    /// Wait until no element currently matches this complete query in its source context,
+    /// including every selector branch and its filters.
+    ///
+    /// This returns immediately if the query is already absent. If matching elements remain when
+    /// the configured poller ends, this returns [`WebDriverError::Timeout`]. A replacement node
+    /// that also matches keeps the query waiting. With [`ElementQuery::nowait()`], the query is
+    /// checked exactly once.
+    pub async fn wait_until_gone(&self) -> WebDriverResult<()> {
+        let elements = self.run_poller(false, true).await?;
+        if elements.is_empty() {
+            return Ok(());
+        }
+
+        let element_description =
+            get_elements_description(None, self.options.description.as_deref().unwrap_or_default());
+        Err(WebDriverError::Timeout(format!(
+            "timed out waiting for {element_description} to disappear using selectors: {}",
+            get_selector_summary(&self.selectors)
+        )))
     }
 
     /// Return the first WebElement that matches any selector (including filters).
@@ -465,8 +490,10 @@ impl ElementQuery {
         // Start the poller.
         let mut poller = self.poller.start();
 
-        let mut elements = IndexMap::new();
         loop {
+            // Each poll must reflect the query's current matches. In particular, absence checks
+            // must not retain an element that was found by an earlier poll.
+            let mut elements = IndexMap::new();
             for selector in &self.selectors {
                 let mut new_elements =
                     match self.fetch_elements_from_source(selector.by.clone()).await {
@@ -954,6 +981,7 @@ async fn _test_is_send() -> WebDriverResult<()> {
     let query = driver.query(By::Css("div"));
     is_send_val(&query.exists());
     is_send_val(&query.not_exists());
+    is_send_val(&query.wait_until_gone());
     is_send_val(&query.first());
     is_send_val(&query.all_from_selector());
     is_send_val(&query.all_from_selector_required());

--- a/thirtyfour/src/web_element.rs
+++ b/thirtyfour/src/web_element.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crate::common::command::Command;
 use crate::error::{WebDriverError, WebDriverErrorInner};
+use crate::extensions::query::ElementWaitable;
 use crate::js::SIMULATE_DRAG_AND_DROP;
 use crate::session::handle::SessionHandle;
 use crate::support::base64_decode;
@@ -319,6 +320,35 @@ impl WebElement {
     pub async fn click(&self) -> WebDriverResult<()> {
         self.handle.cmd(Command::ElementClick(self.element_id.clone())).await?;
         Ok(())
+    }
+
+    /// Wait for the WebElement to be displayed and enabled, then click it.
+    ///
+    /// This is equivalent to `self.wait_until().clickable().await?; self.click().await`. Here,
+    /// clickable means displayed and enabled; it is not a complete interactability guarantee.
+    /// This method acts on this already-resolved element, clicks once, and does not re-resolve a
+    /// stale element, retry a failed click, or wait for an outcome. The click can still fail if,
+    /// for example, another element intercepts it after the readiness check.
+    ///
+    /// # Example:
+    /// ```no_run
+    /// # use thirtyfour::prelude::*;
+    /// # use thirtyfour::support::block_on;
+    /// #
+    /// # fn main() -> WebDriverResult<()> {
+    /// #     block_on(async {
+    /// #         let caps = DesiredCapabilities::chrome();
+    /// #         let driver = WebDriver::new("http://localhost:4444", caps).await?;
+    /// let elem = driver.find(By::Id("button1")).await?;
+    /// elem.click_when_ready().await?;
+    /// #         driver.quit().await?;
+    /// #         Ok(())
+    /// #     })
+    /// # }
+    /// ```
+    pub async fn click_when_ready(&self) -> WebDriverResult<()> {
+        self.wait_until().clickable().await?;
+        self.click().await
     }
 
     /// Clear the WebElement contents.

--- a/thirtyfour/tests/elements.rs
+++ b/thirtyfour/tests/elements.rs
@@ -108,6 +108,31 @@ fn element_text(test_harness: TestHarness) -> WebDriverResult<()> {
 }
 
 #[rstest]
+fn element_click_when_ready(test_harness: TestHarness) -> WebDriverResult<()> {
+    let c = test_harness.driver();
+    block_on(async {
+        c.goto(sample_page_url()).await?;
+        c.find(By::Id("text-input2")).await?.send_keys("ready").await?;
+        c.execute(
+            "const button = document.getElementById('button-copy'); \
+             button.disabled = true; \
+             button.dataset.clicks = '0'; \
+             button.addEventListener('click', () => button.dataset.clicks = String(Number(button.dataset.clicks) + 1)); \
+             setTimeout(() => button.disabled = false, 100);",
+            vec![],
+        )
+        .await?;
+
+        let button = c.find(By::Id("button-copy")).await?;
+        button.click_when_ready().await?;
+
+        assert_eq!(c.find(By::Id("text-output")).await?.text().await?, "ready");
+        assert_eq!(button.attr("data-clicks").await?.as_deref(), Some("1"));
+        Ok(())
+    })
+}
+
+#[rstest]
 fn element_rect(test_harness: TestHarness) -> WebDriverResult<()> {
     let c = test_harness.driver();
     block_on(async {

--- a/thirtyfour/tests/helpers.rs
+++ b/thirtyfour/tests/helpers.rs
@@ -1,0 +1,114 @@
+mod common;
+
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use common::*;
+use rstest::rstest;
+use thirtyfour::components::ElementResolverSingle;
+use thirtyfour::error::WebDriverErrorInner;
+use thirtyfour::prelude::*;
+use thirtyfour::support::block_on;
+
+#[rstest]
+fn query_absence_polling(test_harness: TestHarness) -> WebDriverResult<()> {
+    let c = test_harness.driver();
+    block_on(async {
+        c.goto(sample_page_url()).await?;
+
+        // `nowait()` performs one complete check, including every `or()` branch.
+        assert!(
+            !c.query(By::Id("doesnotexist")).or(By::Id("navigation")).nowait().not_exists().await?
+        );
+        let error = c
+            .query(By::Id("doesnotexist"))
+            .or(By::Id("navigation"))
+            .desc("navigation alternatives")
+            .nowait()
+            .wait_until_gone()
+            .await
+            .expect_err("the navigation branch still matches");
+        let message = error.to_string();
+        assert!(message.contains("navigation alternatives"));
+        assert!(message.contains("Id(doesnotexist)"));
+        assert!(message.contains("Id(navigation)"));
+        assert_matches!(error.into_inner(), WebDriverErrorInner::Timeout(_));
+
+        // A waiting `not_exists()` must forget matches from earlier poll attempts.
+        c.execute("setTimeout(() => document.getElementById('navigation').remove(), 100);", vec![])
+            .await?;
+        assert!(
+            c.query(By::Id("navigation"))
+                .wait(Duration::from_secs(2), Duration::from_millis(20))
+                .not_exists()
+                .await?
+        );
+
+        // Filters are part of the query: the raw node may remain while the filtered match goes.
+        c.execute(
+            "const footer = document.getElementById('footer'); \
+             footer.classList.add('temporary-match'); \
+             setTimeout(() => footer.classList.remove('temporary-match'), 100);",
+            vec![],
+        )
+        .await?;
+        assert!(
+            c.query(By::Id("footer"))
+                .with_class("temporary-match")
+                .wait(Duration::from_secs(2), Duration::from_millis(20))
+                .not_exists()
+                .await?
+        );
+        assert!(c.query(By::Id("footer")).nowait().exists().await?);
+
+        // Every branch must be absent in the same poll attempt.
+        c.goto(sample_page_url()).await?;
+        c.execute(
+            "setTimeout(() => document.getElementById('navigation').remove(), 50); \
+             setTimeout(() => document.getElementById('footer').remove(), 150);",
+            vec![],
+        )
+        .await?;
+        c.query(By::Id("navigation"))
+            .or(By::Id("footer"))
+            .wait(Duration::from_secs(2), Duration::from_millis(20))
+            .wait_until_gone()
+            .await?;
+
+        // Already-absent queries complete on their first attempt.
+        c.query(By::Id("footer")).nowait().wait_until_gone().await?;
+        Ok(())
+    })
+}
+
+#[rstest]
+fn resolver_element_helpers(test_harness: TestHarness) -> WebDriverResult<()> {
+    let c = test_harness.driver();
+    block_on(async {
+        c.goto(sample_page_url()).await?;
+        let section = c.find(By::Id("section-text")).await?;
+        let input = ElementResolverSingle::new_single(section.clone(), By::Id("text-input2"));
+        let button = ElementResolverSingle::new_single(section, By::Id("button-copy"));
+
+        assert_eq!(input.value().await?.as_deref(), Some(""));
+        input.send_keys("from resolver").await?;
+        assert_eq!(input.value().await?.as_deref(), Some("from resolver"));
+        assert_eq!(button.text().await?, "Copy");
+
+        button.click().await?;
+        assert_eq!(c.find(By::Id("text-output")).await?.text().await?, "from resolver");
+
+        // Replace the cached button. The helper should validate and re-resolve it before clicking.
+        c.execute(
+            "const old = document.getElementById('button-copy'); old.replaceWith(old.cloneNode(true));",
+            vec![],
+        )
+        .await?;
+        input.clear().await?;
+        input.send_keys("ready again").await?;
+        button.click_when_ready().await?;
+        assert_eq!(c.find(By::Id("text-output")).await?.text().await?, "ready again");
+
+        Ok(())
+    })
+}


### PR DESCRIPTION
## Summary

- add `WebElement::click_when_ready()` as the explicit displayed-and-enabled wait followed by one click
- add same-named `ElementResolver<WebElement>` helpers for `click`, `click_when_ready`, `clear`, `send_keys`, `text`, and `value`, each resolving a present element before forwarding
- add `ElementQuery::wait_until_gone()` and fix `not_exists()` so each poll evaluates current matches rather than retaining matches from earlier polls
- document the distinction between full-query disappearance and a concrete element becoming stale

## Semantics

`nowait().not_exists()` remains a one-attempt boolean check. With polling enabled, `not_exists()` returns `false` if matches remain at the deadline, while `wait_until_gone()` returns `WebDriverError::Timeout`. Absence is evaluated across every selector branch and its filters.

The click helpers wait for displayed + enabled, issue one click, and do not retry the operation or wait for an application outcome.

## Validation

- `cargo test -p thirtyfour --lib`
- `cargo test -p thirtyfour --test helpers -- --nocapture`
- `cargo test -p thirtyfour --test elements element_click_when_ready -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --all-features --all-targets`
- `cargo doc --no-deps --all-features`
- `cargo test -p thirtyfour --doc`
- `mdbook build docs`