### PR TITLE
Keep mdBook crate version in sync

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -31,9 +31,10 @@ jobs:
           echo `pwd`/mdbook >> $GITHUB_PATH
       - name: Replace crate version
         run: |
-          LATEST_VERSION=$(cargo search thirtyfour | grep "^thirtyfour = " | cut -d'"' -f2)
+          THIRTYFOUR_VERSION=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "thirtyfour") | .version')
           cd docs
-          find src/ -name '*.md' -exec sed -i "s/THIRTYFOUR_CRATE_VERSION/${LATEST_VERSION}/g" {} \;
+          find src/ -name '*.md' -exec sed -i "s/THIRTYFOUR_CRATE_VERSION/${THIRTYFOUR_VERSION}/g" {} \;
       - name: Build Book
         run: |
           # This assumes your book is in the root of your repository.


### PR DESCRIPTION
## Summary

- derive the mdBook dependency version from the checked-out `thirtyfour` package via `cargo metadata`
- stop querying crates.io for the latest published version during documentation deployment

## Why

The mdBook deployment runs immediately after changes merge to `main`. Querying crates.io can return the previous release until the newly bumped crate has been published, causing the deployed installation snippets to lag the source version. Reading workspace metadata keeps the book aligned with the exact source revision being deployed.

## Validation

- confirmed the workflow resolves `thirtyfour` as `0.37.4`
- `mdbook build docs`
- `git diff --check`