### PR TITLE
Add configurable WebDriver manager polling

### DIFF
--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thirtyfour"
-version = "0.37.3"
+version = "0.37.4"
 edition = "2024"
 description = """
 Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI testing.

--- a/thirtyfour/examples/query/custom_poller.rs
+++ b/thirtyfour/examples/query/custom_poller.rs
@@ -8,7 +8,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use thirtyfour::common::config::WebDriverConfig;
 use thirtyfour::extensions::query::ElementPollerWithTimeout;
 use thirtyfour::prelude::*;
 
@@ -33,17 +32,15 @@ async fn main() -> anyhow::Result<()> {
         .displayed()
         .await?;
 
-    // Use a custom poller instance.
+    // Replace the default poller for subsequent queries and waits.
     let my_poller =
         Arc::new(ElementPollerWithTimeout::new(Duration::from_secs(120), Duration::from_secs(1)));
-    let new_config = WebDriverConfig::builder().poller(my_poller).build()?;
-    let my_driver = driver.clone_with_config(new_config);
+    driver.set_poller(my_poller);
 
     // Perform query using custom poller.
-    let elem_form = my_driver.query(By::Id("search-form")).single().await?;
+    let elem_form = driver.query(By::Id("search-form")).single().await?;
 
-    // Perform element wait using custom poller. Elements always inherit the `WebDriverConfig` from
-    // the `WebDriver` instance that found them.
+    // Perform element wait using the current poller from the shared session configuration.
     elem_form.wait_until().displayed().await?;
 
     // Always explicitly close the browser. This prevents the executor from being blocked

--- a/thirtyfour/src/common/config.rs
+++ b/thirtyfour/src/common/config.rs
@@ -23,7 +23,14 @@ pub struct WebDriverConfig {
     /// Per-request HTTP timeout. Applied to the default reqwest-based
     /// [`HttpClient`]; custom client implementations may also honour it.
     ///
+    /// The HTTP client is configured when the session is created. Replacing
+    /// this config later via [`WebDriver::set_config`] or
+    /// [`SessionHandle::set_config`] does not change the existing client's
+    /// timeout.
+    ///
     /// [`HttpClient`]: crate::session::http::HttpClient
+    /// [`SessionHandle::set_config`]: crate::session::handle::SessionHandle::set_config
+    /// [`WebDriver::set_config`]: crate::WebDriver::set_config
     pub request_timeout: Duration,
 }
 

--- a/thirtyfour/src/manager/manager.rs
+++ b/thirtyfour/src/manager/manager.rs
@@ -15,6 +15,7 @@ use url::Url;
 use crate::Capabilities;
 use crate::common::config::WebDriverConfig;
 use crate::error::{WebDriverError, WebDriverResult};
+use crate::extensions::query::IntoElementPoller;
 use crate::session::DriverGuard;
 use crate::session::create::start_session;
 use crate::session::handle::SessionHandle;
@@ -50,6 +51,8 @@ fn default_cache_dir() -> PathBuf {
 /// [`WebDriver::managed`]: crate::WebDriver::managed
 pub struct WebDriverManager {
     pub(crate) cfg: ResolvedConfig,
+    /// Configuration applied to every WebDriver session launched by this manager.
+    pub(crate) web_driver_config: WebDriverConfig,
     /// HTTP client used for fetching upstream metadata and binaries.
     download_client: reqwest::Client,
     /// Map from `(browser, resolved_version)` to a Weak handle on a live driver.
@@ -72,7 +75,10 @@ pub struct WebDriverManager {
 
 impl std::fmt::Debug for WebDriverManager {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WebDriverManager").field("cfg", &self.cfg).finish_non_exhaustive()
+        f.debug_struct("WebDriverManager")
+            .field("cfg", &self.cfg)
+            .field("web_driver_config", &self.web_driver_config)
+            .finish_non_exhaustive()
     }
 }
 
@@ -178,6 +184,8 @@ pub struct WebDriverManagerBuilder {
     pub(crate) status_subscribers: Vec<StatusCallback>,
     /// Driver-log subscribers registered before `build`.
     pub(crate) log_subscribers: Vec<DriverLogCallback>,
+    /// Configuration applied to every WebDriver session launched by the manager.
+    pub(crate) web_driver_config: WebDriverConfig,
     /// Set when constructed via `WebDriver::managed(caps)`.
     pub(crate) preloaded_caps: Option<Capabilities>,
 }
@@ -196,6 +204,7 @@ impl std::fmt::Debug for WebDriverManagerBuilder {
             .field("driver_paths", &self.driver_paths)
             .field("status_subscribers", &self.status_subscribers.len())
             .field("log_subscribers", &self.log_subscribers.len())
+            .field("web_driver_config", &self.web_driver_config)
             .finish_non_exhaustive()
     }
 }
@@ -215,12 +224,31 @@ impl Clone for WebDriverManagerBuilder {
             driver_paths: self.driver_paths.clone(),
             status_subscribers: self.status_subscribers.iter().map(Arc::clone).collect(),
             log_subscribers: self.log_subscribers.iter().map(Arc::clone).collect(),
+            web_driver_config: self.web_driver_config.clone(),
             preloaded_caps: self.preloaded_caps.clone(),
         }
     }
 }
 
 impl WebDriverManagerBuilder {
+    /// Set the configuration used by every [`WebDriver`] session launched by
+    /// the resulting manager.
+    pub fn config(mut self, config: WebDriverConfig) -> Self {
+        self.web_driver_config = config;
+        self
+    }
+
+    /// Set the element poller used by every [`WebDriver`] session launched by
+    /// the resulting manager.
+    ///
+    /// This replaces the poller in the current [`WebDriverConfig`], including
+    /// a configuration previously supplied via
+    /// [`WebDriverManagerBuilder::config`].
+    pub fn poller(mut self, poller: Arc<dyn IntoElementPoller + Send + Sync>) -> Self {
+        self.web_driver_config.poller = poller;
+        self
+    }
+
     /// Pick a driver version. See [`DriverVersion`] for variants.
     pub fn version(mut self, v: DriverVersion) -> Self {
         self.version = v;
@@ -408,6 +436,7 @@ impl WebDriverManagerBuilder {
             std::mem::forget(log_subscribers.add_arc(cb));
         }
         Arc::new(WebDriverManager {
+            web_driver_config: self.web_driver_config,
             download_client: reqwest::Client::builder()
                 .build()
                 .expect("default reqwest client should always build"),
@@ -486,7 +515,7 @@ impl WebDriverManager {
             .parse()
             .map_err(|e| WebDriverError::ParseError(format!("invalid driver url: {e}")))?;
 
-        let config = WebDriverConfig::default();
+        let config = self.web_driver_config.clone();
         let client = create_reqwest_client(config.request_timeout);
         let client_arc: Arc<dyn crate::session::http::HttpClient> = Arc::new(client);
         self.emitter.emit(Status::SessionStarting {

--- a/thirtyfour/src/manager/tests.rs
+++ b/thirtyfour/src/manager/tests.rs
@@ -18,6 +18,8 @@ use super::status::{DriverLogLine, Emitter, LogSubscribers, Status};
 use super::version::DriverVersion;
 use super::{StdioMode, WebDriverManager};
 use crate::Capabilities;
+use crate::common::config::WebDriverConfig;
+use crate::extensions::query::{ElementPollerNoWait, ElementPollerWithTimeout, IntoElementPoller};
 
 #[test]
 fn builder_defaults_match_match_local() {
@@ -58,6 +60,33 @@ fn builder_offline_toggle() {
 fn builder_stdio() {
     let mgr = WebDriverManager::builder().stdio(StdioMode::Null).build();
     assert!(matches!(mgr.cfg.stdio, StdioMode::Null));
+}
+
+#[test]
+fn builder_web_driver_config() {
+    let config = WebDriverConfig::builder()
+        .keep_alive(false)
+        .request_timeout(Duration::from_secs(42))
+        .build()
+        .unwrap();
+    let manager = WebDriverManager::builder().config(config).build();
+
+    assert!(!manager.web_driver_config.keep_alive);
+    assert_eq!(manager.web_driver_config.request_timeout, Duration::from_secs(42));
+}
+
+#[test]
+fn builder_poller_replaces_config_poller() {
+    let initial_poller: Arc<dyn IntoElementPoller + Send + Sync> =
+        Arc::new(ElementPollerWithTimeout::default());
+    let replacement_poller: Arc<dyn IntoElementPoller + Send + Sync> =
+        Arc::new(ElementPollerNoWait);
+    let config = WebDriverConfig::builder().poller(initial_poller).build().unwrap();
+
+    let manager =
+        WebDriverManager::builder().config(config).poller(Arc::clone(&replacement_poller)).build();
+
+    assert!(Arc::ptr_eq(&manager.web_driver_config.poller, &replacement_poller));
 }
 
 #[test]

--- a/thirtyfour/src/session/handle.rs
+++ b/thirtyfour/src/session/handle.rs
@@ -42,7 +42,7 @@ pub struct SessionHandle {
     /// for BiDi).
     capabilities: Arc<Capabilities>,
     /// Atomically replaceable config used by this instance.
-    config: Arc<ArcSwap<WebDriverConfig>>,
+    config: ArcSwap<WebDriverConfig>,
     /// quit session flag
     quit: Arc<OnceCell<()>>,
     /// Lazily-connected WebDriver BiDi handle, shared by every clone of the
@@ -84,7 +84,7 @@ impl SessionHandle {
             server_url: Arc::new(server_url.into_url()?),
             session_id,
             capabilities: Arc::new(capabilities),
-            config: Arc::new(ArcSwap::from_pointee(config)),
+            config: ArcSwap::from_pointee(config),
             quit: Arc::new(OnceCell::new()),
             #[cfg(feature = "bidi")]
             bidi: Arc::new(OnceCell::new()),
@@ -104,7 +104,7 @@ impl SessionHandle {
             quit: Arc::clone(&self.quit),
             #[cfg(feature = "bidi")]
             bidi: Arc::clone(&self.bidi),
-            config: Arc::new(ArcSwap::from_pointee(config)),
+            config: ArcSwap::from_pointee(config),
             driver_guard: self.driver_guard.clone(),
         }
     }
@@ -1282,7 +1282,7 @@ impl Drop for SessionHandle {
             quit: Arc::clone(&self.quit),
             session_id: self.session_id.clone(),
             capabilities: Arc::clone(&self.capabilities),
-            config: Arc::clone(&self.config),
+            config: ArcSwap::from(self.config.load_full()),
             #[cfg(feature = "bidi")]
             bidi: Arc::clone(&self.bidi),
             // The guard stays on the *original* SessionHandle so it drops after

--- a/thirtyfour/src/session/handle.rs
+++ b/thirtyfour/src/session/handle.rs
@@ -1,3 +1,4 @@
+use arc_swap::ArcSwap;
 use serde_json::Value;
 use std::fmt::{Debug, Display, Formatter};
 use std::future::Future;
@@ -14,6 +15,7 @@ use crate::common::config::WebDriverConfig;
 use crate::common::cookie::Cookie;
 use crate::common::print::PrintParameters;
 use crate::error::WebDriverResult;
+use crate::extensions::query::IntoElementPoller;
 use crate::prelude::WebDriverError;
 use crate::session::scriptret::ScriptRet;
 use crate::support::base64_decode;
@@ -39,8 +41,8 @@ pub struct SessionHandle {
     /// are read from here for CDP WebSocket discovery; W3C `webSocketUrl`
     /// for BiDi).
     capabilities: Arc<Capabilities>,
-    /// The config used by this instance.
-    config: WebDriverConfig,
+    /// Atomically replaceable config used by this instance.
+    config: Arc<ArcSwap<WebDriverConfig>>,
     /// quit session flag
     quit: Arc<OnceCell<()>>,
     /// Lazily-connected WebDriver BiDi handle, shared by every clone of the
@@ -82,7 +84,7 @@ impl SessionHandle {
             server_url: Arc::new(server_url.into_url()?),
             session_id,
             capabilities: Arc::new(capabilities),
-            config,
+            config: Arc::new(ArcSwap::from_pointee(config)),
             quit: Arc::new(OnceCell::new()),
             #[cfg(feature = "bidi")]
             bidi: Arc::new(OnceCell::new()),
@@ -102,7 +104,7 @@ impl SessionHandle {
             quit: Arc::clone(&self.quit),
             #[cfg(feature = "bidi")]
             bidi: Arc::clone(&self.bidi),
-            config,
+            config: Arc::new(ArcSwap::from_pointee(config)),
             driver_guard: self.driver_guard.clone(),
         }
     }
@@ -145,21 +147,48 @@ impl SessionHandle {
         &self.server_url
     }
 
-    /// The configuration used by this instance.
+    /// Return a snapshot of the configuration currently used by this session.
     ///
-    /// NOTE: It's sometimes useful to have separate instances pointing at the same
-    ///       underlying browser session but using different configurations.
-    ///       See [`WebDriver::clone_with_config()`] for more details.
+    /// The returned [`Arc`] keeps this snapshot alive if another task replaces
+    /// the session configuration.
+    pub fn config(&self) -> Arc<WebDriverConfig> {
+        self.config.load_full()
+    }
+
+    /// Atomically replace the configuration used by this session.
     ///
-    /// [`WebDriver::clone_with_config()`]: crate::WebDriver::clone_with_config()
-    pub fn config(&self) -> &WebDriverConfig {
-        &self.config
+    /// The new configuration is shared by all [`WebDriver`](crate::WebDriver)
+    /// clones and [`WebElement`]s associated with this session. Existing
+    /// [`ElementQuery`](crate::extensions::query::ElementQuery) and
+    /// [`ElementWaiter`](crate::extensions::query::ElementWaiter) values keep
+    /// the poller they were created with.
+    ///
+    /// Changing [`WebDriverConfig::request_timeout`] does not reconfigure the
+    /// existing HTTP client. Its timeout is fixed when the client is created.
+    pub fn set_config(&self, config: WebDriverConfig) {
+        self.config.store(Arc::new(config));
+    }
+
+    /// Atomically replace the default element poller used by this session.
+    ///
+    /// The new poller is shared by all [`WebDriver`](crate::WebDriver) clones
+    /// and [`WebElement`]s associated with this session. Existing
+    /// [`ElementQuery`](crate::extensions::query::ElementQuery) and
+    /// [`ElementWaiter`](crate::extensions::query::ElementWaiter) values keep
+    /// the poller they were created with.
+    pub fn set_poller(&self, poller: Arc<dyn IntoElementPoller + Send + Sync>) {
+        self.config.rcu(|current| {
+            let mut config = current.as_ref().clone();
+            config.poller = Arc::clone(&poller);
+            config
+        });
     }
 
     /// Send the specified command to the webdriver server.
     pub async fn cmd(&self, command: impl FormatRequestData) -> WebDriverResult<CmdResponse> {
         let request_data = command.format_request(&self.session_id);
-        run_webdriver_cmd(&*self.client, &request_data, &self.server_url, &self.config).await
+        let config = self.config();
+        run_webdriver_cmd(&*self.client, &request_data, &self.server_url, config.as_ref()).await
     }
 
     /// Get the WebDriver status.
@@ -1253,7 +1282,7 @@ impl Drop for SessionHandle {
             quit: Arc::clone(&self.quit),
             session_id: self.session_id.clone(),
             capabilities: Arc::clone(&self.capabilities),
-            config: self.config.clone(),
+            config: Arc::clone(&self.config),
             #[cfg(feature = "bidi")]
             bidi: Arc::clone(&self.bidi),
             // The guard stays on the *original* SessionHandle so it drops after
@@ -1308,5 +1337,99 @@ impl Drop for SessionHandle {
             });
         })
         .join();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use http::{Request, Response};
+
+    use super::*;
+    use crate::extensions::query::{
+        ElementPollerNoWait, ElementPollerWithTimeout, IntoElementPoller,
+    };
+    use crate::session::http::{Body, HttpClient};
+    use crate::{Capabilities, WebDriver};
+
+    struct UnusedClient;
+
+    #[async_trait::async_trait]
+    impl HttpClient for UnusedClient {
+        async fn send(&self, _: Request<Body<'_>>) -> WebDriverResult<Response<Bytes>> {
+            unreachable!("configuration tests do not issue WebDriver commands")
+        }
+
+        async fn new(&self) -> Arc<dyn HttpClient> {
+            Arc::new(Self)
+        }
+    }
+
+    fn test_driver() -> WebDriver {
+        let handle = Arc::new(
+            SessionHandle::new_with_config_guard_and_caps(
+                Arc::new(UnusedClient),
+                "http://localhost:4444",
+                SessionId::from("config-test-session"),
+                WebDriverConfig::default(),
+                None,
+                Capabilities::new(),
+            )
+            .unwrap(),
+        );
+        handle.leak().unwrap();
+        WebDriver {
+            handle,
+        }
+    }
+
+    #[test]
+    fn config_updates_are_shared_by_driver_clones() {
+        let driver = test_driver();
+        let clone = driver.clone();
+        let poller: Arc<dyn IntoElementPoller + Send + Sync> = Arc::new(ElementPollerNoWait);
+
+        driver.set_poller(Arc::clone(&poller));
+
+        let config = clone.config();
+        assert!(Arc::ptr_eq(&config.poller, &poller));
+        assert_eq!(config.request_timeout, Duration::from_secs(120));
+
+        let replacement_poller: Arc<dyn IntoElementPoller + Send + Sync> =
+            Arc::new(ElementPollerWithTimeout::default());
+        let replacement = WebDriverConfig::builder()
+            .keep_alive(false)
+            .poller(Arc::clone(&replacement_poller))
+            .request_timeout(Duration::from_secs(42))
+            .build()
+            .unwrap();
+
+        clone.set_config(replacement);
+
+        let config = driver.config();
+        assert!(!config.keep_alive);
+        assert_eq!(config.request_timeout, Duration::from_secs(42));
+        assert!(Arc::ptr_eq(&config.poller, &replacement_poller));
+    }
+
+    #[test]
+    fn session_handle_setters_update_the_shared_config() {
+        let driver = test_driver();
+        let handle = Arc::clone(driver.handle());
+        let poller: Arc<dyn IntoElementPoller + Send + Sync> = Arc::new(ElementPollerNoWait);
+
+        handle.set_poller(Arc::clone(&poller));
+        assert!(Arc::ptr_eq(&driver.config().poller, &poller));
+
+        let replacement = WebDriverConfig::builder()
+            .keep_alive(false)
+            .request_timeout(Duration::from_secs(7))
+            .build()
+            .unwrap();
+        handle.set_config(replacement);
+
+        let config = driver.config();
+        assert!(!config.keep_alive);
+        assert_eq!(config.request_timeout, Duration::from_secs(7));
     }
 }

--- a/thirtyfour/src/web_driver.rs
+++ b/thirtyfour/src/web_driver.rs
@@ -122,13 +122,42 @@ impl WebDriver {
         &self.handle
     }
 
+    /// Atomically replace the configuration used by this driver session.
+    ///
+    /// The new configuration is shared by all clones and elements associated
+    /// with this session. Changing [`WebDriverConfig::request_timeout`] does
+    /// not reconfigure the existing HTTP client because its timeout is fixed
+    /// when the client is created.
+    pub fn set_config(&self, config: WebDriverConfig) {
+        self.handle.set_config(config);
+    }
+
+    /// Atomically replace the default element poller used by this driver
+    /// session.
+    ///
+    /// The new poller is shared by all clones and elements associated with
+    /// this session. Queries and waiters that have already been created keep
+    /// their existing poller.
+    pub fn set_poller(&self, poller: Arc<dyn IntoElementPoller + Send + Sync>) {
+        self.handle.set_poller(poller);
+    }
+
     /// Clone this `WebDriver` keeping the session handle, but supplying a new `WebDriverConfig`.
     ///
     /// This still uses the same underlying client, and still controls the same browser
     /// session, but uses a different `WebDriverConfig` for this instance.
     ///
-    /// This is useful in cases where you want to specify a custom poller configuration (or
-    /// some other configuration option) for only one instance of `WebDriver`.
+    /// Prefer configuring [`WebDriverBuilder`] or
+    /// [`WebDriverManagerBuilder`](crate::manager::WebDriverManagerBuilder) before creating the
+    /// session. For query-specific polling behavior, use
+    /// [`ElementQuery::with_poller`](crate::extensions::query::ElementQuery::with_poller).
+    ///
+    /// This method creates a separate [`SessionHandle`] that participates in synchronous teardown
+    /// when dropped, so dropping either driver can terminate the shared browser session.
+    #[deprecated(
+        since = "0.37.4",
+        note = "configure WebDriverBuilder or WebDriverManagerBuilder before creating the session; clone_with_config() creates a separate SessionHandle that can tear down the shared session when dropped"
+    )]
     pub fn clone_with_config(&self, config: WebDriverConfig) -> Self {
         Self {
             handle: Arc::new(self.handle.clone_with_config(config)),


### PR DESCRIPTION
## Summary

- add `WebDriverManagerBuilder::config()` and `WebDriverManagerBuilder::poller()` so managed sessions can start with a custom `WebDriverConfig`
- store each session's live configuration behind `ArcSwap` and add `set_config()` / `set_poller()` on both `WebDriver` and `SessionHandle`
- deprecate `WebDriver::clone_with_config()` because its independent `SessionHandle` can tear down the shared browser session when dropped
- update the custom poller example and bump `thirtyfour` to `0.37.4`

## Rationale and impact

Managed sessions previously always used `WebDriverConfig::default()`, leaving no safe way to configure their poller or other WebDriver settings. The available `clone_with_config()` workaround creates a second `SessionHandle`; its destructor can terminate the underlying shared session unexpectedly.

The builder methods now apply configuration at session creation, while the atomic runtime setters propagate changes to normal driver clones and associated elements without creating another teardown owner. Existing queries and waiters retain the poller captured when they were created. Updating `request_timeout` after session creation is documented as metadata-only because the timeout is baked into the existing HTTP client.

## Validation

- `cargo test -p thirtyfour --lib` (99 passed)
- `cargo test -p thirtyfour --doc` (125 passed, 10 ignored)
- `cargo clippy --all-features --all-targets`
- `cargo doc --no-deps --all-features`
- `cargo check -p thirtyfour --no-default-features`
- `cargo fmt --check`
- `git diff --check`