### PR TITLE
Await managed driver shutdown and prepare 0.37.5

### DIFF
--- a/thirtyfour/Cargo.toml
+++ b/thirtyfour/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thirtyfour"
-version = "0.37.4"
+version = "0.37.5"
 edition = "2024"
 description = """
 Thirtyfour is a Selenium / WebDriver library for Rust, for automated website UI testing.

--- a/thirtyfour/src/lib.rs
+++ b/thirtyfour/src/lib.rs
@@ -223,7 +223,7 @@ pub use common::{
     requestdata::*,
     types::*,
 };
-pub use web_driver::{WebDriver, WebDriverBuilder};
+pub use web_driver::{WebDriver, WebDriverBuilder, WebDriverRunError};
 pub use web_element::WebElement;
 
 /// Allow importing the common types via `use thirtyfour::prelude::*`.

--- a/thirtyfour/src/manager/manager.rs
+++ b/thirtyfour/src/manager/manager.rs
@@ -5,7 +5,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard, Weak};
 use std::time::Duration;
 
 use serde_json::Value;
@@ -130,7 +130,7 @@ impl DriverGuard for ManagedDriverProcess {}
 /// underlying [`ManagedDriverProcess`] alive for the lifetime of the session,
 /// and emits [`Status::SessionEnded`] when dropped.
 pub(crate) struct SessionGuard {
-    pub(crate) driver: Arc<ManagedDriverProcess>,
+    driver: StdMutex<Option<Arc<ManagedDriverProcess>>>,
     emitter: Emitter,
     browser: BrowserKind,
     session_id: String,
@@ -141,8 +141,25 @@ impl std::fmt::Debug for SessionGuard {
         f.debug_struct("SessionGuard")
             .field("browser", &self.browser)
             .field("session_id", &self.session_id)
-            .field("driver", &self.driver)
+            .field("driver", &self.driver())
             .finish_non_exhaustive()
+    }
+}
+
+impl SessionGuard {
+    fn driver(&self) -> StdMutexGuard<'_, Option<Arc<ManagedDriverProcess>>> {
+        self.driver.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    pub(crate) fn driver_id(&self) -> Option<DriverId> {
+        self.driver().as_ref().map(|driver| driver.driver_id)
+    }
+
+    pub(crate) fn subscribe_log<F>(&self, f: F) -> Option<DriverLogSubscription>
+    where
+        F: Fn(&DriverLogLine) + Send + Sync + 'static,
+    {
+        self.driver().as_ref().map(|driver| driver.subscribe_log(f))
     }
 }
 
@@ -156,6 +173,18 @@ impl Drop for SessionGuard {
 }
 
 impl DriverGuard for SessionGuard {
+    fn release(&self) -> Pin<Box<dyn Future<Output = WebDriverResult<()>> + Send + '_>> {
+        Box::pin(async move {
+            let driver = self.driver().take();
+            if let Some(driver) = driver
+                && let Some(process) = Arc::into_inner(driver)
+            {
+                process.shutdown().await.map_err(WebDriverError::from)?;
+            }
+            Ok(())
+        })
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -530,7 +559,7 @@ impl WebDriverManager {
             url: server_url.to_string(),
         });
         let guard: Arc<dyn DriverGuard> = Arc::new(SessionGuard {
-            driver,
+            driver: StdMutex::new(Some(driver)),
             emitter: self.emitter.clone(),
             browser,
             session_id: session_id.to_string(),

--- a/thirtyfour/src/manager/process.rs
+++ b/thirtyfour/src/manager/process.rs
@@ -148,6 +148,22 @@ impl ManagedDriverProcess {
     {
         self.log_subscribers.add(f)
     }
+
+    /// Kill the driver and wait until the OS has reaped it.
+    ///
+    /// This consumes the process after the final managed-session lease is
+    /// released. [`Drop`] remains the non-blocking fallback when explicit
+    /// asynchronous cleanup is skipped or cancelled.
+    pub(crate) async fn shutdown(mut self) -> std::io::Result<()> {
+        self.shutdown.store(true, Ordering::Relaxed);
+        for handle in self.pump_handles.drain(..) {
+            handle.abort();
+        }
+        if let Some(mut child) = self.child.take() {
+            child.kill().await?;
+        }
+        Ok(())
+    }
 }
 
 /// Heuristic: did this error come from the OS reporting that the chosen port
@@ -377,8 +393,9 @@ impl Drop for ManagedDriverProcess {
         self.shutdown.store(true, Ordering::Relaxed);
         // Sync drop, so we can't await. `start_kill` issues SIGKILL (or
         // TerminateProcess on Windows) without blocking; `kill_on_drop(true)`
-        // set on the Command ensures the child is reaped asynchronously when
-        // the Child handle drops.
+        // asks Tokio to reap the child on a best-effort basis when the Child
+        // handle drops. Explicit `WebDriver::quit().await` uses `shutdown()`
+        // above and waits for reaping instead.
         if let Some(mut child) = self.child.take()
             && let Err(e) = child.start_kill()
         {

--- a/thirtyfour/src/session/handle.rs
+++ b/thirtyfour/src/session/handle.rs
@@ -1228,6 +1228,9 @@ impl SessionHandle {
         self.quit
             .get_or_try_init(|| async { self.cmd(Command::DeleteSession).await.map(drop) })
             .await?;
+        if let Some(driver_guard) = &self.driver_guard {
+            driver_guard.release().await?;
+        }
         Ok(())
     }
 

--- a/thirtyfour/src/session/mod.rs
+++ b/thirtyfour/src/session/mod.rs
@@ -17,6 +17,23 @@ pub mod scriptret;
 ///
 /// [`SessionHandle`]: handle::SessionHandle
 pub trait DriverGuard: Send + Sync + std::fmt::Debug + 'static {
+    /// Asynchronously release the external resource after the session has
+    /// ended. Implementations must be idempotent because concurrent clones can
+    /// call [`SessionHandle::quit`](handle::SessionHandle::quit) at the same
+    /// time.
+    ///
+    /// The default does nothing. Resource-owning guards should retain a
+    /// synchronous `Drop` fallback for callers that do not explicitly await
+    /// session cleanup.
+    #[doc(hidden)]
+    fn release(
+        &self,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = crate::error::WebDriverResult<()>> + Send + '_>,
+    > {
+        Box::pin(async { Ok(()) })
+    }
+
     /// Downcast helper used by [`crate::WebDriver::driver_id`] and friends to
     /// reach concrete guard types (e.g. the manager's `SessionGuard`). Default
     /// returns a placeholder; types with no useful runtime info don't need to

--- a/thirtyfour/src/testing/runner.rs
+++ b/thirtyfour/src/testing/runner.rs
@@ -1,10 +1,6 @@
-use std::future::{Future, IntoFuture};
-use std::panic::AssertUnwindSafe;
-
-use futures_util::FutureExt;
-
-use crate::WebDriver;
 use crate::error::{WebDriverError, WebDriverResult};
+use crate::{WebDriver, WebDriverRunError};
+use std::future::{Future, IntoFuture};
 
 /// An error produced while setting up, running, or cleaning up a browser test.
 ///
@@ -107,44 +103,25 @@ where
     Fut: Future<Output = Result<T, E>>,
 {
     let driver = session.into_future().await.map_err(BrowserTestError::Setup)?;
-    let body_driver = driver.clone();
-    let body_result = AssertUnwindSafe(async move { test(body_driver).await }).catch_unwind().await;
-    let cleanup_result = AssertUnwindSafe(driver.quit()).catch_unwind().await;
-
-    match body_result {
-        Ok(body_result) => match cleanup_result {
-            Ok(cleanup_result) => match (body_result, cleanup_result) {
-                (Ok(value), Ok(())) => Ok(value),
-                (Ok(_), Err(cleanup)) => Err(BrowserTestError::Cleanup(cleanup)),
-                (Err(body), Ok(())) => Err(BrowserTestError::Body(body)),
-                (Err(body), Err(cleanup)) => Err(BrowserTestError::BodyAndCleanup {
-                    body,
-                    cleanup,
-                }),
-            },
-            Err(cleanup_panic) => std::panic::resume_unwind(cleanup_panic),
-        },
-        Err(body_panic) => {
-            match cleanup_result {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) => {
-                    tracing::warn!(
-                        %error,
-                        "browser cleanup failed while unwinding a browser test panic"
-                    );
-                }
-                Err(_) => {
-                    tracing::warn!("browser cleanup panicked while unwinding a browser test panic");
-                }
-            }
-            std::panic::resume_unwind(body_panic)
-        }
+    match driver.run_and_quit(test).await {
+        Ok(value) => Ok(value),
+        Err(WebDriverRunError::Body(body)) => Err(BrowserTestError::Body(body)),
+        Err(WebDriverRunError::Cleanup(cleanup)) => Err(BrowserTestError::Cleanup(cleanup)),
+        Err(WebDriverRunError::BodyAndCleanup {
+            body,
+            cleanup,
+        }) => Err(BrowserTestError::BodyAndCleanup {
+            body,
+            cleanup,
+        }),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use futures_util::FutureExt;
     use std::fmt::{Display, Formatter};
+    use std::panic::AssertUnwindSafe;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
@@ -212,6 +189,14 @@ mod tests {
         fail_first_delete: bool,
         panic_first_delete: bool,
     ) -> (WebDriver, Arc<ClientState>) {
+        test_driver_with_guard(fail_first_delete, panic_first_delete, None)
+    }
+
+    fn test_driver_with_guard(
+        fail_first_delete: bool,
+        panic_first_delete: bool,
+        driver_guard: Option<Arc<dyn crate::session::DriverGuard>>,
+    ) -> (WebDriver, Arc<ClientState>) {
         let state = Arc::new(ClientState {
             delete_attempts: AtomicUsize::new(0),
             fail_first_delete: AtomicBool::new(fail_first_delete),
@@ -223,7 +208,7 @@ mod tests {
             "http://localhost:4444",
             SessionId::from("test-session"),
             WebDriverConfig::default(),
-            None,
+            driver_guard,
             Capabilities::new(),
         )
         .expect("valid test session");
@@ -240,11 +225,42 @@ mod tests {
     async fn returns_body_value_after_successful_cleanup() {
         let (driver, state) = test_driver(false);
 
-        let result =
-            run_browser_test(async { Ok(driver) }, |_| async { Ok::<_, BodyError>(42) }).await;
+        let result = driver.run_and_quit(|_| async { Ok::<_, BodyError>(42) }).await;
 
-        assert_eq!(result.expect("test succeeds"), 42);
+        assert_eq!(result.expect("operation succeeds"), 42);
         assert_eq!(state.delete_attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[derive(Debug)]
+    struct RecordingGuard(Arc<AtomicUsize>);
+
+    impl crate::session::DriverGuard for RecordingGuard {
+        fn release(
+            &self,
+        ) -> std::pin::Pin<Box<dyn Future<Output = WebDriverResult<()>> + Send + '_>> {
+            Box::pin(async move {
+                tokio::task::yield_now().await;
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn run_and_quit_awaits_driver_guard_release() {
+        let releases = Arc::new(AtomicUsize::new(0));
+        let guard: Arc<dyn crate::session::DriverGuard> =
+            Arc::new(RecordingGuard(Arc::clone(&releases)));
+        let (driver, state) = test_driver_with_guard(false, false, Some(guard));
+
+        let value = driver
+            .run_and_quit(|_| async { Ok::<_, BodyError>(42) })
+            .await
+            .expect("operation and cleanup succeed");
+
+        assert_eq!(value, 42);
+        assert_eq!(state.delete_attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(releases.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/thirtyfour/src/web_driver.rs
+++ b/thirtyfour/src/web_driver.rs
@@ -1,10 +1,12 @@
 use std::fmt::Formatter;
 use std::future::{Future, IntoFuture};
 use std::ops::Deref;
+use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures_util::FutureExt;
 use http::HeaderValue;
 
 use crate::Capabilities;
@@ -45,6 +47,55 @@ pub struct WebDriver {
 #[derive(Debug, thiserror::Error)]
 #[error("Webdriver has already quit, can't leak an already quit driver")]
 pub struct AlreadyQuit(pub(crate) ());
+
+/// An error returned by [`WebDriver::run_and_quit`].
+///
+/// Body and cleanup failures are retained together rather than allowing
+/// cleanup to hide the operation's original failure.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WebDriverRunError<E = WebDriverError> {
+    /// The operation failed and browser cleanup succeeded.
+    #[error("browser operation failed: {0}")]
+    Body(E),
+    /// The operation succeeded but browser cleanup failed.
+    #[error("browser cleanup failed: {0}")]
+    Cleanup(WebDriverError),
+    /// Both the operation and browser cleanup failed.
+    #[error("browser operation failed: {body}; browser cleanup also failed: {cleanup}")]
+    BodyAndCleanup {
+        /// The original operation error.
+        body: E,
+        /// The failure returned by [`WebDriver::quit`].
+        cleanup: WebDriverError,
+    },
+}
+
+impl<E> WebDriverRunError<E> {
+    /// Return the operation error, if the operation failed.
+    pub fn body_error(&self) -> Option<&E> {
+        match self {
+            Self::Body(error)
+            | Self::BodyAndCleanup {
+                body: error,
+                ..
+            } => Some(error),
+            Self::Cleanup(_) => None,
+        }
+    }
+
+    /// Return the cleanup error, if browser cleanup failed.
+    pub fn cleanup_error(&self) -> Option<&WebDriverError> {
+        match self {
+            Self::Cleanup(error)
+            | Self::BodyAndCleanup {
+                cleanup: error,
+                ..
+            } => Some(error),
+            Self::Body(_) => None,
+        }
+    }
+}
 
 impl WebDriver {
     /// Create a new WebDriver as follows:
@@ -282,7 +333,7 @@ impl WebDriver {
         let guard = self.handle.driver_guard()?;
         let session_guard =
             guard.as_any().downcast_ref::<crate::manager::manager_internal::SessionGuard>()?;
-        Some(session_guard.driver.driver_id)
+        session_guard.driver_id()
     }
 
     /// Subscribe to log lines from just this session's driver process. Returns
@@ -302,10 +353,14 @@ impl WebDriver {
         let guard = self.handle.driver_guard()?;
         let session_guard =
             guard.as_any().downcast_ref::<crate::manager::manager_internal::SessionGuard>()?;
-        Some(session_guard.driver.subscribe_log(f))
+        session_guard.subscribe_log(f)
     }
 
     /// End the webdriver session and close the browser.
+    ///
+    /// For a locally managed browser, quitting the final session also waits
+    /// for the driver subprocess to exit. A driver shared by other live
+    /// sessions remains running until the final session quits.
     ///
     /// **NOTE:** Although `WebDriver` does close when all instances go out of scope.
     ///           When this happens it blocks the current executor,
@@ -315,6 +370,77 @@ impl WebDriver {
     ///           and possibly panic or report back to the user
     pub async fn quit(self) -> WebDriverResult<()> {
         self.handle.quit().await
+    }
+
+    /// Run an asynchronous operation, then safely quit the browser and return
+    /// the operation's value.
+    ///
+    /// The operation receives a clone of this driver. Cleanup is attempted
+    /// after success, an error, or a panic. Panics resume after cleanup; if
+    /// cleanup also panics or fails while unwinding, the original operation
+    /// panic takes precedence.
+    ///
+    /// The returned future must be driven to completion. Cancelling it can
+    /// interrupt asynchronous cleanup, in which case the synchronous `Drop`
+    /// fallback still requests process termination.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use thirtyfour::prelude::*;
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// let driver = WebDriver::managed(DesiredCapabilities::chrome()).await?;
+    /// let title = driver
+    ///     .run_and_quit(|driver| async move {
+    ///         driver.goto("https://example.com").await?;
+    ///         driver.title().await
+    ///     })
+    ///     .await?;
+    /// assert_eq!(title, "Example Domain");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn run_and_quit<F, Fut, T, E>(self, operation: F) -> Result<T, WebDriverRunError<E>>
+    where
+        F: FnOnce(WebDriver) -> Fut,
+        Fut: Future<Output = Result<T, E>>,
+    {
+        let operation_driver = self.clone();
+        let operation_result =
+            AssertUnwindSafe(async move { operation(operation_driver).await }).catch_unwind().await;
+        let cleanup_result = AssertUnwindSafe(self.quit()).catch_unwind().await;
+
+        match operation_result {
+            Ok(operation_result) => match cleanup_result {
+                Ok(cleanup_result) => match (operation_result, cleanup_result) {
+                    (Ok(value), Ok(())) => Ok(value),
+                    (Ok(_), Err(cleanup)) => Err(WebDriverRunError::Cleanup(cleanup)),
+                    (Err(body), Ok(())) => Err(WebDriverRunError::Body(body)),
+                    (Err(body), Err(cleanup)) => Err(WebDriverRunError::BodyAndCleanup {
+                        body,
+                        cleanup,
+                    }),
+                },
+                Err(cleanup_panic) => std::panic::resume_unwind(cleanup_panic),
+            },
+            Err(operation_panic) => {
+                match cleanup_result {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        tracing::warn!(
+                            %error,
+                            "browser cleanup failed while unwinding an operation panic"
+                        );
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            "browser cleanup panicked while unwinding an operation panic"
+                        );
+                    }
+                }
+                std::panic::resume_unwind(operation_panic)
+            }
+        }
     }
 
     /// Leak the webdriver session and prevent it from being closed,

--- a/thirtyfour/tests/managed.rs
+++ b/thirtyfour/tests/managed.rs
@@ -73,10 +73,15 @@ fn edge_caps() -> EdgeCapabilities {
 async fn managed_chrome_smoke() -> WebDriverResult<()> {
     with_timeout(async {
         let driver = WebDriver::managed(chrome_caps()).await?;
+        let server_url = driver.server_url().clone();
         if !skip_navigation() {
             driver.goto("about:blank").await?;
         }
         driver.quit().await?;
+        assert!(
+            !driver_is_listening(&server_url).await,
+            "quit().await must not return while chromedriver is still listening"
+        );
         Ok(())
     })
     .await
@@ -164,7 +169,40 @@ async fn managed_chrome_options_and_dedup() -> WebDriverResult<()> {
         }
 
         d1.quit().await?;
+        assert!(
+            driver_is_listening(d2.server_url()).await,
+            "quitting one shared session must keep chromedriver alive"
+        );
+        let server_url = d2.server_url().clone();
         d2.quit().await?;
+        assert!(
+            !driver_is_listening(&server_url).await,
+            "quitting the final shared session must await chromedriver exit"
+        );
+        Ok(())
+    })
+    .await
+}
+
+/// Concurrent explicit cleanup of every session sharing one chromedriver must
+/// still leave exactly one caller responsible for awaiting process exit.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_quit_awaits_shared_chromedriver_exit() -> WebDriverResult<()> {
+    with_timeout(async {
+        let mgr = WebDriverManager::builder().build();
+        let d1 = mgr.launch(chrome_caps()).await?;
+        let d2 = mgr.launch(chrome_caps()).await?;
+        let server_url = d1.server_url().clone();
+        assert_eq!(d2.server_url(), &server_url);
+
+        let (r1, r2) = tokio::join!(d1.quit(), d2.quit());
+        r1?;
+        r2?;
+
+        assert!(
+            !driver_is_listening(&server_url).await,
+            "concurrent quit().await calls must await the shared chromedriver exit"
+        );
         Ok(())
     })
     .await


### PR DESCRIPTION
## Summary

- make explicit managed-browser cleanup await the final driver subprocess exit and reap
- preserve shared-driver lifetimes and the synchronous `Drop` fallback
- add `WebDriver::run_and_quit` with panic-safe cleanup and combined body/cleanup errors
- route `run_browser_test` through the new lifecycle helper
- bump `thirtyfour` to 0.37.5

## Why

Managed driver teardown previously called `Child::start_kill()` from `Drop`. That sends the termination request but does not wait for the process to exit or be reaped, so `WebDriver::quit().await` could return while chromedriver was still alive. The new explicit release path transfers ownership to exactly one final session releaser and awaits Tokio's kill-and-wait operation. Callers that skip or cancel explicit cleanup still retain the existing best-effort synchronous fallback.

## Impact

For managed browsers, the final `quit().await` now guarantees that the local driver subprocess has exited before returning. Other sessions sharing the driver keep it alive. `run_and_quit` provides the same error- and unwind-aware cleanup behavior as the test runner while returning the operation's successful value.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-features --all-targets`
- `cargo doc --no-deps --all-features`
- `cargo test -p thirtyfour --lib` (100 passed)
- `cargo test -p thirtyfour --doc` (126 passed, 10 ignored)
- `cargo check -p thirtyfour --no-default-features`
- live Chrome manager tests for single-session, shared-session, and concurrent final shutdown
- `cargo publish --dry-run --allow-dirty -p thirtyfour`